### PR TITLE
Build fastscapelib using xtensor master (cmake option)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,14 @@ matrix:
         apt:
           sources:
             - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env: COMPILER=gcc GCC=7 XTENSOR=dev
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
             - llvm-toolchain-trusty-3.9
           packages:
             - clang-3.9
@@ -105,6 +113,14 @@ matrix:
       language: python
       env: DOCS=yes
   allow_failures:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env: COMPILER=gcc GCC=7 XTENSOR=dev
     - os: osx
       osx_image: xcode6.4
       compiler: clang
@@ -158,7 +174,8 @@ install:
   - source activate test_env
   - conda list
   # Maybe build tests or build/install Python bindings
-  - if [[ "$DOCS" == "yes" ]]; then
+  - |
+    if [[ "$DOCS" == "yes" ]]; then
       cd doc;
     elif [[ "$PYTEST" == "2.7" || "$PYTEST" == "3.6" ]]; then
       cd python;
@@ -166,7 +183,11 @@ install:
     else
       mkdir build;
       cd build;
-      cmake -DBUILD_TESTS=ON ..;
+      if [[ "$XTENSOR" == "dev" ]]; then
+        cmake -DBUILD_TESTS=ON -DDOWNLOAD_XTENSOR=ON ..;
+      else
+        cmake -DBUILD_TESTS=ON ..;
+      fi
       make -j2 test_fastscapelib;
       cd test;
     fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,13 +36,60 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 # Dependencies
 # ============
 
-# TODO: xtl should be found by xtensor config.
-# fix upstream"find_dependency(xtl REQUIRED)" in xtensorConfig.cmake?
-find_package(xtl REQUIRED)
-message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
+OPTION(DOWNLOAD_XTENSOR "Download xtensor from github (master)" OFF)
 
-find_package(xtensor REQUIRED)
-message(STATUS "Found xtensor: ${xtensor_INCLUDE_DIRS}/xtensor")
+if(DOWNLOAD_XTENSOR)
+  configure_file(downloadXTensor.cmake.in
+    xtensor-download/CMakeLists.txt)
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/xtensor-download
+    )
+
+  if(result)
+    message(FATAL_ERROR "CMake step for xtensor failed: ${result}")
+  endif()
+
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/xtensor-download
+    )
+
+  if(result)
+    message(FATAL_ERROR "Build step for xtensor failed: ${result}")
+  endif()
+
+  # Add xtensor directly to our build
+  # temporarily disable conflicting options
+  # (we don't want to build xtensor's test/benchmark suites here)
+  SET(TEMP_BUILD_TESTS ${BUILD_TESTS})
+  SET(BUILD_TESTS OFF CACHE INTERNAL "" FORCE)
+  SET(TEMP_BUILD_BENCHMARK ${BUILD_BENCHMARK})
+  SET(BUILD_BENCHMARK OFF CACHE INTERNAL "" FORCE)
+  SET(TEMP_DOWNLOAD_GBENCHMARK ${DOWNLOAD_GBENCHMARK})
+  SET(DOWNLOAD_GBENCHMARK OFF CACHE INTERNAL "" FORCE)
+
+  add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/xtensor-src
+    ${CMAKE_CURRENT_BINARY_DIR}/xtensor-build)
+
+  SET(BUILD_TESTS ${TEMP_BUILD_TESTS} CACHE INTERNAL "" FORCE)
+  SET(DOWNLOAD_GBENCHMARK ${TEMP_DOWNLOAD_GBENCHMARK} CACHE INTERNAL "" FORCE)
+  SET(BUILD_BENCHMARK ${TEMP_BUILD_BENCHMARK} CACHE INTERNAL "" FORCE)
+
+  set(xtensor_INCLUDE_DIRS "${xtensor_SOURCE_DIR}/include")
+else()
+  # TODO: xtl should be found by xtensor config.
+  # fix upstream"find_dependency(xtl REQUIRED)" in xtensorConfig.cmake?
+  find_package(xtl REQUIRED)
+  message(STATUS "Found xtl: ${xtl_INCLUDE_DIRS}/xtl")
+
+  find_package(xtensor REQUIRED)
+  message(STATUS "Found xtensor: ${xtensor_INCLUDE_DIRS}/xtensor")
+endif()
+
 
 # Build
 # =====
@@ -86,7 +133,7 @@ if(BUILD_TESTS)
 endif()
 
 if(BUILD_BENCHMARK)
-    add_subdirectory(benchmark)
+  add_subdirectory(benchmark)
 endif()
 
 if(BUILD_PYTHON_MODULE)

--- a/doc/source/build_options.rst
+++ b/doc/source/build_options.rst
@@ -17,6 +17,10 @@ default). See below for more explanations.
   instead of downloading them.
 - ``BUILD_PYTHON_MODULE``: enables building fastscapelib as a Python
   extension.
+- ``DOWNLOAD_XTENSOR``: downloads xtensor development version (master
+  branch on github) and uses it to build fastscapelib (useful for
+  testing - might be needed for building fastscapelib development
+  version).
 
 Build and run tests
 -------------------

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -3,6 +3,12 @@
 Release Notes
 =============
 
+v0.2.0 (Unreleased)
+-------------------
+
+- Add a cmake option that allows downloading/using xtensor development
+  version (:issue:`37`).
+
 v0.1.3 (5 November 2018)
 ------------------------
 

--- a/downloadXTensor.cmake.in
+++ b/downloadXTensor.cmake.in
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8.2)
+
+project(xtensor-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(xtensor
+    GIT_REPOSITORY    "https://github.com/QuantStack/xtensor.git"
+    GIT_TAG           "master"
+    SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/xtensor-src"
+    BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/xtensor-build"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND     ""
+    INSTALL_COMMAND   ""
+    TEST_COMMAND      ""
+)


### PR DESCRIPTION
This PR adds the possibility to configure fastscapelib build so that xtensor is downloaded from github (master):

```
   $ cmake -DDOWNLOAD_XTENSOR=ON ..
```

This is useful for CI testing against development version of xtensor (added as xfail to travis).
