### PR TITLE
Fix fastscapelib namespace in headers

### DIFF
--- a/include/fastscapelib/flow_routing.hpp
+++ b/include/fastscapelib/flow_routing.hpp
@@ -19,9 +19,6 @@
 #include "fastscapelib/consts.hpp"
 
 
-namespace fs = fastscapelib;
-
-
 namespace fastscapelib
 {
 
@@ -36,8 +33,8 @@ inline auto get_d8_distances(double dx, double dy) -> std::array<double, 9>
     for(size_t k=0; k<9; ++k)
     {
         d8_dists[k] = std::sqrt(
-            std::pow(dy * fs::consts::d8_row_offsets[k], 2.0) +
-            std::pow(dx * fs::consts::d8_col_offsets[k], 2.0));
+            std::pow(dy * fastscapelib::consts::d8_row_offsets[k], 2.0) +
+            std::pow(dx * fastscapelib::consts::d8_col_offsets[k], 2.0));
     }
 
     return d8_dists;
@@ -97,10 +94,10 @@ void compute_receivers_d8_impl(R&& receivers,
 
             for(size_t k=1; k<=8; ++k)
             {
-                index_t kr = r + fs::consts::d8_row_offsets[k];
-                index_t kc = c + fs::consts::d8_col_offsets[k];
+                index_t kr = r + fastscapelib::consts::d8_row_offsets[k];
+                index_t kc = c + fastscapelib::consts::d8_col_offsets[k];
 
-                if(!fs::detail::in_bounds(elev_shape, kr, kc))
+                if(!fastscapelib::detail::in_bounds(elev_shape, kr, kc))
                 {
                     continue;
                 }

--- a/include/fastscapelib/sinks.hpp
+++ b/include/fastscapelib/sinks.hpp
@@ -17,9 +17,6 @@
 #include "fastscapelib/consts.hpp"
 
 
-namespace fs = fastscapelib;
-
-
 namespace fastscapelib
 {
 
@@ -119,10 +116,10 @@ void fill_sinks_flat_impl(E&& elevation)
 
         for(unsigned short k=1; k<=8; ++k)
         {
-            index_t kr = inode.r + fs::consts::d8_row_offsets[k];
-            index_t kc = inode.c + fs::consts::d8_col_offsets[k];
+            index_t kr = inode.r + fastscapelib::consts::d8_row_offsets[k];
+            index_t kc = inode.c + fastscapelib::consts::d8_col_offsets[k];
 
-            if(!fs::detail::in_bounds(elev_shape, kr, kc)) { continue; }
+            if(!fastscapelib::detail::in_bounds(elev_shape, kr, kc)) { continue; }
             if(closed(kr, kc)) { continue; }
 
             elevation(kr, kc) = std::max(elevation(kr, kc), inode.value);
@@ -169,10 +166,10 @@ void fill_sinks_sloped_impl(E&& elevation)
 
         for(unsigned short k=1; k<=8; ++k)
         {
-            index_t kr = inode.r + fs::consts::d8_row_offsets[k];
-            index_t kc = inode.c + fs::consts::d8_col_offsets[k];
+            index_t kr = inode.r + fastscapelib::consts::d8_row_offsets[k];
+            index_t kc = inode.c + fastscapelib::consts::d8_col_offsets[k];
 
-            if(!fs::detail::in_bounds(elev_shape, kr, kc)) { continue; }
+            if(!fastscapelib::detail::in_bounds(elev_shape, kr, kc)) { continue; }
             if(closed(kr, kc)) { continue; }
 
             if(elevation(kr, kc) <= elev_tiny_step)

--- a/test/test_flow_routing.cpp
+++ b/test/test_flow_routing.cpp
@@ -7,6 +7,9 @@
 #include "fastscapelib/flow_routing.hpp"
 
 
+namespace fs = fastscapelib;
+
+
 TEST(flow_routing, get_d8_distances)
 {
     auto d8_dist = fs::detail::get_d8_distances(2., 1.);

--- a/test/test_sinks.cpp
+++ b/test/test_sinks.cpp
@@ -4,6 +4,9 @@
 #include "fastscapelib/sinks.hpp"
 
 
+namespace fs = fastscapelib;
+
+
 TEST(sinks, fill_sinks_flat)
 {
     xt::xtensor<double, 2> arr


### PR DESCRIPTION
Fixes #14.

`fastscapelib`  is kept as namespace (no abbreviation is used).