### PR TITLE
Add tests for Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,9 @@ wheels/
 .installed.cfg
 *.egg
 
+# Python tests
+.pytest_cache
+
 # Installer logs
 pip-log.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,68 +17,52 @@ matrix:
           packages:
             - g++-4.9
       env: COMPILER=gcc GCC=4.9
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #       packages:
-    #         - g++-5
-    #   env: COMPILER=gcc GCC=5
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #       packages:
-    #         - g++-6
-    #   env: COMPILER=gcc GCC=6
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #       packages:
-    #         - g++-7
-    #   env: COMPILER=gcc GCC=7
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #       packages:
-    #         - g++-8
-    #   env: COMPILER=gcc GCC=8
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #         - llvm-toolchain-trusty-3.9
-    #       packages:
-    #         - clang-3.9
-    #         - libstdc++-6-dev  # need newer libstdc++ for C++14 support
-    #   env: COMPILER=clang CLANG=3.9
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #         - llvm-toolchain-trusty-4.0
-    #       packages:
-    #         - clang-4.0
-    #         - libstdc++-6-dev
-    #   env: COMPILER=clang CLANG=4.0
-    # - os: linux
-    #   addons:
-    #     apt:
-    #       sources:
-    #         - ubuntu-toolchain-r-test
-    #         - llvm-toolchain-trusty-5.0
-    #       packages:
-    #         - clang-5.0
-    #         - libstdc++-6-dev
-    #   env: COMPILER=clang CLANG=5.0
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env: COMPILER=gcc GCC=5
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env: COMPILER=gcc GCC=6
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-3.9
+          packages:
+            - clang-3.9
+            - libstdc++-6-dev  # need newer libstdc++ for C++14 support
+      env: COMPILER=clang CLANG=3.9
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+            - libstdc++-6-dev
+      env: COMPILER=clang CLANG=4.0
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+            - libstdc++-6-dev
+      env: COMPILER=clang CLANG=5.0
     - os: linux
       addons:
         apt:
@@ -110,9 +94,9 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - g++-7
+            - g++-8
       language: python
-      env: PYTEST=3.6 COMPILER=gcc GCC=7
+      env: PYTEST=3.6 COMPILER=gcc GCC=8
     - python: 3.5
       language: python
       env: DOCS=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -169,7 +169,7 @@ install:
       cd doc;
     elif [[ "$PYTEST" == "2.7" || "$PYTEST" == "3.6" ]]; then
       cd python;
-      pip install -e . -v
+      pip install -e . -v;
     else
       mkdir build;
       cd build;
@@ -184,7 +184,7 @@ script:
       doxygen;
       sphinx-build -n -j auto -b html -d _build/doctrees source _build/html;
     elif [[ "$PYTEST" == "2.7" || "$PYTEST" == "3.6" ]]; then
-      pytest -vv fastscapelib
+      pytest -vv fastscapelib;
     else
       ./test_fastscapelib;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,68 +17,68 @@ matrix:
           packages:
             - g++-4.9
       env: COMPILER=gcc GCC=4.9
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env: COMPILER=gcc GCC=5
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env: COMPILER=gcc GCC=6
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env: COMPILER=gcc GCC=7
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-8
-      env: COMPILER=gcc GCC=8
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-3.9
-          packages:
-            - clang-3.9
-            - libstdc++-6-dev  # need newer libstdc++ for C++14 support
-      env: COMPILER=clang CLANG=3.9
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-4.0
-          packages:
-            - clang-4.0
-            - libstdc++-6-dev
-      env: COMPILER=clang CLANG=4.0
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
-            - libstdc++-6-dev
-      env: COMPILER=clang CLANG=5.0
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - g++-5
+    #   env: COMPILER=gcc GCC=5
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - g++-6
+    #   env: COMPILER=gcc GCC=6
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - g++-7
+    #   env: COMPILER=gcc GCC=7
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #       packages:
+    #         - g++-8
+    #   env: COMPILER=gcc GCC=8
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-trusty-3.9
+    #       packages:
+    #         - clang-3.9
+    #         - libstdc++-6-dev  # need newer libstdc++ for C++14 support
+    #   env: COMPILER=clang CLANG=3.9
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-trusty-4.0
+    #       packages:
+    #         - clang-4.0
+    #         - libstdc++-6-dev
+    #   env: COMPILER=clang CLANG=4.0
+    # - os: linux
+    #   addons:
+    #     apt:
+    #       sources:
+    #         - ubuntu-toolchain-r-test
+    #         - llvm-toolchain-trusty-5.0
+    #       packages:
+    #         - clang-5.0
+    #         - libstdc++-6-dev
+    #   env: COMPILER=clang CLANG=5.0
     - os: linux
       addons:
         apt:
