### PR TITLE
Fix old apple-clang versions (Python bindings)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,10 @@ matrix:
     - python: 3.5
       language: python
       env: DOCS=yes
+  allow_failures:
+    - os: osx
+      osx_image: xcode6.4
+      compiler: clang
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,14 +74,15 @@ matrix:
             - libstdc++-6-dev
       env: COMPILER=clang CLANG=6.0
     - os: osx
-      osx_image: xcode6.4
-      compiler: clang
-    - os: osx
       osx_image: xcode8
       compiler: clang
     - os: osx
       osx_image: xcode9
       compiler: clang
+    - os: osx
+      osx_image: xcode6.4
+      compiler: clang
+      env: PYTEST=3.6
     - os: linux
       addons:
         apt:
@@ -107,6 +108,7 @@ matrix:
     - os: osx
       osx_image: xcode6.4
       compiler: clang
+      env: PYTEST=3.6
 
 env:
   global:

--- a/include/fastscapelib/hillslope.hpp
+++ b/include/fastscapelib/hillslope.hpp
@@ -82,8 +82,10 @@ auto get_adi_factors(T k_coef,
                      sshape_t ncols,
                      typename std::enable_if_t<std::is_arithmetic<T>::value>* = 0)
 {
-    auto fr = xt::empty<double>({ncols});
-    auto fc = xt::empty<double>({ncols});
+    std::array<std::size_t, 1> shape_cols {static_cast<std::size_t>(ncols)};
+
+    auto fr = xt::empty<double>(shape_cols);
+    auto fc = xt::empty<double>(shape_cols);
 
     fr.fill(k_coef * 0.5 * dt / (dy * dy));
     fc.fill(k_coef * 0.5 * dt / (dx * dx));

--- a/include/fastscapelib/hillslope.hpp
+++ b/include/fastscapelib/hillslope.hpp
@@ -227,10 +227,12 @@ void erode_linear_diffusion_impl(Er&& erosion,
         nrows, ncols);
 
     // solve for cols (i.e., transpose)
+    auto tranposed_dims = std::array<std::size_t, 3> {0, 2, 1};
+
     auto elevation_next = solve_diffusion_adi_row(
         xt::transpose(elevation_tmp),
-        xt::transpose(factors.second, {0, 2, 1}),
-        xt::transpose(factors.first, {0, 2, 1}),
+        xt::transpose(factors.second, tranposed_dims),
+        xt::transpose(factors.first, tranposed_dims),
         ncols, nrows);
 
     auto erosion_v = xt::view(erosion, xt::all(), xt::all());


### PR DESCRIPTION
Some fixes + CI settings to ensure that the fastscapelib Python library will compile on older apple-clang versions (e.g., the one used by conda-forge).

This test is allowed to fail on travis, as hopefully conda-forge will soon use more recent compilers.