### PR TITLE
Update to xtensor latest version (0.18)

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -4,7 +4,7 @@ Install Fastscapelib
 ====================
 
 This library is header only and uses C++14 standards. It depends on
-xtensor_.
+xtensor_ (>0.18).
 
 .. _xtensor: https://github.com/QuantStack/xtensor
 

--- a/include/fastscapelib/bedrock_channel.hpp
+++ b/include/fastscapelib/bedrock_channel.hpp
@@ -9,7 +9,7 @@
 #include <type_traits>
 
 #include "xtensor/xtensor.hpp"
-#include "xtensor/xstrided_view.hpp"
+#include "xtensor/xmanipulation.hpp"
 
 #include "fastscapelib/utils.hpp"
 

--- a/include/fastscapelib/flow_routing.hpp
+++ b/include/fastscapelib/flow_routing.hpp
@@ -14,7 +14,7 @@
 
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xview.hpp"
-#include "xtensor/xstrided_view.hpp"
+#include "xtensor/xmanipulation.hpp"
 
 #include "fastscapelib/utils.hpp"
 #include "fastscapelib/consts.hpp"

--- a/include/fastscapelib/hillslope.hpp
+++ b/include/fastscapelib/hillslope.hpp
@@ -175,15 +175,23 @@ auto solve_diffusion_adi_row(Ei&& elevation,
         }
 
         // boundary conditions
-        auto lower_bounds = xt::view(lower, xt::keep(0, -1));
-        lower_bounds = 0;
-        auto diag_bounds = xt::view(diag, xt::keep(0, -1));
-        diag_bounds = 1;
-        auto upper_bounds = xt::view(upper, xt::keep(0, -1));
-        upper_bounds = 0;
+        auto ilast = ncols - 1;
+
+        lower(0) = 0;
+        lower(ilast) = 0;
+        diag(0) = 1;
+        diag(ilast) = 1;
+        upper(0) = 0;
+        upper(ilast) = 0;
         vec(0) = elevation(r, 0);
-        vec(ncols - 1) = elevation(r, ncols - 1);
-        // TODO: the code below works with xtensor 0.17.1 but not with 0.17.2
+        vec(ilast) = elevation(r, ilast);
+        // TODO: the code below works with xtensor 0.17.1 but not with later versions
+        // auto lower_bounds = xt::view(lower, xt::keep(0, -1));
+        // lower_bounds = 0;
+        // auto diag_bounds = xt::view(diag, xt::keep(0, -1));
+        // diag_bounds = 1;
+        // auto upper_bounds = xt::view(upper, xt::keep(0, -1));
+        // upper_bounds = 0;
         // auto vec_bounds = xt::view(vec, xt::keep(0, -1));
         // vec_bounds = xt::view(elevation, r, xt::keep(0, -1));
 

--- a/include/fastscapelib/hillslope.hpp
+++ b/include/fastscapelib/hillslope.hpp
@@ -13,7 +13,7 @@
 #include "xtensor/xbuilder.hpp"
 #include "xtensor/xnoalias.hpp"
 #include "xtensor/xview.hpp"
-#include "xtensor/xstrided_view.hpp"
+#include "xtensor/xmanipulation.hpp"
 
 #include "fastscapelib/utils.hpp"
 

--- a/include/fastscapelib/hillslope.hpp
+++ b/include/fastscapelib/hillslope.hpp
@@ -163,10 +163,9 @@ auto solve_diffusion_adi_row(Ei&& elevation,
 
     for (index_t r=1; r<nrows-1; ++r)
     {
-        // TODO use xt::view with xbroadcast (check xtensor #1036 #917)
-        xt::noalias(lower) = -1 * xt::strided_view(factors_col, {0, r, xt::all()});
-        xt::noalias(diag) = 1 + 2 * xt::strided_view(factors_col, {1, r, xt::all()});
-        xt::noalias(upper) = -1 * xt::strided_view(factors_col, {2, r, xt::all()});
+        xt::noalias(lower) = -1 * xt::view(factors_col, 0, r, xt::all());
+        xt::noalias(diag) = 1 + 2 * xt::view(factors_col, 1, r, xt::all());
+        xt::noalias(upper) = -1 * xt::view(factors_col, 2, r, xt::all());
 
         for (index_t c=1; c<ncols-1; ++c)
         {

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -5,7 +5,6 @@
 #include <cstdint>
 
 #include "pybind11/pybind11.h"
-#include "xtl/xmeta_utils.hpp"   // TODO: remove when xtensor 0.18 is released
 #define FORCE_IMPORT_ARRAY
 #include "xtensor-python/pytensor.hpp"
 #include "xtensor-python/pyarray.hpp"

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "pybind11/pybind11.h"
+#include "xtl/xmeta_utils.hpp"   // TODO: remove when xtensor 0.18 is released
 #define FORCE_IMPORT_ARRAY
 #include "xtensor-python/pytensor.hpp"
 #include "xtensor-python/pyarray.hpp"


### PR DESCRIPTION
Don't merge until xtensor 0.18 is released (and new release for xtensor-python too).

TODO:

- [x] remove temp fix for python bindings
- [x] update docs (min xtensor version required)