### PR TITLE
Configure Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - master
+
 build: false
 
 platform:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,38 @@
+build: false
+
+platform:
+  - x64
+  - x86
+
+image:
+  - Visual Studio 2017
+  - Visual Studio 2015
+
+environment:
+  matrix:
+    - MINICONDA: C:\fastscapelib-conda
+
+init:
+  - "ECHO %MINICONDA%"
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCARGUMENT=%PLATFORM%
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x64" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x86" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - echo "%VCVARPATH% %VCARGUMENT%"
+  - "%VCVARPATH% %VCARGUMENT%"
+  - ps: if($env:Platform -eq "x64"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe' C:\Miniconda.exe; echo "Done"}
+  - ps: if($env:Platform -eq "x86"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86.exe' C:\Miniconda.exe; echo "Done"}
+  - cmd: C:\Miniconda.exe /S /D=C:\fastscapelib-conda
+  - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"
+
+install:
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
+  - conda install gtest cmake xtensor -c conda-forge
+  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON .
+  - nmake test_fastscapelib
+  - cd test
+
+build_script:
+- .\test_fastscapelib

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ install:
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" conda install xtensor-python pybind11 numpy pytest pip -c conda-forge
   - mkdir build
   - cd build
-  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON -DCMAKE_BUILD_TYPE=Release ..
+  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release ..
   - nmake test_fastscapelib
   - "set PYTHONHOME=%MINICONDA%"
   - cd ..\\python

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,16 +35,17 @@ install:
   - conda info -a
   - conda install gtest cmake xtensor -c conda-forge
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" conda install xtensor-python pybind11 numpy pytest -c conda-forge
-  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON -DCMAKE_BUILD_TYPE=Release .
+  - mkdir build
+  - cd build
+  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON -DCMAKE_BUILD_TYPE=Release ..
   - nmake test_fastscapelib
   - "set PYTHONHOME=%MINICONDA%"
-  - cd python
+  - cd ..\\python
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" pip install -e . -v
   - cd ..
 
 build_script:
-  - cd test
+  - cd build\\test
   - .\test_fastscapelib
-  - cd ..
-  - cd python
+  - cd ..\\..\\python
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" pytest fastscapelib -vv

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,10 +17,11 @@ environment:
 
 init:
   - "ECHO %MINICONDA%"
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat %PLATFORM%"
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCARGUMENT=%PLATFORM%
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - echo "%VCVARPATH%"
-  - "%VCVARPATH%"
+  - echo "%VCVARPATH% %VCARGUMENT%"
+  - %VCVARPATH% %VCARGUMENT%
   - ps: Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe' C:\Miniconda.exe; echo "Done"
   - cmd: C:\Miniconda.exe /S /D=C:\fastscapelib-conda
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install gtest cmake xtensor -c conda-forge
-  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON .
+  - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON -DCMAKE_BUILD_TYPE=Release .
   - nmake test_fastscapelib
   - cd test
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@ build: false
 
 platform:
   - x64
-  - x86
+  #- x86
 
 image:
   - Visual Studio 2017
@@ -17,7 +17,7 @@ init:
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCARGUMENT=%PLATFORM%
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x64" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x86" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
+  #- if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x86" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
   - echo "%VCVARPATH% %VCARGUMENT%"
   - "%VCVARPATH% %VCARGUMENT%"
   - ps: if($env:Platform -eq "x64"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe' C:\Miniconda.exe; echo "Done"}

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,7 +6,6 @@ build: false
 
 platform:
   - x64
-  #- x86
 
 image:
   - Visual Studio 2017
@@ -18,14 +17,11 @@ environment:
 
 init:
   - "ECHO %MINICONDA%"
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat"
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCARGUMENT=%PLATFORM%
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x64" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
-  #- if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" if "%PLATFORM%" == "x86" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - echo "%VCVARPATH% %VCARGUMENT%"
-  - "%VCVARPATH% %VCARGUMENT%"
-  - ps: if($env:Platform -eq "x64"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe' C:\Miniconda.exe; echo "Done"}
-  - ps: if($env:Platform -eq "x86"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86.exe' C:\Miniconda.exe; echo "Done"}
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat %PLATFORM%"
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
+  - echo "%VCVARPATH%"
+  - "%VCVARPATH%"
+  - ps: Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe' C:\Miniconda.exe; echo "Done"
   - cmd: C:\Miniconda.exe /S /D=C:\fastscapelib-conda
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"
 
@@ -34,7 +30,7 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install gtest cmake xtensor -c conda-forge
-  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" conda install xtensor-python pybind11 numpy pytest -c conda-forge
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" conda install xtensor-python pybind11 numpy pytest pip -c conda-forge
   - mkdir build
   - cd build
   - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON -DCMAKE_BUILD_TYPE=Release ..

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,9 +34,17 @@ install:
   - conda update -q conda
   - conda info -a
   - conda install gtest cmake xtensor -c conda-forge
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" conda install xtensor-python pybind11 numpy pytest -c conda-forge
   - cmake -G "NMake Makefiles" -D CMAKE_INSTALL_PREFIX=%MINICONDA%\\LIBRARY -DBUILD_TESTS=ON -DDISABLE_VS2017=ON -DCMAKE_BUILD_TYPE=Release .
   - nmake test_fastscapelib
-  - cd test
+  - "set PYTHONHOME=%MINICONDA%"
+  - cd python
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" pip install -e . -v
+  - cd ..
 
 build_script:
-- .\test_fastscapelib
+  - cd test
+  - .\test_fastscapelib
+  - cd ..
+  - cd python
+  - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" pytest fastscapelib -vv

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,7 @@ init:
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2015" set VCARGUMENT=%PLATFORM%
   - if "%APPVEYOR_BUILD_WORKER_IMAGE%" == "Visual Studio 2017" set VCVARPATH="C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat"
   - echo "%VCVARPATH% %VCARGUMENT%"
-  - %VCVARPATH% %VCARGUMENT%
+  - "%VCVARPATH% %VCARGUMENT%"
   - ps: Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe' C:\Miniconda.exe; echo "Done"
   - cmd: C:\Miniconda.exe /S /D=C:\fastscapelib-conda
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%MINICONDA%\\Library\\bin;%PATH%"

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Fastscapelib
 ============
 
-|Build Status| |Doc Status|
+|Build Status| |Win Build Status| |Doc Status|
 
 A C++ library of efficient algorithms for processing topographic data
 and landscape evolution modeling.
@@ -12,6 +12,9 @@ other languages.
 .. |Build Status| image:: https://travis-ci.org/fastscape-lem/fastscapelib.svg?branch=master
    :target: https://travis-ci.org/fastscape-lem/fastscapelib
    :alt: Build Status
+.. |Win Build Status| image:: https://ci.appveyor.com/api/projects/status/4gm51wb8knpvq0rp/branch/master?svg=true
+   :target: https://ci.appveyor.com/project/benbovy/fastscapelib
+   :alt: Win Build Status
 .. |Doc Status| image:: http://readthedocs.org/projects/fastscapelib/badge/?version=latest
    :target: http://fastscapelib.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status

--- a/include/fastscapelib/bedrock_channel.hpp
+++ b/include/fastscapelib/bedrock_channel.hpp
@@ -48,7 +48,7 @@ index_t erode_stream_power_impl(Er&& erosion,
     const auto elevation_flat = xt::flatten(elevation);
     const auto drainage_area_flat = xt::flatten(drainage_area);
 
-    index_t n_corr = 0.;
+    index_t n_corr = 0;
 
     for (const auto& istack : stack)
     {

--- a/python/fastscapelib/tests/test_flow_routing.py
+++ b/python/fastscapelib/tests/test_flow_routing.py
@@ -12,9 +12,9 @@ def braun_example():
     """
     network = {}
     network['receivers'] = np.array([1, 4, 1, 6, 4, 4, 5, 4, 6, 7],
-                                    dtype='int')
+                                    dtype=np.intp)
     network['ndonors'] = np.array([0, 2, 0, 0, 3, 1, 2, 1, 0, 0],
-                                  dtype='int')
+                                  dtype=np.intp)
     network['donors'] = np.array([[-1, -1, -1, -1, -1, -1, -1, -1],
                                   [ 0,  2, -1, -1, -1, -1, -1, -1],
                                   [-1, -1, -1, -1, -1, -1, -1, -1],
@@ -25,7 +25,7 @@ def braun_example():
                                   [ 9, -1, -1, -1, -1, -1, -1, -1],
                                   [-1, -1, -1, -1, -1, -1, -1, -1],
                                   [-1, -1, -1, -1, -1, -1, -1, -1]],
-                                 dtype='int')
+                                 dtype=np.intp)
     network['stack'] = np.array([4, 1, 0, 2, 5, 6, 3, 8, 7, 9])
 
     return network
@@ -44,11 +44,11 @@ def test_compute_receivers_d8():
                              [False, False, False, False]],
                             dtype='bool')
 
-    receivers = np.ones((16), dtype='int') * -1
+    receivers = np.ones((16), dtype=np.intp) * -1
     expected_receivers = np.array([0,  1,  2,  3,
                                    4,  9,  7,  7,
                                    8,  9,  9,  11,
-                                   12, 13, 14, 15], dtype='int')
+                                   12, 13, 14, 15], dtype=np.intp)
 
     dist2receivers = np.ones((16), dtype='d') * -1
     expected_dist2receivers = np.array([0., 0., 0., 0.,
@@ -65,8 +65,8 @@ def test_compute_receivers_d8():
 
 
 def test_compute_donors(braun_example):
-    ndonors = np.empty(10, dtype='int')
-    donors = np.ones((10, 8), dtype='int') * -1
+    ndonors = np.empty(10, dtype=np.intp)
+    donors = np.ones((10, 8), dtype=np.intp) * -1
 
     fastscapelib.compute_donors(ndonors, donors, braun_example['receivers'])
 
@@ -75,7 +75,7 @@ def test_compute_donors(braun_example):
 
 
 def test_compute_stack(braun_example):
-    stack = np.empty(10, dtype='int')
+    stack = np.empty(10, dtype=np.intp)
     fastscapelib.compute_stack(stack,
                                braun_example['ndonors'],
                                braun_example['donors'],
@@ -85,12 +85,12 @@ def test_compute_stack(braun_example):
 
 
 def test_compute_basins(braun_example):
-    basins = np.empty(10, dtype='int')
-    outlets_or_pits = np.ones(10, dtype='int') * -1
+    basins = np.empty(10, dtype=np.intp)
+    outlets_or_pits = np.ones(10, dtype=np.intp) * -1
 
     expected_basins = np.zeros_like(basins)
     expected_outlets_or_pits = np.array([4, -1, -1, -1, -1, -1, -1, -1, -1, -1],
-                                        dtype='int')
+                                        dtype=np.intp)
 
     nbasins = fastscapelib.compute_basins(basins, outlets_or_pits,
                                           braun_example['stack'],
@@ -108,19 +108,19 @@ def test_find_pits():
     outlets_or_pits = np.array([0,  1,  2,  3,
                                 4,  7,  8,  11,
                                 12, 13, 14, 15,
-                                9,  -1, -1, -1], dtype='int')
+                                9,  -1, -1, -1], dtype=np.intp)
     active_nodes = np.array([[False, False, False, False],
                              [False, True,  True,  False],
                              [False, True,  True,  False],
                              [False, False, False, False]],
                             dtype='bool')
-    pits = np.ones(16, dtype='int') * -1
+    pits = np.ones(16, dtype=np.intp) * -1
 
     expected_pits = np.array([9,  -1, -1, -1,
                               -1, -1, -1, -1,
                               -1, -1, -1, -1,
                               -1, -1, -1, -1],
-                             dtype='int')
+                             dtype=np.intp)
 
     npits = fastscapelib.find_pits(pits, outlets_or_pits,
                                    active_nodes, nbasins)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,8 +9,8 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(FASTSCAPELIB_INCLUDE_DIR ${fastscapelib_INCLUDE_DIRS})
 endif ()
 
-message(STATUS "Forcing tests build type to Release")
-set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+# message(STATUS "Forcing tests build type to Release")
+# set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 
 include(CheckCXXCompilerFlag)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,9 +18,11 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
     CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR
-    CMAKE_CXX_COMPILER_ID MATCHES "Intel")
+    (CMAKE_CXX_COMPILER_ID MATCHES "Intel" AND NOT WIN32))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -Wunused-parameter")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wreorder -Wconversion")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -Wreorder")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wconversion -Wsign-conversion")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Wunused-variable")
 
   CHECK_CXX_COMPILER_FLAG("-std=c++14" HAS_CPP14_FLAG)
 
@@ -36,6 +38,8 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR
 endif()
 
 if(MSVC)
+  add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+  add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc /MP /bigobj")
   set(CMAKE_EXE_LINKER_FLAGS /MANIFEST:NO)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,8 +9,8 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
   set(FASTSCAPELIB_INCLUDE_DIR ${fastscapelib_INCLUDE_DIRS})
 endif ()
 
-#message(STATUS "Forcing tests build type to Release")
-#set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
+message(STATUS "Forcing tests build type to Release")
+set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 
 include(CheckCXXCompilerFlag)
 


### PR DESCRIPTION
TODO:

- [x] add badge in README
- [x] add Python to test matrix (test only for VS2015, which is used by conda for Python 3.5+)

Maybe for later: google-test is installed using conda (built in release mode I guess), which probably causes the MSVC linking error if tests are not built in release mode too. So we build here in release mode. It's probably not the best solution, but at least there is no error. An alternative could be building google-test from source in debug mode? Or maybe the real issue is static vs. dynamic linking to google-test?