@@ -95,6 +95,12 @@ matrix:
     - os: osx
       osx_image: xcode9
       compiler: clang
+    - python: 2.7
+      language: python
+      env: PYTEST=2.7
+    - python: 3.6
+      language: python
+      env: PYTEST=3.6
     - python: 3.5
       language: python
       env: DOCS=yes
@@ -137,14 +143,21 @@ install:
   - if [[ "$DOCS" == "yes" ]]; then
       conda env create -n test_env --file doc/environment.yml;
       conda install -n test_env doxygen sphinx_rtd_theme -c conda-forge;
+    elif [[ "$PYTEST" == "2.7" ]]; then
+      conda install -n test_env python=2.7 pip numpy cmake xtensor-python pytest -c conda-forge;
+    elif [[ "$PYTEST" == "3.6" ]]; then
+      conda install -n test_env python=3.6 pip numpy cmake xtensor-python pytest -c conda-forge;
     else
       conda create -n test_env gtest cmake xtensor -c conda-forge;
     fi
   - source activate test_env
   - conda list
-  # Maybe build tests
+  # Maybe build tests or build/install Python bindings
   - if [[ "$DOCS" == "yes" ]]; then
       cd doc;
+    elif [[ "$PYTEST" == "2.7" || "$PYTEST" == "3.6" ]]; then
+      cd python;
+      pip install -e . -v
     else
       mkdir build;
       cd build;
@@ -158,6 +171,8 @@ script:
   - if [[ "$DOCS" == "yes" ]]; then
       doxygen;
       sphinx-build -n -j auto -b html -d _build/doctrees source _build/html;
+    elif [[ "$PYTEST" == "2.7" || "$PYTEST" == "3.6" ]]; then
+      pytest -vv fastscapelib
     else
       ./test_fastscapelib;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,12 +95,24 @@ matrix:
     - os: osx
       osx_image: xcode9
       compiler: clang
-    - python: 2.7
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
       language: python
-      env: PYTEST=2.7
-    - python: 3.6
+      env: PYTEST=2.7 COMPILER=gcc GCC=7
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
       language: python
-      env: PYTEST=3.6
+      env: PYTEST=3.6 COMPILER=gcc GCC=7
     - python: 3.5
       language: python
       env: DOCS=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,9 +144,9 @@ install:
       conda env create -n test_env --file doc/environment.yml;
       conda install -n test_env doxygen sphinx_rtd_theme -c conda-forge;
     elif [[ "$PYTEST" == "2.7" ]]; then
-      conda install -n test_env python=2.7 pip numpy cmake xtensor-python pytest -c conda-forge;
+      conda create -n test_env python=2.7 pip numpy cmake xtensor-python pytest -c conda-forge;
     elif [[ "$PYTEST" == "3.6" ]]; then
-      conda install -n test_env python=3.6 pip numpy cmake xtensor-python pytest -c conda-forge;
+      conda create -n test_env python=3.6 pip numpy cmake xtensor-python pytest -c conda-forge;
     else
       conda create -n test_env gtest cmake xtensor -c conda-forge;
     fi

