### PR TITLE
Better xtensor style compatibility

### DIFF
--- a/doc/source/api_cpp.rst
+++ b/doc/source/api_cpp.rst
@@ -3,19 +3,17 @@ C++ API Reference
 
 Fastscapelib heavily relies on xtensor_ for handling n-dimensional
 arrays. Almost all arrays defined in the C++ interface have the
-``xtensor_t<D>`` type, which refers to any xtensor-compatible array
+``xtensor_t`` type, which refers to any xtensor-compatible array
 such as :cpp:type:`xt::xtensor <xt::xtensor>`, :cpp:type:`xt::xarray
 <xt::xtensor>`, :cpp:type:`xt::pytensor <xt::pytensor>` or
 :cpp:type:`xt::pyarray <xt::pyarray>` (this list is extensible).
 
-In fact, ``xtensor_t<D>`` is just an alias of the base class
-``xt::xcontainer<D>``. The unique template parameter (here noted
-``D``) refers to the derived type like one of those above. By
-convention, the parameter name is chosen using the first character(s)
-of the corresponding argument in function signatures.
-
-The lazy expression capabilities of xtensor (i.e.,
-:cpp:type:`xt::xexpression <xt::xexpression>`) are not used here.
+In fact, ``xtensor_t`` is just an alias of xtensor's class
+:cpp:type:`xt::xexpression <xt::xexpression>`. It has a unique
+template parameter which refers to the derived array type like one of
+those above. By convention, the parameter name is chosen using the
+first character(s) of the corresponding argument in function
+signatures.
 
 .. _xtensor: https://xtensor.readthedocs.io/en/latest/
 
@@ -81,8 +79,8 @@ Drainage area, basins, outlets & pits
 .. doxygenfunction:: fastscapelib::find_pits
    :project: fastscapelib
 
-.. doxygenfunction:: fastscapelib::compute_drainage_area(D&, C&, const xtensor_t<S>&, const xtensor_t<R>&)
+.. doxygenfunction:: fastscapelib::compute_drainage_area(xtensor_t<D>&, xtensor_t<C>&, const xtensor_t<S>&, const xtensor_t<R>&)
    :project: fastscapelib
 
-.. doxygenfunction:: fastscapelib::compute_drainage_area(D&, const xtensor_t<S>&, const xtensor_t<R>&, double, double)
+.. doxygenfunction:: fastscapelib::compute_drainage_area(xtensor_t<D>&, const xtensor_t<S>&, const xtensor_t<R>&, double, double)
    :project: fastscapelib

--- a/include/fastscapelib/consts.hpp
+++ b/include/fastscapelib/consts.hpp
@@ -11,6 +11,7 @@ namespace fastscapelib
 namespace consts
 {
 
+
 /*
  * @brief Row index offsets (from a central grid point) of D8
  *  neighbour directions.
@@ -27,7 +28,6 @@ const short d8_row_offsets[9] = {0, -1, -1, 0, 1, 1, 1, 0, -1};
  * The first element correspond to the central grid point itself.
  */
 const short d8_col_offsets[9] = {0, 0, -1, -1, -1, 0, 1, 1, 1};
-
 
 }  // namespace consts
 

--- a/include/fastscapelib/utils.hpp
+++ b/include/fastscapelib/utils.hpp
@@ -4,17 +4,18 @@
  */
 #pragma once
 
-#include <cstdint>
+#include <cstddef>
 
 #include "xtensor/xcontainer.hpp"
 
 
 // type used for indexing arrays and array sizes.
-using index_t = int64_t;
+// TODO: use xt::index_t directly if/when xtensor #661 is merged.
+using index_t = std::ptrdiff_t;
 
 
-template<typename D>
-using xtensor_t = xt::xcontainer<D>;
+template<class E>
+using xtensor_t = xt::xexpression<E>;
 
 
 namespace fastscapelib


### PR DESCRIPTION
Split implementation (in `fastscapelib::detail` namespace) and API functions (in `fastscapelib` namespace), as suggested [here](https://github.com/QuantStack/xtensor/pull/867#issuecomment-392526275).

Use xt::xexpression in API (to be replaced by a shaped expression -- see https://github.com/QuantStack/xtensor/pull/867).

`index_t` is now an alias of `std::ptrdiff_t` (instead of `int64_t` previously). Maybe replace this with `xt::index_t` if/when it is ready (see https://github.com/QuantStack/xtensor/pull/661).