### PR TITLE
Support spatially variable stream-power-law coefficient

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -112,6 +112,8 @@ endif()
 include_directories(${GBENCHMARK_INCLUDE_DIRS})
 
 set(FASTSCAPELIB_BENCHMARK_SRC
+  benchmark_setup.hpp
+  benchmark_bedrock_channel.cpp
   benchmark_hillslope.cpp
   benchmark_sinks.cpp
   main.cpp

--- a/benchmark/benchmark_bedrock_channel.cpp
+++ b/benchmark/benchmark_bedrock_channel.cpp
@@ -1,13 +1,12 @@
 #include <array>
-#include <math.h>
-#include <iostream>
+#include <cmath>
+#include <type_traits>
 
 #include <benchmark/benchmark.h>
 
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xrandom.hpp"
-#include "xtensor/xio.hpp"
 
 #include "fastscapelib/flow_routing.hpp"
 #include "fastscapelib/bedrock_channel.hpp"

--- a/benchmark/benchmark_bedrock_channel.cpp
+++ b/benchmark/benchmark_bedrock_channel.cpp
@@ -1,0 +1,128 @@
+#include <array>
+#include <math.h>
+#include <iostream>
+
+#include <benchmark/benchmark.h>
+
+#include "xtensor/xbuilder.hpp"
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xrandom.hpp"
+#include "xtensor/xio.hpp"
+
+#include "fastscapelib/flow_routing.hpp"
+#include "fastscapelib/bedrock_channel.hpp"
+
+#include "benchmark_setup.hpp"
+
+
+namespace fs = fastscapelib;
+namespace bms = benchmark_setup;
+
+
+namespace fastscapelib
+{
+
+namespace benchmark_bedrock_channel
+{
+
+    template<class K, class S>
+    typename std::enable_if_t<std::is_floating_point<K>::value, K>
+    get_k_coef(S&& shape)
+    {
+        (void) shape;  // do not show warning
+        return 1e-3;
+    }
+
+
+    template<class K, class S>
+    typename std::enable_if_t<xt::is_xexpression<K>::value, K>
+    get_k_coef(S&& shape)
+    {
+        using T = typename K::value_type;
+
+        K k_coef_arr = xt::empty<T>(shape);
+        k_coef_arr.fill(1e-3);
+
+        return k_coef_arr;
+    }
+
+
+    template<class T, class K, int Nd>
+    void bm_erode_stream_power(benchmark::State& state)
+    {
+        auto ns = static_cast<size_t>(state.range(0));
+
+        xt::xtensor<double, Nd> erosion;
+        xt::xtensor<double, Nd> elevation;
+        xt::xtensor<index_t, 1> receivers;
+        xt::xtensor<double, 1> dist2receivers;
+        xt::xtensor<index_t, 1> stack;
+        xt::xtensor<double, Nd> drainage_area;
+
+        if (Nd == 1)
+        {
+            double spacing = 300.;
+            double x0 = 300.;
+            double length = (ns - 1) * spacing;
+
+            xt::xtensor<double, Nd> x = xt::linspace<double>(length + x0, x0, ns);
+            erosion = xt::zeros_like(x);
+            elevation = (length + x0 - x) * 1e-4;
+            receivers = xt::arange<index_t>(-1, ns - 1);
+            dist2receivers = xt::full_like(elevation, spacing);
+            stack = xt::arange<index_t>(0, ns);
+            drainage_area = 6.69 * xt::pow(x, 1.67);   // Hack's law
+        }
+
+        else if (Nd == 2)
+        {
+            auto s = bms::FastscapeSetupBase<bms::SurfaceType::cone, T>(state.range(0));
+
+            fs::compute_receivers_d8(s.receivers, s.dist2receivers,
+                                     s.elevation, s.active_nodes,
+                                     s.dx, s.dy);
+            fs::compute_donors(s.ndonors, s.donors, s.receivers);
+            fs::compute_stack(s.stack, s.ndonors,
+                              s.donors, s.receivers);
+
+            erosion = xt::zeros_like(s.elevation);
+            elevation = s.elevation;
+            receivers = s.receivers;
+            dist2receivers = s.dist2receivers;
+            stack = s.stack;
+            drainage_area = xt::empty_like(s.elevation);
+            fs::compute_drainage_area(drainage_area, stack, receivers, s.dx, s.dy);
+        }
+
+        K k_coef = get_k_coef<K>(elevation.shape());
+        double m_exp = 0.5;
+        double n_exp = 1;
+
+        double dt = 1e4;
+
+        index_t ncorr;
+
+        for (auto _ : state)
+        {
+            ncorr = fs::erode_stream_power(erosion, elevation, stack,
+                                           receivers, dist2receivers, drainage_area,
+                                           k_coef, m_exp, n_exp, dt, 1e-3);
+        }
+    }
+
+
+    BENCHMARK_TEMPLATE(bm_erode_stream_power, double, double, 1)
+    ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+
+    BENCHMARK_TEMPLATE(bm_erode_stream_power, double, xt::xtensor<double, 1>, 1)
+    ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+
+    BENCHMARK_TEMPLATE(bm_erode_stream_power, double, double, 2)
+    ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+    BENCHMARK_TEMPLATE(bm_erode_stream_power, double, xt::xtensor<double, 2>, 2)
+    ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+}  // namespace benchmark_bedrock_channel
+
+}  // namespace fastscapelib

--- a/benchmark/benchmark_hillslope.cpp
+++ b/benchmark/benchmark_hillslope.cpp
@@ -1,5 +1,6 @@
 #include <array>
-#include <math.h>
+#include <cmath>
+#include <type_traits>
 
 #include <benchmark/benchmark.h>
 

--- a/benchmark/benchmark_setup.hpp
+++ b/benchmark/benchmark_setup.hpp
@@ -1,0 +1,180 @@
+#pragma once
+
+#include <math.h>
+#include <array>
+#include <tuple>
+
+#include "xtensor/xmath.hpp"
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xrandom.hpp"
+#include "xtensor/xview.hpp"
+
+
+namespace benchmark_setup
+{
+
+
+/*
+ * Run benchmarks for different grid sizes.
+ *
+ * Assumes a square grid, i.e., the total number of grid points is s^2.
+ *
+ * Use this function with benchmark macros, e.g.,
+ *    BENCHMARK(...)->Apply(grid_sizes<benchmark::kMillisecond>)
+ */
+template<benchmark::TimeUnit time_unit>
+static void grid_sizes(benchmark::internal::Benchmark* bench) {
+    std::array<int, 5> sizes {256, 512, 1024, 2048, 4096};
+
+    for (int s : sizes)
+    {
+        bench->Args({s})->Unit(time_unit);
+    }
+}
+
+
+enum class SurfaceType {cone, cone_inv, cone_noise, flat_noise, gauss, custom};
+
+
+/*
+ * A class for generating one of the following synthetic topography on
+ * a ``n`` x ``n`` square grid:
+ *
+ * cone
+ *   Cone surface (smooth, regular slope, no depression)
+ * cone_inv
+ *   Inverted cone surface (a single, big depression)
+ * cone_noise
+ *   Cone surface with random perturbations so that the surface
+ *   has many depressions of different sizes
+ * flat_noise
+ *   Nearly flat surface with random perturbations
+ *   (many small depressions)
+ * gauss
+ *   Gaussian surface (smooth, no depression)
+ */
+template<SurfaceType surf_type, class T>
+class SyntheticTopography
+{
+public:
+    int seed = 0;
+
+    SyntheticTopography(int n)
+    {
+        nnodes_side = n;
+        auto n_ = static_cast<size_t>(n);
+        shape = {n_, n_};
+
+        grid = xt::meshgrid(xt::linspace<double>(-1, 1, n),
+                            xt::linspace<double>(-1, 1, n));
+    }
+
+    xt::xtensor<T, 2> get_elevation()
+    {
+        xt::random::seed(seed);
+
+        switch (surf_type) {
+        case SurfaceType::cone:
+            elevation = get_elevation_cone();
+            break;
+
+        case SurfaceType::cone_inv:
+            elevation = -get_elevation_cone();
+            break;
+
+        case SurfaceType::cone_noise:
+            elevation = (get_elevation_cone()
+                         + xt::random::rand<T>(shape) * 5. / nnodes_side);
+            break;
+
+        case SurfaceType::flat_noise:
+            elevation = xt::random::rand<T>(shape);
+            break;
+
+        case SurfaceType::gauss:
+            elevation = xt::exp(-(xt::pow(std::get<0>(grid), 2) / 2.
+                                  + xt::pow(std::get<1>(grid), 2) / 2.));
+            break;
+
+        default:
+            elevation = xt::zeros<T>(shape);
+            break;
+        }
+
+        return elevation;
+    }
+
+private:
+    int nnodes_side;
+    std::array<size_t, 2> shape;
+    std::tuple<xt::xtensor<double, 2>, xt::xtensor<double, 2>> grid;
+    xt::xtensor<T, 2> elevation;
+
+    auto get_elevation_cone()
+    {
+        return std::sqrt(2.) - xt::sqrt(xt::pow(std::get<0>(grid), 2) +
+                                        xt::pow(std::get<1>(grid), 2));
+    }
+
+};
+
+/*
+ * Set fixed boundary conditions for each of the 4 sides of the grid.
+ */
+template<class A>
+void set_fixed_boundary_faces(A&& active_nodes)
+{
+    auto active_nodes_ = xt::view(active_nodes, xt::all(), xt::all());
+    active_nodes_ = true;
+
+    const auto shape = active_nodes.shape();
+    const std::array<size_t, 2> rows_idx {0, shape[0] - 1};
+    const std::array<size_t, 2> cols_idx {0, shape[1] - 1};
+
+    auto row_bounds = xt::view(active_nodes, xt::keep(rows_idx), xt::all());
+    row_bounds = false;
+
+    auto col_bounds = xt::view(active_nodes, xt::all(), xt::keep(cols_idx));
+    col_bounds = false;
+}
+
+
+/*
+ * A base setup common to various benchmarks.
+ */
+template<SurfaceType surf_type, class T>
+struct FastscapeSetupBase
+{
+    int nnodes;
+    double dx = 100.;
+    double dy = 100.;
+    xt::xtensor<T, 2> elevation;
+    xt::xtensor<bool, 2> active_nodes;
+    xt::xtensor<index_t, 1> receivers;
+    xt::xtensor<T, 1> dist2receivers;
+    xt::xtensor<index_t, 1> ndonors;
+    xt::xtensor<index_t, 2> donors;
+    xt::xtensor<index_t, 1> stack;
+    xt::xtensor<index_t, 1> basins;
+
+    FastscapeSetupBase(int n)
+    {
+        auto topo = SyntheticTopography<surf_type, T>(n);
+
+        elevation = topo.get_elevation();
+
+        active_nodes = xt::ones<bool>(elevation.shape());
+        set_fixed_boundary_faces(active_nodes);
+
+        nnodes = n * n;
+
+        receivers = xt::empty<index_t>({nnodes});
+        dist2receivers = xt::empty<T>({nnodes});
+        ndonors = xt::empty<index_t>({nnodes});
+        donors = xt::empty<index_t>({nnodes, 8});
+        stack = xt::empty<index_t>({nnodes});
+        basins = xt::empty<index_t>({nnodes});
+    }
+};
+
+}  // namespace benchmark_setup

--- a/doc/source/api_cpp.rst
+++ b/doc/source/api_cpp.rst
@@ -94,7 +94,10 @@ Functions used to drive the evolution of bedrock channels.
 
 Defined in ``fastscapelib/bedrock_channel.hpp``.
 
-.. doxygenfunction:: fastscapelib::erode_stream_power
+.. doxygenfunction:: fastscapelib::erode_stream_power(xtensor_t<Er>&, const xtensor_t<El>&, const xtensor_t<S>&, const xtensor_t<R>&, const xtensor_t<Di>&, const xtensor_t<Dr>&, double, double, double, double, double)
+   :project: fastscapelib
+
+.. doxygenfunction:: fastscapelib::erode_stream_power(xtensor_t<Er>&, const xtensor_t<El>&, const xtensor_t<S>&, const xtensor_t<R>&, const xtensor_t<Di>&, const xtensor_t<Dr>&, const xtensor_t<K>&, double, double, double, double)
    :project: fastscapelib
 
 Hillslope

--- a/include/fastscapelib/bedrock_channel.hpp
+++ b/include/fastscapelib/bedrock_channel.hpp
@@ -3,8 +3,10 @@
  */
 #pragma once
 
+#include <cassert>
 #include <cmath>
 #include <limits>
+#include <type_traits>
 
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xstrided_view.hpp"
@@ -19,6 +21,28 @@ namespace detail
 {
 
 
+template<class T, class S>
+auto k_coef_as_array(T k_coef,
+                     S&& shape,
+                     typename std::enable_if_t<std::is_floating_point<T>::value>* = 0)
+{
+    return xt::broadcast(std::forward<T>(k_coef), shape);
+}
+
+
+template<class K, class S>
+auto k_coef_as_array(K&& k_coef,
+                     S&& shape,
+                     typename std::enable_if_t<xt::is_xexpression<K>::value>* = 0)
+{
+    auto k_coef_arr = xt::flatten(k_coef);
+
+    assert(k_coef_arr.shape() == shape);
+
+    return k_coef_arr;
+}
+
+
 /**
  * erode_stream_power implementation.
  *
@@ -28,14 +52,14 @@ namespace detail
  * between a node and its receiver, rather than on the node's
  * elevation itself. This allows saving some operations.
  */
-template<class Er, class El, class S, class R, class Di, class Dr>
+template<class Er, class El, class S, class R, class Di, class Dr, class K>
 index_t erode_stream_power_impl(Er&& erosion,
                                 El&& elevation,
                                 S&& stack,
                                 R&& receivers,
                                 Di&& dist2receivers,
                                 Dr&& drainage_area,
-                                double k_coef,
+                                K&& k_coef,
                                 double m_exp,
                                 double n_exp,
                                 double dt,
@@ -47,6 +71,8 @@ index_t erode_stream_power_impl(Er&& erosion,
     auto erosion_flat = xt::flatten(erosion);
     const auto elevation_flat = xt::flatten(elevation);
     const auto drainage_area_flat = xt::flatten(drainage_area);
+
+    const auto k_coef_arr = k_coef_as_array(k_coef, elevation_flat.shape());
 
     index_t n_corr = 0;
 
@@ -71,7 +97,8 @@ index_t erode_stream_power_impl(Er&& erosion,
             continue;
         }
 
-        auto factor = k_coef * dt * std::pow(drainage_area_flat(istack), m_exp);
+        auto factor = (k_coef_arr(istack) * dt *
+                       std::pow(drainage_area_flat(istack), m_exp));
 
         T delta_0 = istack_elevation - irec_elevation;
         T delta_k;
@@ -197,6 +224,64 @@ index_t erode_stream_power(xtensor_t<Er>& erosion,
                                            dist2receivers.derived_cast(),
                                            drainage_area.derived_cast(),
                                            k_coef, m_exp, n_exp,
+                                           dt, tolerance);
+}
+
+
+/**
+ * Compute bedrock channel erosion during a single time step using the
+ * Stream Power Law.
+ *
+ * This version accepts a spatially variable stream-power law coefficient.
+ *
+ * @param erosion : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
+ *     Erosion at grid node.
+ * @param elevation : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
+ *     Elevation at grid node.
+ * @param stack :``[intent=in, shape=(nnodes)]``
+ *     Stack position at grid node.
+ * @param receivers : ``[intent=in, shape=(nnodes)]``
+ *     Index of flow receiver at grid node.
+ * @param dist2receivers : ``[intent=out, shape=(nnodes)]``
+ *     Distance to receiver at grid node.
+ * @param drainage_area : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
+ *     Drainage area at grid node.
+ * @param k_coef : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
+ *     Stream Power Law coefficient.
+ * @param m_exp : ``[intent=in]``
+ *     Stream Power Law drainage area exponent.
+ * @param n_exp : ``[intent=in]``
+ *     Stream Power Law slope exponent.
+ * @param dt : ``[intent=in]``
+ *     Time step duration.
+ * @param tolerance : ``[intent=in]``
+ *     Tolerance used for Newton's iterations (``n_exp`` != 1).
+ *
+ * @returns
+ *     Total number of nodes for which erosion has been
+ *     arbitrarily limited to ensure consistency.
+ */
+template<class Er, class El, class S, class R, class Di, class Dr, class K>
+index_t erode_stream_power(xtensor_t<Er>& erosion,
+                           const xtensor_t<El>& elevation,
+                           const xtensor_t<S>& stack,
+                           const xtensor_t<R>& receivers,
+                           const xtensor_t<Di>& dist2receivers,
+                           const xtensor_t<Dr>& drainage_area,
+                           const xtensor_t<K>& k_coef,
+                           double m_exp,
+                           double n_exp,
+                           double dt,
+                           double tolerance)
+{
+    return detail::erode_stream_power_impl(erosion.derived_cast(),
+                                           elevation.derived_cast(),
+                                           stack.derived_cast(),
+                                           receivers.derived_cast(),
+                                           dist2receivers.derived_cast(),
+                                           drainage_area.derived_cast(),
+                                           k_coef.derived_cast(),
+                                           m_exp, n_exp,
                                            dt, tolerance);
 }
 

--- a/include/fastscapelib/bedrock_channel.hpp
+++ b/include/fastscapelib/bedrock_channel.hpp
@@ -38,6 +38,7 @@ auto k_coef_as_array(K&& k_coef,
     auto k_coef_arr = xt::flatten(k_coef);
 
     assert(k_coef_arr.shape() == shape);
+    (void) shape;   // TODO: still unused parameter warning despite assert?
 
     return k_coef_arr;
 }

--- a/python/fastscapelib/tests/test_bedrock_channel.py
+++ b/python/fastscapelib/tests/test_bedrock_channel.py
@@ -1,9 +1,11 @@
+import pytest
 import numpy as np
 
 import fastscapelib
 
 
-def test_erode_stream_power():
+@pytest.mark.parametrize("k_coef_type", ["constant", "variable"])
+def test_erode_stream_power(k_coef_type):
     # Test on a tiny (2x2) 2-d square grid with a planar surface
     # tilted in y (rows) and with all outlets on the 1st row.
     spacing = 300.
@@ -27,10 +29,16 @@ def test_erode_stream_power():
     dt = 1   # use small time step (compare with explicit scheme)
     tolerance = 1e-3
 
-    n_corr = fastscapelib.erode_stream_power_d(
-        erosion, elevation, stack,
-        receivers, dist2receivers, drainage_area,
-        k_coef, m_exp, n_exp, dt, tolerance)
+    if k_coef_type == 'constant':
+        func = fastscapelib.erode_stream_power_d
+        k = k_coef
+    elif k_coef_type == 'variable':
+        func = fastscapelib.erode_stream_power_var_d
+        k = np.full_like(elevation, k_coef)
+
+    n_corr = func(erosion, elevation, stack,
+                  receivers, dist2receivers, drainage_area,
+                  k, m_exp, n_exp, dt, tolerance)
 
     slope = h / spacing
     err = dt * k_coef * a**m_exp * slope**n_exp

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -119,14 +119,14 @@ void compute_drainage_area_grid_py(xt::pytensor<T, 2>& drainage_area,
 }
 
 
-template<class T>
+template<class K, class T>
 index_t erode_stream_power_py(xt::pyarray<T>& erosion,
                               const xt::pyarray<T>& elevation,
                               const xt::pytensor<index_t, 1>& stack,
                               const xt::pytensor<index_t, 1>& receivers,
                               const xt::pytensor<T, 1>& dist2receivers,
                               const xt::pyarray<T>& drainage_area,
-                              double k_coef,
+                              const K k_coef,
                               double m_exp,
                               double n_exp,
                               double dt,
@@ -194,9 +194,14 @@ PYBIND11_MODULE(_fastscapelib_py, m)
     m.def("fill_sinks_sloped_d", &fill_sinks_sloped_py<double>,
           "Fill depressions in elevation data (slightly sloped surfaces).");
 
-    m.def("erode_stream_power_d", &erode_stream_power_py<double>,
+    m.def("erode_stream_power_d", &erode_stream_power_py<double, double>,
           "Compute bedrock channel erosion during a single time step "
           "using the Stream Power Law.");
+
+    m.def("erode_stream_power_var_d", &erode_stream_power_py<xt::pyarray<double>&, double>,
+          "Compute bedrock channel erosion during a single time step "
+          "using the Stream Power Law.\n\n"
+          "Version with spatially variable stream power coefficient.");
 
     m.def("erode_linear_diffusion_d", &erode_linear_diffusion_py<double, double>,
           "Compute hillslope erosion by linear diffusion on a 2-d regular "

--- a/test/test_bedrock_channel.cpp
+++ b/test/test_bedrock_channel.cpp
@@ -2,6 +2,7 @@
 #include <limits>
 #include <array>
 #include <string>
+#include <type_traits>
 
 #include "gtest/gtest.h"
 #include "xtensor/xtensor.hpp"
@@ -21,18 +22,22 @@ namespace fs = fastscapelib;
  * result of uplift vs. erosion using the Stream-Power law.
  *
  * Drainage area along the profile is estimated using Hack's law.
+ *
+ * The template parameter is used to set if the stream-power
+ * coefficient ``k_coef`` is a scalar or an array.
  */
+template<class K>
 struct ChannelProfile1D
 {
-    double k_coef = 1e-3;
+    int nnodes = 101;
+    double spacing = 300.;
+    double x0 = 300.;
+
+    K k_coef;
     double m_exp = 0.5;
     double n_exp = 1;
 
     double u_rate = 1e-3;
-
-    int nnodes = 101;
-    double spacing = 300.;
-    double x0 = 300.;
 
     double hack_coef = 6.69;
     double hack_exp = 1.67;
@@ -41,6 +46,8 @@ struct ChannelProfile1D
 
     ChannelProfile1D()
     {
+        init_k_coef();
+
         // fixed boundary (outlet)
         receivers(0) = 0;
         dist2receivers(0) = 0.;
@@ -51,6 +58,8 @@ struct ChannelProfile1D
     xt::xtensor<double, 1> get_steady_slope_analytical(void);
 
     private:
+    double k_coef_scalar = 1e-3;
+
     double length = (nnodes - 1) * spacing;
     xt::xtensor<double, 1> x = xt::linspace<double>(length + x0, x0,
                                                     static_cast<size_t>(nnodes));
@@ -64,6 +73,18 @@ struct ChannelProfile1D
 
     xt::xtensor<double, 1> uplift = xt::ones<double>({nnodes}) * u_rate;
     xt::xtensor<double, 1> erosion = xt::zeros<double>({nnodes});
+
+    template<typename K_ = K>
+    void init_k_coef(typename std::enable_if_t<xt::is_xexpression<K_>::value>* = 0)
+    {
+        k_coef = xt::full_like(elevation, k_coef_scalar);
+    }
+
+    template<typename K_ = K>
+    void init_k_coef(typename std::enable_if_t<std::is_floating_point<K_>::value>* = 0)
+    {
+        k_coef = k_coef_scalar;
+    }
 };
 
 
@@ -71,8 +92,9 @@ struct ChannelProfile1D
  * Get slope along the channel profile from the numerical solution at
  * steady state.
  */
-xt::xtensor<double, 1> ChannelProfile1D::get_steady_slope_numerical(double dt,
-                                                                    double tolerance)
+template<class K>
+xt::xtensor<double, 1> ChannelProfile1D<K>::get_steady_slope_numerical(double dt,
+                                                                       double tolerance)
 {
     // run model until steady state is reached
     double elevation_diff = std::numeric_limits<double>::max();
@@ -103,14 +125,18 @@ xt::xtensor<double, 1> ChannelProfile1D::get_steady_slope_numerical(double dt,
 
 /**
  * Get slope along the channel profile from the analytical solution at
- * steady state.
+ * steady state
+ *
+ * Note: this should be used to compare with the numerical solution only if
+ * ``k_coef`` is invariant in space!
  */
-xt::xtensor<double, 1> ChannelProfile1D::get_steady_slope_analytical(void)
+template<class K>
+xt::xtensor<double, 1> ChannelProfile1D<K>::get_steady_slope_analytical(void)
 {
     // exclude 1st node for proper comparison with the numerical solution
     auto drainage_area_ = xt::view(drainage_area, xt::range(1, _));
 
-    xt::xtensor<double, 1> slope = (std::pow(u_rate / k_coef, 1. / n_exp) *
+    xt::xtensor<double, 1> slope = (std::pow(u_rate / k_coef_scalar, 1. / n_exp) *
                                     xt::pow(drainage_area_, -m_exp / n_exp));
 
     return slope;
@@ -127,8 +153,21 @@ TEST(bedrock_channel, erode_stream_power)
                      "along a 1-d profile at steady-state for n_exp = " +
                      std::to_string(n_exp));
 
-        auto profile_1d = ChannelProfile1D();
+        auto profile_1d = ChannelProfile1D<double>();
         profile_1d.n_exp = n_exp;
+
+        auto slope_n = profile_1d.get_steady_slope_numerical(1e4, 1e-3);
+        auto slope_a = profile_1d.get_steady_slope_analytical();
+
+        EXPECT_TRUE(xt::allclose(slope_n, slope_a, 1e-5, 1e-5));
+        EXPECT_TRUE(profile_1d.n_corr == 0);
+    }
+
+    {
+        SCOPED_TRACE("test against analytical solution of slope "
+                     "using a 1-d array for k_coef");
+
+        auto profile_1d = ChannelProfile1D<xt::xtensor<double, 1>>();
 
         auto slope_n = profile_1d.get_steady_slope_numerical(1e4, 1e-3);
         auto slope_a = profile_1d.get_steady_slope_analytical();
@@ -140,7 +179,7 @@ TEST(bedrock_channel, erode_stream_power)
     {
         SCOPED_TRACE("test arbitrary limitation of erosion");
 
-        auto profile_1d = ChannelProfile1D();
+        auto profile_1d = ChannelProfile1D<double>();
         profile_1d.n_exp = 0.8;
 
         auto slope_n = profile_1d.get_steady_slope_numerical(1e4, 1e-3);
@@ -150,7 +189,8 @@ TEST(bedrock_channel, erode_stream_power)
 
     {
         SCOPED_TRACE("test on a tiny (2x2) 2-d square grid "
-                     "with a planar surface tilted in y (rows)");
+                     "with a planar surface tilted in y (rows) "
+                     "and set k_coef with a 2-d array");
 
         double k_coef = 1e-3;
         double m_exp = 0.5;
@@ -170,18 +210,21 @@ TEST(bedrock_channel, erode_stream_power)
 
         xt::xtensor<double, 2> erosion = xt::empty<double>({2, 2});
 
+        auto k_coef_arr = xt::full_like(elevation, k_coef);
+
         double dt = 1.;  // use small time step (compare with explicit scheme)
         double tolerance = 1e-3;
 
         index_t n_corr = fs::erode_stream_power(
             erosion, elevation, stack,
             receivers, dist2receivers, drainage_area,
-            k_coef, m_exp, n_exp, dt, tolerance);
+            k_coef_arr, m_exp, n_exp, dt, tolerance);
 
         double slope = h / dy;
         double err = dt * k_coef * std::pow(a, m_exp) * std::pow(slope, n_exp);
         xt::xtensor<double, 2> expected_erosion = {{0., 0.}, {err, err}};
 
         EXPECT_TRUE(xt::allclose(erosion, expected_erosion, 1e-5, 1e-5));
+        EXPECT_TRUE(n_corr == 0);
     }
 }

--- a/test/test_bedrock_channel.cpp
+++ b/test/test_bedrock_channel.cpp
@@ -4,6 +4,9 @@
 #include <string>
 #include <type_traits>
 
+#include <iostream>
+#include "xtensor/xio.hpp"
+
 #include "gtest/gtest.h"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xview.hpp"
@@ -65,7 +68,7 @@ struct ChannelProfile1D
                                                     static_cast<size_t>(nnodes));
 
     xt::xtensor<double, 1> drainage_area = hack_coef * xt::pow(x, hack_exp);
-    xt::xtensor<double, 1> elevation = (x - (length + x0)) * 0.001;
+    xt::xtensor<double, 1> elevation = (length + x0 - x) * 1e-4;
 
     xt::xtensor<index_t, 1> receivers = xt::arange<index_t>(-1, nnodes - 1);
     xt::xtensor<double, 1> dist2receivers = xt::ones<double>({nnodes}) * spacing;

--- a/test/test_bedrock_channel.cpp
+++ b/test/test_bedrock_channel.cpp
@@ -4,9 +4,6 @@
 #include <string>
 #include <type_traits>
 
-#include <iostream>
-#include "xtensor/xio.hpp"
-
 #include "gtest/gtest.h"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xview.hpp"

--- a/test/test_hillslope.cpp
+++ b/test/test_hillslope.cpp
@@ -7,8 +7,6 @@
 
 #include "fastscapelib/hillslope.hpp"
 
-#include <iostream>
-
 
 namespace fs = fastscapelib;
 


### PR DESCRIPTION
``k_coef`` argument should now accepts either a scalar or a (1-d or 2-d) array.

TODO:

- [x] maybe add benchmarks with all cases (scalar, 1-d, 2-d)