--- a/python/fastscapelib/tests/test_flow_routing.py
+++ b/python/fastscapelib/tests/test_flow_routing.py
@@ -1,0 +1,156 @@
+import numpy as np
+import pytest
+
+import fastscapelib
+
+
+@pytest.fixture(scope='session')
+def braun_example():
+    """Small drainage network example from Braun and Willet (2013) used
+    for testing.
+
+    """
+    network = {}
+    network['receivers'] = np.array([1, 4, 1, 6, 4, 4, 5, 4, 6, 7],
+                                    dtype='int')
+    network['ndonors'] = np.array([0, 2, 0, 0, 3, 1, 2, 1, 0, 0],
+                                  dtype='int')
+    network['donors'] = np.array([[-1, -1, -1, -1, -1, -1, -1, -1],
+                                  [ 0,  2, -1, -1, -1, -1, -1, -1],
+                                  [-1, -1, -1, -1, -1, -1, -1, -1],
+                                  [-1, -1, -1, -1, -1, -1, -1, -1],
+                                  [ 1,  5,  7, -1, -1, -1, -1, -1],
+                                  [ 6, -1, -1, -1, -1, -1, -1, -1],
+                                  [ 3,  8, -1, -1, -1, -1, -1, -1],
+                                  [ 9, -1, -1, -1, -1, -1, -1, -1],
+                                  [-1, -1, -1, -1, -1, -1, -1, -1],
+                                  [-1, -1, -1, -1, -1, -1, -1, -1]],
+                                 dtype='int')
+    network['stack'] = np.array([4, 1, 0, 2, 5, 6, 3, 8, 7, 9])
+
+    return network
+
+
+def test_compute_receivers_d8():
+    elevation = np.array([[0.82,  0.16,  0.14,  0.20],
+                          [0.71,  0.97,  0.41,  0.09],
+                          [0.49,  0.01,  0.19,  0.38],
+                          [0.29,  0.82,  0.09,  0.88]],
+                         dtype='d')
+
+    active_nodes = np.array([[False, False, False, False],
+                             [False, True,  True,  False],
+                             [False, True,  True,  False],
+                             [False, False, False, False]],
+                            dtype='bool')
+
+    receivers = np.ones((16), dtype='int') * -1
+    expected_receivers = np.array([0,  1,  2,  3,
+                                   4,  9,  7,  7,
+                                   8,  9,  9,  11,
+                                   12, 13, 14, 15], dtype='int')
+
+    dist2receivers = np.ones((16), dtype='d') * -1
+    expected_dist2receivers = np.array([0., 0., 0., 0.,
+                                        0., 1., 1., 0.,
+                                        0., 0., 1., 0.,
+                                        0., 0., 0., 0.,],
+                                       dtype='d')
+    fastscapelib.compute_receivers_d8_d(receivers, dist2receivers,
+                                        elevation, active_nodes,
+                                        1., 1.)
+
+    np.testing.assert_array_equal(receivers, expected_receivers)
+    np.testing.assert_allclose(dist2receivers, expected_dist2receivers)
+
+
+def test_compute_donors(braun_example):
+    ndonors = np.empty(10, dtype='int')
+    donors = np.ones((10, 8), dtype='int') * -1
+
+    fastscapelib.compute_donors(ndonors, donors, braun_example['receivers'])
+
+    np.testing.assert_array_equal(ndonors, braun_example['ndonors'])
+    np.testing.assert_array_equal(donors, braun_example['donors'])
+
+
+def test_compute_stack(braun_example):
+    stack = np.empty(10, dtype='int')
+    fastscapelib.compute_stack(stack,
+                               braun_example['ndonors'],
+                               braun_example['donors'],
+                               braun_example['receivers'])
+
+    np.testing.assert_array_equal(stack, braun_example['stack'])
+
+
+def test_compute_basins(braun_example):
+    basins = np.empty(10, dtype='int')
+    outlets_or_pits = np.ones(10, dtype='int') * -1
+
+    expected_basins = np.zeros_like(basins)
+    expected_outlets_or_pits = np.array([4, -1, -1, -1, -1, -1, -1, -1, -1, -1],
+                                        dtype='int')
+
+    nbasins = fastscapelib.compute_basins(basins, outlets_or_pits,
+                                          braun_example['stack'],
+                                          braun_example['receivers'])
+
+    assert nbasins == 1
+    np.testing.assert_array_equal(basins, expected_basins)
+    np.testing.assert_array_equal(outlets_or_pits, expected_outlets_or_pits)
+
+
+def test_find_pits():
+    # simple 4x4 test case with fixed boundaries and pit located at (2, 1)
+    # 12 boundary nodes (i.e., 1-node open basin) + 1 pit = 13 basins
+    nbasins = 13
+    outlets_or_pits = np.array([0,  1,  2,  3,
+                                4,  7,  8,  11,
+                                12, 13, 14, 15,
+                                9,  -1, -1, -1], dtype='int')
+    active_nodes = np.array([[False, False, False, False],
+                             [False, True,  True,  False],
+                             [False, True,  True,  False],
+                             [False, False, False, False]],
+                            dtype='bool')
+    pits = np.ones(16, dtype='int') * -1
+
+    expected_pits = np.array([9,  -1, -1, -1,
+                              -1, -1, -1, -1,
+                              -1, -1, -1, -1,
+                              -1, -1, -1, -1],
+                             dtype='int')
+
+    npits = fastscapelib.find_pits(pits, outlets_or_pits,
+                                   active_nodes, nbasins)
+
+    assert npits == 1
+    np.testing.assert_array_equal(pits, expected_pits)
+
+
+def test_compute_drainage_area_mesh(braun_example):
+    drainage_area = np.empty(10, dtype='d')
+    cell_area = np.ones(10, dtype='d') * 2
+
+    expected_drainage_area = np.array(
+        [2., 6., 2., 2., 20., 8., 6., 4., 2., 2.], dtype='d')
+
+    fastscapelib.compute_drainage_area_mesh_d(drainage_area, cell_area,
+                                              braun_example['stack'],
+                                              braun_example['receivers'])
+
+    np.testing.assert_allclose(drainage_area, expected_drainage_area)
+
+
+def test_compute_drainage_area_grid(braun_example):
+    drainage_area = np.empty((2, 5), dtype='d')
+    expected_drainage_area = np.array([[2., 6., 2., 2., 20.],
+                                       [8., 6., 4., 2., 2.]], dtype='d')
+
+    fastscapelib.compute_drainage_area_grid_d(drainage_area,
+                                              braun_example['stack'],
+                                              braun_example['receivers'],
+                                              1., 2.)
+
+    np.testing.assert_allclose(drainage_area, expected_drainage_area)

--- a/python/fastscapelib/tests/test_sinks.py
+++ b/python/fastscapelib/tests/test_sinks.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+import fastscapelib
+
+
+def test_fill_sinks_flat():
+    arr = np.array([[1.0, 2.0, 3.0],
+                    [2.0, 0.1, 7.0],
+                    [2.0, 5.0, 7.0]], dtype='d')
+
+    fastscapelib.fill_sinks_flat_d(arr)
+
+    assert arr[1, 1] == arr[0, 0]
+
+
+def test_fill_sinks_sloped():
+    arr = np.array([[1.0, 2.0, 3.0],
+                    [2.0, 0.1, 7.0],
+                    [2.0, 5.0, 7.0]], dtype='d')
+
+    fastscapelib.fill_sinks_sloped_d(arr)
+
+    assert arr[1, 1] > arr[0, 0]

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -62,7 +62,7 @@ index_t compute_basins_py(xt::pytensor<index_t, 1>& basins,
 
 index_t find_pits_py(xt::pytensor<index_t, 1>& pits,
                      const xt::pytensor<index_t, 1>& outlets_or_pits,
-                     const xt::pytensor<bool, 1>& active_nodes,
+                     const xt::pytensor<bool, 2>& active_nodes,
                      index_t nbasins)
 {
     py::gil_scoped_release release;


### PR DESCRIPTION
Uses pytest.

It seems a bit silly to duplicate tests here, but I don't see other ways to have reliable tests for Python bindings. Edges cases should still be tested only in the C++ test suite.
