### PR TITLE
Add grid classes

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -16,5 +16,6 @@
   (flycheck-gcc-language-standard . "c++14")
   (flycheck-clang-language-standard . "c++14")
   (flycheck-clang-standard-library . "libc++")
+  (flycheck-clang-warnings . ("everything" "no-pragma-once-outside-header" "no-c++98-compat"))
   (indent-tabs-mode . nil)
   (c-basic-offset . 4)))

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -18,4 +18,6 @@
   (flycheck-clang-standard-library . "libc++")
   (flycheck-clang-warnings . ("everything" "no-pragma-once-outside-header" "no-c++98-compat"))
   (indent-tabs-mode . nil)
-  (c-basic-offset . 4)))
+  (c-basic-offset . 4)
+  (c-file-offsets
+   (innamespace . -))))

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,9 @@ matrix:
             - g++-7
       env: COMPILER=gcc GCC=7 XTENSOR=dev
     - os: osx
+      osx_image: xcode8
+      compiler: clang
+    - os: osx
       osx_image: xcode6.4
       compiler: clang
       env: PYTEST=3.6

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,9 @@ set(FASTSCAPELIB_HEADERS
   ${VERSION_HEADER_FILE}
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/fastscapelib.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/utils.hpp
+  ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/xtensor_utils.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/consts.hpp
+  ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/grid.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/sinks.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/flow_routing.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/bedrock_channel.hpp

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -112,6 +112,8 @@ endif()
 
 set(FASTSCAPELIB_BENCHMARK_SRC
   benchmark_setup.hpp
+  benchmark_grid.cpp
+  benchmark_flow_routing.cpp
   benchmark_bedrock_channel.cpp
   benchmark_hillslope.cpp
   benchmark_sinks.cpp

--- a/benchmark/benchmark_flow_routing.cpp
+++ b/benchmark/benchmark_flow_routing.cpp
@@ -1,0 +1,39 @@
+#include <benchmark/benchmark.h>
+
+#include "xtensor/xbuilder.hpp"
+#include "xtensor/xtensor.hpp"
+
+#include "fastscapelib/flow_routing.hpp"
+
+#include "benchmark_setup.hpp"
+
+
+namespace fs = fastscapelib;
+namespace bms = benchmark_setup;
+
+
+namespace fastscapelib
+{
+
+namespace benchmark_grid
+{
+
+template<class T>
+void bm_compute_receivers_d8(benchmark::State& state)
+{
+    auto s = bms::FastscapeSetupBase<bms::SurfaceType::flat_noise, T>(state.range(0));
+
+    for (auto _ : state)
+    {
+        fs::compute_receivers_d8(s.receivers, s.dist2receivers,
+                                 s.elevation, s.active_nodes,
+                                 s.dx, s.dy);
+    }
+}
+
+BENCHMARK_TEMPLATE(bm_compute_receivers_d8, double)
+->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+} // namespace benchmark_grid
+
+} // namespace fastscapelib

--- a/benchmark/benchmark_grid.cpp
+++ b/benchmark/benchmark_grid.cpp
@@ -1,0 +1,164 @@
+#include <benchmark/benchmark.h>
+
+#include "xtensor/xfixed.hpp"
+#include "xtensor/xtensor.hpp"
+
+#include "fastscapelib/consts.hpp"
+#include "fastscapelib/grid.hpp"
+
+#include "benchmark_setup.hpp"
+
+
+namespace fs = fastscapelib;
+namespace bms = benchmark_setup;
+
+
+namespace fastscapelib
+{
+
+namespace benchmark_grid
+{
+
+template <class XT>
+void bm_raster_grid_create(benchmark::State& state)
+{
+    using grid = fs::raster_grid_xt<XT>;
+    using size_type = typename grid::size_type;
+
+    auto n = static_cast<size_type>(state.range(0));
+    std::array<size_type, 2> shape {n, n};
+
+    for (auto _ : state)
+    {
+        auto rg = grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
+    }
+}
+
+template <fs::raster_connect RC>
+void bm_raster_grid_neighbor_indices(benchmark::State& state)
+{
+    using size_type = typename fs::raster_grid::size_type;
+
+    auto n = static_cast<size_type>(state.range(0));
+    std::array<size_type, 2> shape {n, n};
+
+    auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
+
+    for (auto _ : state)
+    {
+        for (size_type r = 0; r < shape[0]; ++r)
+        {
+            for (size_type c = 0; c < shape[1]; ++c)
+            {
+                auto nb_indices = rg.neighbor_indices<RC>(r, c);
+            }
+        }
+    }
+}
+
+template <fs::raster_connect RC>
+void bm_raster_grid_neighbor_view(benchmark::State& state)
+{
+    using size_type = typename fs::raster_grid::size_type;
+
+    auto n = static_cast<size_type>(state.range(0));
+    std::array<size_type, 2> shape {n, n};
+
+    auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
+    xt::xtensor<double, 2> field(shape, 1.);
+
+    for (auto _ : state)
+    {
+        for (size_type r = 0; r < shape[0]; ++r)
+        {
+            for (size_type c = 0; c < shape[1]; ++c)
+            {
+                auto nb_field_view = rg.neighbor_view<RC>(field, r, c);
+            }
+        }
+    }
+}
+
+template <fs::raster_connect RC>
+void bm_raster_grid_neighbor_distances(benchmark::State& state)
+{
+    using size_type = typename fs::raster_grid::size_type;
+
+    auto n = static_cast<size_type>(state.range(0));
+    std::array<size_type, 2> shape {n, n};
+
+    auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
+
+    for (auto _ : state)
+    {
+        for (size_type r = 0; r < shape[0]; ++r)
+        {
+            for (size_type c = 0; c < shape[1]; ++c)
+            {
+                auto nb_distances = rg.neighbor_distances<RC>(r, c);
+            }
+        }
+    }
+}
+
+template <fs::raster_connect RC>
+void bm_raster_grid_neighbor_classic(benchmark::State& state)
+{
+    using size_type = typename fs::raster_grid::size_type;
+
+    auto n = static_cast<size_type>(state.range(0));
+    std::array<size_type, 2> shape {n, n};
+
+    auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
+
+    for (auto _ : state)
+    {
+        for (size_type r = 0; r < shape[0]; ++r)
+        {
+            for (size_type c = 0; c < shape[1]; ++c)
+            {
+                for(std::size_t k=1; k<=8; ++k)
+                {
+                    const index_t kr = r + fs::consts::d8_row_offsets[k];
+                    const index_t kc = c + fs::consts::d8_col_offsets[k];
+
+                    if(!fs::detail::in_bounds(shape, kr, kc))
+                    {
+                        continue;
+                    }
+
+                    benchmark::DoNotOptimize(kr);
+                    benchmark::DoNotOptimize(kc);
+                }
+            }
+        }
+    }
+}
+
+BENCHMARK_TEMPLATE(bm_raster_grid_neighbor_classic, fs::raster_connect::queen)
+->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+BENCHMARK_TEMPLATE(bm_raster_grid_create, fs::xtensor_selector)
+->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+
+BENCHMARK_TEMPLATE(bm_raster_grid_neighbor_indices, fs::raster_connect::queen)
+->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+BENCHMARK_TEMPLATE(bm_raster_grid_neighbor_indices, fs::raster_connect::rook)
+->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+BENCHMARK_TEMPLATE(bm_raster_grid_neighbor_view, fs::raster_connect::queen)
+->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+BENCHMARK_TEMPLATE(bm_raster_grid_neighbor_view, fs::raster_connect::rook)
+->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+BENCHMARK_TEMPLATE(bm_raster_grid_neighbor_distances, fs::raster_connect::queen)
+->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+BENCHMARK_TEMPLATE(bm_raster_grid_neighbor_distances, fs::raster_connect::rook)
+->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+
+} // namespace benchmark_grid
+
+} // namespace fastscapelib

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,5 +2,6 @@ name: fastscapelib-docs
 channels:
   - conda-forge
 dependencies:
+  - sphinx=1.8.5
   - breathe
   - cmake

--- a/doc/source/api_cpp.rst
+++ b/doc/source/api_cpp.rst
@@ -69,6 +69,13 @@ Grid elements
    :project: fastscapelib
    :members:
 
+Grid interface
+~~~~~~~~~~~~~~
+
+.. doxygenclass:: fastscapelib::grid_interface
+   :project: fastscapelib
+   :members:
+
 Profile grid (1D)
 ~~~~~~~~~~~~~~~~~
 

--- a/doc/source/api_cpp.rst
+++ b/doc/source/api_cpp.rst
@@ -33,6 +33,56 @@ or include just a subset of the functions (by topic), e.g.,
 
    #include "fastscapelib/flow_routing.hpp"
 
+Grid
+----
+
+Grid/mesh (and related) structures.
+
+Defined in ``fastscapelib/grid.hpp``.
+
+Grid boundaries
+~~~~~~~~~~~~~~~
+
+.. doxygenenum:: fastscapelib::node_status
+   :project: fastscapelib
+
+.. doxygenstruct:: fastscapelib::edge_nodes_status
+   :project: fastscapelib
+   :members:
+
+.. doxygenstruct:: fastscapelib::border_nodes_status
+   :project: fastscapelib
+   :members:
+
+Grid elements
+~~~~~~~~~~~~~
+
+.. doxygenstruct:: fastscapelib::node
+   :project: fastscapelib
+   :members:
+
+.. doxygenstruct:: fastscapelib::raster_node
+   :project: fastscapelib
+   :members:
+
+.. doxygenstruct:: fastscapelib::neighbor
+   :project: fastscapelib
+   :members:
+
+.. doxygenstruct:: fastscapelib::raster_neighbor
+   :project: fastscapelib
+   :members:
+
+Profile grid (1D)
+~~~~~~~~~~~~~~~~~
+
+.. doxygenclass:: fastscapelib::profile_grid_xt
+   :project: fastscapelib
+   :members:
+
+.. doxygentypedef:: fastscapelib::profile_grid
+   :project: fastscapelib
+
 Sinks (depressions)
 -------------------
 

--- a/doc/source/api_cpp.rst
+++ b/doc/source/api_cpp.rst
@@ -46,7 +46,7 @@ Grid boundaries
 .. doxygenenum:: fastscapelib::node_status
    :project: fastscapelib
 
-.. doxygenstruct:: fastscapelib::boundary_status
+.. doxygenclass:: fastscapelib::boundary_status
    :project: fastscapelib
    :members:
 

--- a/doc/source/api_cpp.rst
+++ b/doc/source/api_cpp.rst
@@ -50,21 +50,6 @@ Grid boundaries
    :project: fastscapelib
    :members:
 
-.. doxygenfunction:: fastscapelib::set_boundaries(node_status)
-   :project: fastscapelib
-
-.. doxygenfunction:: fastscapelib::set_boundaries(node_status, node_status)
-   :project: fastscapelib
-
-.. doxygenfunction:: fastscapelib::set_boundaries(const std::array<node_status, 2>&)
-   :project: fastscapelib
-
-.. doxygenfunction:: fastscapelib::set_boundaries(node_status, node_status, node_status, node_status)
-   :project: fastscapelib
-
-.. doxygenfunction:: fastscapelib::set_boundaries(const std::array<node_status, 4>&)
-   :project: fastscapelib
-
 Grid elements
 ~~~~~~~~~~~~~
 

--- a/doc/source/api_cpp.rst
+++ b/doc/source/api_cpp.rst
@@ -46,13 +46,24 @@ Grid boundaries
 .. doxygenenum:: fastscapelib::node_status
    :project: fastscapelib
 
-.. doxygenstruct:: fastscapelib::edge_nodes_status
+.. doxygenstruct:: fastscapelib::boundary_status
    :project: fastscapelib
    :members:
 
-.. doxygenstruct:: fastscapelib::border_nodes_status
+.. doxygenfunction:: fastscapelib::set_boundaries(node_status)
    :project: fastscapelib
-   :members:
+
+.. doxygenfunction:: fastscapelib::set_boundaries(node_status, node_status)
+   :project: fastscapelib
+
+.. doxygenfunction:: fastscapelib::set_boundaries(const std::array<node_status, 2>&)
+   :project: fastscapelib
+
+.. doxygenfunction:: fastscapelib::set_boundaries(node_status, node_status, node_status, node_status)
+   :project: fastscapelib
+
+.. doxygenfunction:: fastscapelib::set_boundaries(const std::array<node_status, 4>&)
+   :project: fastscapelib
 
 Grid elements
 ~~~~~~~~~~~~~

--- a/include/fastscapelib/fastscapelib.hpp
+++ b/include/fastscapelib/fastscapelib.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "fastscapelib/version.hpp"
+#include "fastscapelib/grid.hpp"
 #include "fastscapelib/bedrock_channel.hpp"
 #include "fastscapelib/flow_routing.hpp"
 #include "fastscapelib/hillslope.hpp"

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -224,13 +224,13 @@ public:
 
     std::size_t size() const noexcept;
     double spacing() const noexcept;
-    const xt_node_status_t& node_status() const;
+    const xt_node_status_t& status_at_nodes() const;
 
 private:
     std::size_t m_size;
     double m_spacing;
 
-    xt_node_status_t m_node_status;
+    xt_node_status_t m_status_at_nodes;
     const edge_nodes_status& m_status_at_edges;
     bool has_looped_boundaries = false;
 
@@ -261,17 +261,17 @@ inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
                                            const std::vector<node>& status_at_nodes)
     : m_size(size), m_spacing(spacing), m_status_at_edges(status_at_bounds)
 {
-    m_node_status = xt::zeros<fastscapelib::node_status>({size});
-    m_node_status[0] = status_at_bounds.left;
-    m_node_status[size-1] = status_at_bounds.right;
+    m_status_at_nodes = xt::zeros<fastscapelib::node_status>({size});
+    m_status_at_nodes[0] = status_at_bounds.left;
+    m_status_at_nodes[size-1] = status_at_bounds.right;
 
     for (const node& inode : status_at_nodes)
     {
-        m_node_status(inode.idx) = inode.status;
+        m_status_at_nodes(inode.idx) = inode.status;
     }
 
-    bool left_looped = status_at_bounds.left == node_status::looped_boundary;
-    bool right_looped = status_at_bounds.right == node_status::looped_boundary;
+    bool left_looped = status_at_bounds.left == fastscapelib::node_status::looped_boundary;
+    bool right_looped = status_at_bounds.right == fastscapelib::node_status::looped_boundary;
 
     if (left_looped ^ right_looped)
     {
@@ -296,19 +296,23 @@ void profile_grid_xt<X>::precompute_neighbors()
         for (std::size_t k=1; k<3; ++k)
         {
             std::size_t nb_idx = detail::add_offset(idx, offsets[k]);
-            neighbor nb = {nb_idx, m_spacing, m_node_status[nb_idx]};
+            neighbor nb = {nb_idx, m_spacing, m_status_at_nodes[nb_idx]};
             m_all_neighbors[idx].push_back(nb);
         }
     }
 
-    m_all_neighbors[0].push_back({1, m_spacing, m_node_status[1]});
-    m_all_neighbors[m_size-1].push_back({m_size-2, m_spacing, m_node_status[m_size-2]});
+    m_all_neighbors[0].push_back(
+        {1, m_spacing, m_status_at_nodes[1]});
+    m_all_neighbors[m_size-1].push_back(
+        {m_size-2, m_spacing, m_status_at_nodes[m_size-2]});
 
     if (has_looped_boundaries)
     {
-        m_all_neighbors[0].insert(m_all_neighbors[0].begin(),
-                                  {m_size-1, m_spacing, m_node_status[m_size-1]});
-        m_all_neighbors[m_size-1].push_back({0, m_spacing, m_node_status[0]});
+        m_all_neighbors[0].insert(
+            m_all_neighbors[0].begin(),
+            {m_size-1, m_spacing, m_status_at_nodes[m_size-1]});
+        m_all_neighbors[m_size-1].push_back(
+            {0, m_spacing, m_status_at_nodes[0]});
     }
 }
 
@@ -338,10 +342,10 @@ inline double profile_grid_xt<X>::spacing() const noexcept
  * Returns a reference to the array of status at grid nodes.
  */
 template <class X>
-inline auto profile_grid_xt<X>::node_status() const
+inline auto profile_grid_xt<X>::status_at_nodes() const
     -> const profile_grid_xt<X>::xt_node_status_t&
 {
-    return m_node_status;
+    return m_status_at_nodes;
 }
 //@}
 

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -45,7 +45,6 @@ struct edge_nodes_status
     node_status left = node_status::core;   /**< Status at left edge node */
     node_status right = node_status::core;  /**< Status at right edge node */
 
-    edge_nodes_status(const edge_nodes_status& es);
     edge_nodes_status(node_status status);
     edge_nodes_status(const std::array<node_status, 2>& left_right);
     edge_nodes_status(std::initializer_list<node_status> left_right);
@@ -55,14 +54,6 @@ struct edge_nodes_status
  * @name Constructors
  */
 //@{
-/**
- * Copy constructor.
- */
-inline edge_nodes_status::edge_nodes_status(const edge_nodes_status& es)
-    : left(es.left), right(es.right)
-{
-}
-
 /**
  * Set the same status at both the left and right edge nodes.
  */
@@ -244,7 +235,7 @@ private:
     bool has_looped_boundaries = false;
 
     // TODO: make this "static" in some way? (like C++17 inline variables but in C++14)
-    const std::array<std::ptrdiff_t, 3> offsets {0, -1, 1};
+    const std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
 
     std::vector<neighbor_vec> m_all_neighbors;
     void precompute_neighbors();

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -11,7 +11,7 @@
 #include <initializer_list>
 #include <stdexcept>
 #include <type_traits>
-#include <unordered_map>
+#include <map>
 #include <vector>
 
 #include "xtensor/xbuilder.hpp"
@@ -47,7 +47,7 @@ namespace detail
 
 inline bool node_status_cmp(node_status a, node_status b)
 {
-    static std::unordered_map<node_status, int> priority = {
+    static std::map<node_status, int> priority {
         {node_status::core, 0},
         {node_status::looped_boundary, 1},
         {node_status::fixed_gradient_boundary, 2},

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -219,10 +219,10 @@ private:
  * @param status_at_nodes Manually define the status at any node on the grid.
  */
 template <class X>
-profile_grid_xt<X>::profile_grid_xt(std::size_t size,
-                                    double spacing,
-                                    const boundary_status& status_at_bounds,
-                                    const std::vector<node>& status_at_nodes)
+inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
+                                           double spacing,
+                                           const boundary_status& status_at_bounds,
+                                           const std::vector<node>& status_at_nodes)
     : m_size(size), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
 {
     //set_status_at_nodes(std::move(status_at_nodes));

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -312,7 +312,7 @@ private:
     bool has_looped_edges = false;
     void set_status_at_nodes(const std::vector<node>& status_at_nodes);
 
-    static const std::array<std::ptrdiff_t, 3> offsets;
+    static constexpr std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
     std::vector<neighbors_type> m_all_neighbors;
     void precompute_neighbors();
 
@@ -322,7 +322,7 @@ private:
 };
 
 template <class XT>
-constexpr std::array<std::ptrdiff_t, 3> profile_grid_xt<XT>::offsets = { {0, -1, 1} };
+constexpr std::array<std::ptrdiff_t, 3> profile_grid_xt<XT>::offsets;
 
 /**
  * @name Constructors

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -198,7 +198,7 @@ private:
     xt_node_status_t m_status_at_nodes;
     boundary_status m_status_at_bounds;
     bool has_looped_edges = false;
-    void set_status_at_nodes(const std::vector<node>& status_at_nodes);
+    //void set_status_at_nodes(const std::vector<node>& status_at_nodes);
 
     // TODO: make this "static" in some way? (like C++17 inline variables but in C++14)
     const std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
@@ -225,7 +225,7 @@ profile_grid_xt<X>::profile_grid_xt(std::size_t size,
                                     const std::vector<node>& status_at_nodes)
     : m_size(size), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
 {
-    //set_status_at_nodes(status_at_nodes);
+    //set_status_at_nodes(std::move(status_at_nodes));
 
     std::array<std::size_t, 1> shape {m_size};
     m_status_at_nodes.resize(shape);
@@ -255,33 +255,33 @@ profile_grid_xt<X>::profile_grid_xt(std::size_t size,
 }
 //@}
 
-template <class X>
-void profile_grid_xt<X>::set_status_at_nodes(const std::vector<node>& status_at_nodes)
-{
-    std::array<std::size_t, 1> shape {m_size};
-    m_status_at_nodes.resize(shape);
-    m_status_at_nodes.fill(node_status::core);
+// template <class X>
+// void profile_grid_xt<X>::set_status_at_nodes(const std::vector<node>& status_at_nodes)
+// {
+//     std::array<std::size_t, 1> shape {m_size};
+//     m_status_at_nodes.resize(shape);
+//     m_status_at_nodes.fill(node_status::core);
 
-    m_status_at_nodes[0] = m_status_at_bounds.left;
-    m_status_at_nodes[m_size-1] = m_status_at_bounds.right;
+//     m_status_at_nodes[0] = m_status_at_bounds.left;
+//     m_status_at_nodes[m_size-1] = m_status_at_bounds.right;
 
-    for (const node& inode : status_at_nodes)
-    {
-        m_status_at_nodes(inode.idx) = inode.status;
-    }
+//     for (const node& inode : status_at_nodes)
+//     {
+//         m_status_at_nodes(inode.idx) = inode.status;
+//     }
 
-    bool left_looped = m_status_at_nodes[0] == node_status::looped_boundary;
-    bool right_looped = m_status_at_nodes[m_size-1] == node_status::looped_boundary;
+//     bool left_looped = m_status_at_nodes[0] == node_status::looped_boundary;
+//     bool right_looped = m_status_at_nodes[m_size-1] == node_status::looped_boundary;
 
-    if (left_looped ^ right_looped)
-    {
-        throw std::invalid_argument("inconsistent looped boundary status at grid edges");
-    }
-    else if (left_looped && right_looped)
-    {
-        has_looped_edges = true;
-    }
-}
+//     if (left_looped ^ right_looped)
+//     {
+//         throw std::invalid_argument("inconsistent looped boundary status at grid edges");
+//     }
+//     else if (left_looped && right_looped)
+//     {
+//         has_looped_edges = true;
+//     }
+// }
 
 template <class X>
 void profile_grid_xt<X>::precompute_neighbors()

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -119,6 +119,11 @@ struct neighbor
     node_status status;
 };
 
+inline std::size_t add_offset(std::size_t idx, std::ptrdiff_t offset)
+{
+    return static_cast<std::size_t>(static_cast<std::ptrdiff_t>(idx) + offset);
+}
+
 
 //*******************
 //* Profile grid (1D)
@@ -203,7 +208,7 @@ void profile_grid_xt<Tag>::precompute_neighbors()
     {
         for (std::size_t k=1; k<3; ++k)
         {
-            std::size_t nb_idx = idx + offsets[k];
+            std::size_t nb_idx = add_offset(idx, offsets[k]);
             neighbor nb = {nb_idx, m_spacing, m_node_status[nb_idx]};
             m_all_neighbors[idx].push_back(nb);
         }

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -1,0 +1,273 @@
+/**
+ * grids (channel, raster, etc.) hold and manage grid/mesh geometry,
+ * topology and boundary conditions.
+ */
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "xtensor/xbuilder.hpp"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xtensor.hpp"
+
+#include "fastscapelib/consts.hpp"
+#include "fastscapelib/xtensor_utils.hpp"
+
+
+namespace fastscapelib
+{
+
+//*****************
+//* Grid boundaries
+//*****************
+
+enum class node_status : std::uint8_t
+{
+    core = 0,
+    fixed_value_boundary = 1,
+    fixed_gradient_boundary = 2,
+    looped_boundary = 3
+};
+
+struct edge_status
+{
+    node_status left = node_status::core;
+    node_status right = node_status::core;
+
+    edge_status(node_status status)
+        : left(status), right(status)
+    {
+    }
+
+    edge_status(node_status status_left, node_status status_right)
+        : left(status_left), right(status_right)
+    {
+    }
+
+    edge_status(std::initializer_list<node_status> edges)
+    {
+        if (edges.size() != 2)
+        {
+            throw std::invalid_argument("border status list must have 4 elements: "
+                                        "{left, right}");
+        }
+
+        auto iter = edges.begin();
+        left = *iter++;
+        right = *iter++;
+    }
+};
+
+struct border_status
+{
+    node_status top = node_status::core;
+    node_status right = node_status::core;
+    node_status bottom = node_status::core;
+    node_status left = node_status::core;
+
+    border_status(node_status status)
+        : top(status), right(status), bottom(status), left(status)
+    {
+    }
+
+    border_status(node_status status_top,
+                  node_status status_right,
+                  node_status status_bottom,
+                  node_status status_left)
+        : top(status_top), right(status_right), bottom(status_bottom), left(status_left)
+    {
+    }
+
+    border_status(std::initializer_list<node_status> borders)
+    {
+        if (borders.size() != 4)
+        {
+            throw std::invalid_argument("border status list must have 4 elements: "
+                                        "{top, right, bottom, left}");
+        }
+
+        auto iter = borders.begin();
+        top = *iter++;
+        right = *iter++;
+        bottom = *iter++;
+        left = *iter++;
+    }
+};
+
+
+//***************
+//* Grid elements
+//***************
+
+struct raster_node
+{
+    size_t row;
+    size_t col;
+    node_status status;
+};
+
+struct node
+{
+    size_t idx;
+    node_status status;
+};
+
+struct raster_neighbor
+{
+    size_t flatten_idx;
+    size_t row;
+    size_t col;
+    node_status status;
+    double distance;
+};
+
+struct neighbor
+{
+    size_t idx;
+    double distance;
+    node_status status;
+};
+
+
+//*******************
+//* Profile grid (1D)
+//*******************
+
+template <class Tag>
+class profile_grid_xt
+{
+public:
+
+    using xt_container_tag = Tag;
+    static const std::size_t xt_container_ndims = 1;
+    using status_data_type = std::underlying_type_t<fastscapelib::node_status>;
+    using status_xt_type = xt_container_t<xt_container_tag, status_data_type,
+                                          xt_container_ndims>;
+    using neighbor_list = std::vector<neighbor>;
+
+    static constexpr std::array<std::ptrdiff_t, 3> offsets {0, -1, 1};
+
+    profile_grid_xt(std::size_t size,
+                    const double spacing,
+                    const edge_status& status_at_edges,
+                    const std::vector<node>& status_at_nodes = {});
+
+    neighbor_list neighbors(std::size_t idx) const;
+
+    std::size_t size() const noexcept;
+    double spacing() const noexcept;
+    const status_xt_type& node_status() const;
+
+private:
+    std::size_t m_size;
+    double m_spacing;
+
+    status_xt_type m_node_status;
+    const edge_status& m_status_at_edges;
+    bool has_looped_boundaries = false;
+
+    std::vector<neighbor_list> m_all_neighbors;
+    void precompute_neighbors();
+};
+
+
+template <class Tag>
+inline profile_grid_xt<Tag>::profile_grid_xt(std::size_t size,
+                                             const double spacing,
+                                             const edge_status& status_at_edges,
+                                             const std::vector<node>& status_at_nodes)
+    : m_size(size), m_spacing(spacing), m_status_at_edges(status_at_edges)
+{
+    m_node_status = xt::zeros<status_data_type>({size});
+    m_node_status[0] = status_at_edges.left;
+    m_node_status[size-1] = status_at_edges.right;
+
+    for (const node& inode : status_at_nodes)
+    {
+        m_node_status(inode.idx) = inode.status;
+    }
+
+    bool left_looped = status_at_edges.left == node_status::looped_boundary;
+    bool right_looped = status_at_edges.right == node_status::looped_boundary;
+
+    if (left_looped ^ right_looped)
+    {
+        throw std::invalid_argument("inconsistent looped boundary status at edges");
+    }
+    else if (left_looped && right_looped)
+    {
+        has_looped_boundaries = true;
+    }
+
+    precompute_neighbors();
+}
+
+template <class Tag>
+void profile_grid_xt<Tag>::precompute_neighbors()
+{
+    m_all_neighbors.resize(m_size);
+
+    for (std::size_t idx=1; idx<m_size-1; ++idx)
+    {
+        for (std::size_t k=1; k<3; ++k)
+        {
+            std::size_t nb_idx = idx + offsets[k];
+            neighbor nb = {nb_idx, m_spacing, m_node_status[nb_idx]};
+            m_all_neighbors[idx].push_back(nb);
+        }
+    }
+
+    m_all_neighbors[0].push_back({1, m_spacing, m_node_status[1]});
+    m_all_neighbors[m_size-1].push_back({m_size-2, m_spacing, m_node_status[m_size-2]});
+
+    if (has_looped_boundaries)
+    {
+        m_all_neighbors[0].push_front({m_size-1, m_spacing, m_node_status[m_size-1]});
+        m_all_neighbors[m_size-1].push_back({0, m_spacing, m_node_status[0]});
+    }
+}
+
+template <class Tag>
+inline std::size_t profile_grid_xt<Tag>::size() const noexcept
+{
+    return m_size;
+}
+
+template <class Tag>
+inline double profile_grid_xt<Tag>::spacing() const noexcept
+{
+    return m_spacing;
+}
+
+template <class Tag>
+inline auto profile_grid_xt<Tag>::node_status() const
+    -> const profile_grid_xt<Tag>::status_xt_type&
+{
+    return m_node_status;
+}
+
+template <class Tag>
+inline auto profile_grid_xt<Tag>::neighbors(std::size_t idx) const
+    -> profile_grid_xt<Tag>::neighbor_list
+{
+    return m_all_neighbors[idx];
+}
+
+
+using profile_grid = profile_grid_xt<xtensor_tag>;
+
+
+//******************
+//* Raster grid (2D)
+//******************
+
+enum class raster_connect : std::size_t
+{
+   king = 4,
+   queen = 8
+};
+
+} // namespace fastscapelib

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -47,7 +47,7 @@ namespace detail
 
 inline bool node_status_cmp(node_status a, node_status b)
 {
-    static std::unordered_map<node_status, int> priority {
+    static std::unordered_map<node_status, int> priority = {
         {node_status::core, 0},
         {node_status::looped_boundary, 1},
         {node_status::fixed_gradient_boundary, 2},

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -32,13 +32,6 @@ enum class node_status : std::uint8_t
     looped_boundary = 3
 };
 
-using node_status_ut = std::underlying_type_t<node_status>;
-
-inline bool is_status(node_status_ut status_at_node, node_status status)
-{
-    return status_at_node == detail::cast_underlying(status);
-}
-
 struct edge_status
 {
     node_status left = node_status::core;
@@ -113,18 +106,13 @@ struct raster_node
 {
     std::size_t row;
     std::size_t col;
-    node_status_ut status;
+    node_status status;
 };
 
 struct node
 {
     std::size_t idx;
-    node_status_ut status;
-
-    node(std::size_t n_idx, node_status n_status)
-        : idx(n_idx), status(detail::cast_underlying(n_status))
-    {
-    }
+    node_status status;
 };
 
 struct raster_neighbor
@@ -132,7 +120,7 @@ struct raster_neighbor
     std::size_t flatten_idx;
     std::size_t row;
     std::size_t col;
-    node_status_ut status;
+    node_status status;
     double distance;
 };
 
@@ -140,7 +128,7 @@ struct neighbor
 {
     std::size_t idx;
     double distance;
-    node_status_ut status;
+    node_status status;
 };
 
 
@@ -155,8 +143,8 @@ public:
 
     using xt_container_tag = Tag;
     static const std::size_t xt_container_ndims = 1;
-    using status_data_type = std::underlying_type_t<fastscapelib::node_status>;
-    using status_xt_type = xt_container_t<xt_container_tag, status_data_type,
+    using status_xt_type = xt_container_t<xt_container_tag,
+                                          fastscapelib::node_status,
                                           xt_container_ndims>;
     using neighbor_list = std::vector<neighbor>;
 
@@ -194,9 +182,9 @@ inline profile_grid_xt<Tag>::profile_grid_xt(std::size_t size,
                                              const std::vector<node>& status_at_nodes)
     : m_size(size), m_spacing(spacing), m_status_at_edges(status_at_edges)
 {
-    m_node_status = xt::zeros<status_data_type>({size});
-    m_node_status[0] = detail::cast_underlying(status_at_edges.left);
-    m_node_status[size-1] = detail::cast_underlying(status_at_edges.right);
+    m_node_status = xt::zeros<fastscapelib::node_status>({size});
+    m_node_status[0] = status_at_edges.left;
+    m_node_status[size-1] = status_at_edges.right;
 
     for (const node& inode : status_at_nodes)
     {

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -45,7 +45,7 @@ struct edge_nodes_status
     node_status right = node_status::core;  /**< Status at right edge node */
 
     edge_nodes_status(node_status status);
-    edge_nodes_status(std::array<node_status, 2> left_right);
+    edge_nodes_status(const std::array<node_status, 2>& left_right);
     edge_nodes_status(std::initializer_list<node_status> left_right);
 };
 
@@ -64,7 +64,7 @@ inline edge_nodes_status::edge_nodes_status(node_status status)
 /**
  * Array constructor: status at (left, right) edge nodes.
  */
-inline edge_nodes_status::edge_nodes_status(std::array<node_status, 2> left_right)
+inline edge_nodes_status::edge_nodes_status(const std::array<node_status, 2>& left_right)
     : left(left_right[0]), right(left_right[1])
 {
 }
@@ -211,8 +211,7 @@ class profile_grid_xt
 public:
 
     using xt_container_selector = X;
-    using xt_node_status_t = xt_container_t<
-        xt_container_selector, fastscapelib::node_status, 1>;
+    using xt_node_status_t = xt_container_t<xt_container_selector, node_status, 1>;
     using neighbor_vec = std::vector<neighbor>;
 
     profile_grid_xt(std::size_t size,
@@ -261,7 +260,10 @@ inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
                                            const std::vector<node>& status_at_nodes)
     : m_size(size), m_spacing(spacing), m_status_at_edges(status_at_bounds)
 {
-    m_status_at_nodes = xt::zeros<fastscapelib::node_status>({size});
+    std::array<std::size_t, 1> shape {size};
+    m_status_at_nodes.resize(shape);
+    m_status_at_nodes.fill(node_status::core);
+
     m_status_at_nodes[0] = status_at_bounds.left;
     m_status_at_nodes[size-1] = status_at_bounds.right;
 
@@ -270,8 +272,8 @@ inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
         m_status_at_nodes(inode.idx) = inode.status;
     }
 
-    bool left_looped = status_at_bounds.left == fastscapelib::node_status::looped_boundary;
-    bool right_looped = status_at_bounds.right == fastscapelib::node_status::looped_boundary;
+    bool left_looped = status_at_bounds.left == node_status::looped_boundary;
+    bool right_looped = status_at_bounds.right == node_status::looped_boundary;
 
     if (left_looped ^ right_looped)
     {

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -160,7 +160,8 @@ public:
                                           xt_container_ndims>;
     using neighbor_list = std::vector<neighbor>;
 
-    static constexpr std::array<std::ptrdiff_t, 3> offsets {0, -1, 1};
+    // TODO: make this "static" in some way? (like C++17 inline variables but in C++14)
+    const std::array<std::ptrdiff_t, 3> offsets {0, -1, 1};
 
     profile_grid_xt(std::size_t size,
                     const double spacing,

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -45,6 +45,7 @@ struct edge_nodes_status
     node_status left = node_status::core;   /**< Status at left edge node */
     node_status right = node_status::core;  /**< Status at right edge node */
 
+    edge_nodes_status(const edge_nodes_status& es);
     edge_nodes_status(node_status status);
     edge_nodes_status(const std::array<node_status, 2>& left_right);
     edge_nodes_status(std::initializer_list<node_status> left_right);
@@ -54,6 +55,14 @@ struct edge_nodes_status
  * @name Constructors
  */
 //@{
+/**
+ * Copy constructor.
+ */
+inline edge_nodes_status::edge_nodes_status(const edge_nodes_status& es)
+    : left(es.left), right(es.right)
+{
+}
+
 /**
  * Set the same status at both the left and right edge nodes.
  */

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -46,64 +46,57 @@ struct boundary_status
     node_status right = node_status::core;   /**< Status at right edge/border node(s) */
     node_status top = node_status::core;     /**< Status at top border nodes */
     node_status bottom = node_status::core;  /**< Status at bottom border nodes */
+
+    boundary_status(node_status boundaries);
+    boundary_status(std::initializer_list<node_status> boundaries);
+    boundary_status(const std::array<node_status, 2>& edges);
+    boundary_status(const std::array<node_status, 4>& borders);
 };
 
 /**
- * Helper function to set status at profile/raster grid boundary nodes.
- *
- * @param status The same status for all boundary nodes.
+ * @name Constructors
  */
-inline boundary_status set_boundaries(node_status status)
+//@{
+/**
+ * Set the same status for all boundary nodes.
+ */
+inline boundary_status::boundary_status(node_status boundaries)
+    : left(boundaries), right(boundaries), top(boundaries), bottom(boundaries)
 {
-    return {status, status, status, status};
 }
 
 /**
- * Helper function to set status at boundary nodes of a profile grid.
- *
- * @param left Status at the left edge node.
- * @param right Status at the right edge node.
+ * Set status either at the left/right edges nodes on a profile grid (2-length list)
+ * or at the left/right/top/bottom border nodes on a raster grid (4-length list).
  */
-inline boundary_status set_boundaries(node_status left, node_status right)
+inline boundary_status::boundary_status(std::initializer_list<node_status> boundaries)
 {
-    return {left, right};
+    auto bnd = boundaries.begin();
+    left = *bnd++;
+    right = *bnd++;
+    if (boundaries.size() == 4)
+    {
+        top = *bnd++;
+        bottom = *bnd++;
+    }
 }
 
 /**
- * Helper function to set status at boundary nodes of a profile grid.
- *
- * @param edges Status at the left and right edge nodes.
+ * Set status at the left and right edge nodes of a profile grid.
  */
-inline boundary_status set_boundaries(const std::array<node_status, 2>& edges)
+inline boundary_status::boundary_status(const std::array<node_status, 2>& edges)
+    : left(edges[0]), right(edges[1])
 {
-    return {edges[0], edges[1]};
 }
 
 /**
- * Helper function to set status at boundary nodes of a raster grid.
- *
- * @param left Status at nodes on the left border.
- * @param right Status at nodes on the right border.
- * @param top Status at nodes on the top border.
- * @param bottom Status at nodes on the bottom border.
+ * Set status at the left, right, top and bottom border nodes of a raster grid.
  */
-inline boundary_status set_boundaries(node_status left,
-                                      node_status right,
-                                      node_status top,
-                                      node_status bottom)
+inline boundary_status::boundary_status(const std::array<node_status, 4>& borders)
+    : left(borders[0]), right(borders[1]), top(borders[2]), bottom(borders[3])
 {
-    return {left, right, top, bottom};
 }
-
-/**
- * Helper function to set status at boundary nodes of a raster grid.
- *
- * @param borders Status at the left, right, top and bottom border nodes.
- */
-inline boundary_status set_boundaries(const std::array<node_status, 4>& borders)
-{
-    return {borders[0], borders[1], borders[2], borders[3]};
-}
+//@}
 
 //***************
 //* Grid elements

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -45,6 +45,7 @@ struct edge_nodes_status
     node_status right = node_status::core;  /**< Status at right edge node */
 
     edge_nodes_status(node_status status);
+    edge_nodes_status(std::array<node_status, 2> left_right);
     edge_nodes_status(std::initializer_list<node_status> left_right);
 };
 
@@ -57,6 +58,14 @@ struct edge_nodes_status
  */
 inline edge_nodes_status::edge_nodes_status(node_status status)
     : left(status), right(status)
+{
+}
+
+/**
+ * Array constructor: status at (left, right) edge nodes.
+ */
+inline edge_nodes_status::edge_nodes_status(std::array<node_status, 2> left_right)
+    : left(left_right[0]), right(left_right[1])
 {
 }
 

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -311,8 +311,9 @@ private:
     bool has_looped_edges = false;
     void set_status_at_nodes(const std::vector<node>& status_at_nodes);
 
-    // TODO: may yield duplicate def? (-> C++17 inline variables but in C++14?)
-    static constexpr std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
+    // TODO: this doesn't always work? (-> C++17 inline variables but in C++14?)
+    //static constexpr std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
+    const std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
     std::vector<neighbors_type> m_all_neighbors;
     void precompute_neighbors();
 

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -231,8 +231,8 @@ inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
     m_status_at_nodes.resize(shape);
     m_status_at_nodes.fill(node_status::core);
 
-    m_status_at_nodes[0] = m_status_at_bounds.left;
-    m_status_at_nodes[m_size-1] = m_status_at_bounds.right;
+    m_status_at_nodes[0] = status_at_bounds.left;
+    m_status_at_nodes[size-1] = status_at_bounds.right;
 
     for (const node& inode : status_at_nodes)
     {
@@ -240,7 +240,7 @@ inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
     }
 
     bool left_looped = m_status_at_nodes[0] == node_status::looped_boundary;
-    bool right_looped = m_status_at_nodes[m_size-1] == node_status::looped_boundary;
+    bool right_looped = m_status_at_nodes[size-1] == node_status::looped_boundary;
 
     if (left_looped ^ right_looped)
     {

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -303,6 +303,7 @@ public:
                     const std::vector<node>& status_at_nodes = {});
 
 private:
+
     std::size_t m_size;
     double m_spacing;
 
@@ -311,9 +312,7 @@ private:
     bool has_looped_edges = false;
     void set_status_at_nodes(const std::vector<node>& status_at_nodes);
 
-    // TODO: this doesn't always work? (-> C++17 inline variables but in C++14?)
-    //static constexpr std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
-    const std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
+    static const std::array<std::ptrdiff_t, 3> offsets;
     std::vector<neighbors_type> m_all_neighbors;
     void precompute_neighbors();
 
@@ -321,6 +320,9 @@ private:
 
     friend class grid_interface<self_type>;
 };
+
+template <class XT>
+constexpr std::array<std::ptrdiff_t, 3> profile_grid_xt<XT>::offsets = { {0, -1, 1} };
 
 /**
  * @name Constructors

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -13,7 +13,7 @@
 #include "xtensor/xarray.hpp"
 #include "xtensor/xtensor.hpp"
 
-#include "fastscapelib/consts.hpp"
+#include "fastscapelib/utils.hpp"
 #include "fastscapelib/xtensor_utils.hpp"
 
 
@@ -31,6 +31,13 @@ enum class node_status : std::uint8_t
     fixed_gradient_boundary = 2,
     looped_boundary = 3
 };
+
+using node_status_ut = std::underlying_type_t<node_status>;
+
+inline bool is_status(node_status_ut status_at_node, node_status status)
+{
+    return status_at_node == detail::cast_underlying(status);
+}
 
 struct edge_status
 {
@@ -104,31 +111,36 @@ struct border_status
 
 struct raster_node
 {
-    size_t row;
-    size_t col;
-    node_status status;
+    std::size_t row;
+    std::size_t col;
+    node_status_ut status;
 };
 
 struct node
 {
-    size_t idx;
-    node_status status;
+    std::size_t idx;
+    node_status_ut status;
+
+    node(std::size_t n_idx, node_status n_status)
+        : idx(n_idx), status(detail::cast_underlying(n_status))
+    {
+    }
 };
 
 struct raster_neighbor
 {
-    size_t flatten_idx;
-    size_t row;
-    size_t col;
-    node_status status;
+    std::size_t flatten_idx;
+    std::size_t row;
+    std::size_t col;
+    node_status_ut status;
     double distance;
 };
 
 struct neighbor
 {
-    size_t idx;
+    std::size_t idx;
     double distance;
-    node_status status;
+    node_status_ut status;
 };
 
 
@@ -182,8 +194,8 @@ inline profile_grid_xt<Tag>::profile_grid_xt(std::size_t size,
     : m_size(size), m_spacing(spacing), m_status_at_edges(status_at_edges)
 {
     m_node_status = xt::zeros<status_data_type>({size});
-    m_node_status[0] = status_at_edges.left;
-    m_node_status[size-1] = status_at_edges.right;
+    m_node_status[0] = detail::cast_underlying(status_at_edges.left);
+    m_node_status[size-1] = detail::cast_underlying(status_at_edges.right);
 
     for (const node& inode : status_at_nodes)
     {

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -237,7 +237,8 @@ void profile_grid_xt<Tag>::precompute_neighbors()
 
     if (has_looped_boundaries)
     {
-        m_all_neighbors[0].push_front({m_size-1, m_spacing, m_node_status[m_size-1]});
+        m_all_neighbors[0].insert(m_all_neighbors[0].begin(),
+                                  {m_size-1, m_spacing, m_node_status[m_size-1]});
         m_all_neighbors[m_size-1].push_back({0, m_spacing, m_node_status[0]});
     }
 }

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -198,7 +198,7 @@ private:
     xt_node_status_t m_status_at_nodes;
     boundary_status m_status_at_bounds;
     bool has_looped_edges = false;
-    //void set_status_at_nodes(const std::vector<node>& status_at_nodes);
+    void set_status_at_nodes(const std::vector<node>& status_at_nodes);
 
     // TODO: make this "static" in some way? (like C++17 inline variables but in C++14)
     const std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
@@ -219,20 +219,26 @@ private:
  * @param status_at_nodes Manually define the status at any node on the grid.
  */
 template <class X>
-inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
-                                           double spacing,
-                                           const boundary_status& status_at_bounds,
-                                           const std::vector<node>& status_at_nodes)
+profile_grid_xt<X>::profile_grid_xt(std::size_t size,
+                                    double spacing,
+                                    const boundary_status& status_at_bounds,
+                                    const std::vector<node>& status_at_nodes)
     : m_size(size), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
 {
-    //set_status_at_nodes(std::move(status_at_nodes));
+    set_status_at_nodes(status_at_nodes);
+    precompute_neighbors();
+}
+//@}
 
+template <class X>
+void profile_grid_xt<X>::set_status_at_nodes(const std::vector<node>& status_at_nodes)
+{
     std::array<std::size_t, 1> shape {m_size};
     m_status_at_nodes.resize(shape);
     m_status_at_nodes.fill(node_status::core);
 
-    m_status_at_nodes[0] = status_at_bounds.left;
-    m_status_at_nodes[size-1] = status_at_bounds.right;
+    m_status_at_nodes[0] = m_status_at_bounds.left;
+    m_status_at_nodes[m_size-1] = m_status_at_bounds.right;
 
     for (const node& inode : status_at_nodes)
     {
@@ -240,7 +246,7 @@ inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
     }
 
     bool left_looped = m_status_at_nodes[0] == node_status::looped_boundary;
-    bool right_looped = m_status_at_nodes[size-1] == node_status::looped_boundary;
+    bool right_looped = m_status_at_nodes[m_size-1] == node_status::looped_boundary;
 
     if (left_looped ^ right_looped)
     {
@@ -250,38 +256,7 @@ inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
     {
         has_looped_edges = true;
     }
-
-    precompute_neighbors();
 }
-//@}
-
-// template <class X>
-// void profile_grid_xt<X>::set_status_at_nodes(const std::vector<node>& status_at_nodes)
-// {
-//     std::array<std::size_t, 1> shape {m_size};
-//     m_status_at_nodes.resize(shape);
-//     m_status_at_nodes.fill(node_status::core);
-
-//     m_status_at_nodes[0] = m_status_at_bounds.left;
-//     m_status_at_nodes[m_size-1] = m_status_at_bounds.right;
-
-//     for (const node& inode : status_at_nodes)
-//     {
-//         m_status_at_nodes(inode.idx) = inode.status;
-//     }
-
-//     bool left_looped = m_status_at_nodes[0] == node_status::looped_boundary;
-//     bool right_looped = m_status_at_nodes[m_size-1] == node_status::looped_boundary;
-
-//     if (left_looped ^ right_looped)
-//     {
-//         throw std::invalid_argument("inconsistent looped boundary status at grid edges");
-//     }
-//     else if (left_looped && right_looped)
-//     {
-//         has_looped_edges = true;
-//     }
-// }
 
 template <class X>
 void profile_grid_xt<X>::precompute_neighbors()

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -55,7 +55,7 @@ struct edge_nodes_status
 /**
  * Set the same status at both the left and right edge nodes.
  */
-edge_nodes_status::edge_nodes_status(node_status status)
+inline edge_nodes_status::edge_nodes_status(node_status status)
     : left(status), right(status)
 {
 }
@@ -63,7 +63,7 @@ edge_nodes_status::edge_nodes_status(node_status status)
 /**
  * List constructor: status at (left, right) edge nodes.
  */
-edge_nodes_status::edge_nodes_status(std::initializer_list<node_status> left_right)
+inline edge_nodes_status::edge_nodes_status(std::initializer_list<node_status> left_right)
 {
     if (left_right.size() != 2)
     {
@@ -98,7 +98,7 @@ struct border_nodes_status
 /**
  * Set the same status at all grid border nodes.
  */
-border_nodes_status::border_nodes_status(node_status status)
+inline border_nodes_status::border_nodes_status(node_status status)
     : top(status), right(status), bottom(status), left(status)
 {
 }
@@ -106,7 +106,7 @@ border_nodes_status::border_nodes_status(node_status status)
 /**
  * List constructor: status at (top, right, left, bottom) border nodes.
  */
-border_nodes_status::border_nodes_status(
+inline border_nodes_status::border_nodes_status(
     std::initializer_list<node_status> top_right_bottom_left)
 {
     if (top_right_bottom_left.size() != 4)

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -55,7 +55,7 @@ struct boundary_status
  */
 inline boundary_status set_boundaries(node_status status)
 {
-    return boundary_status({status, status, status, status});
+    return {status, status, status, status};
 }
 
 /**
@@ -66,7 +66,7 @@ inline boundary_status set_boundaries(node_status status)
  */
 inline boundary_status set_boundaries(node_status left, node_status right)
 {
-    return boundary_status({left, right});
+    return {left, right};
 }
 
 /**
@@ -76,7 +76,7 @@ inline boundary_status set_boundaries(node_status left, node_status right)
  */
 inline boundary_status set_boundaries(const std::array<node_status, 2>& edges)
 {
-    return boundary_status({edges[0], edges[1]});
+    return {edges[0], edges[1]};
 }
 
 /**
@@ -92,7 +92,7 @@ inline boundary_status set_boundaries(node_status left,
                                       node_status top,
                                       node_status bottom)
 {
-    return boundary_status({left, right, top, bottom});
+    return {left, right, top, bottom};
 }
 
 /**
@@ -102,7 +102,7 @@ inline boundary_status set_boundaries(node_status left,
  */
 inline boundary_status set_boundaries(const std::array<node_status, 4>& borders)
 {
-    return boundary_status({borders[0], borders[1], borders[2], borders[3]});
+    return {borders[0], borders[1], borders[2], borders[3]};
 }
 
 //***************

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -25,6 +25,9 @@ namespace fastscapelib
 //* Grid boundaries
 //*****************
 
+/**
+ * Status at a grid/mesh node.
+ */
 enum class node_status : std::uint8_t
 {
     core = 0,
@@ -33,120 +36,182 @@ enum class node_status : std::uint8_t
     looped_boundary = 3
 };
 
+/**
+ * Node status at the edge nodes (left, right) of a 1-dimensional grid.
+ */
 struct edge_nodes_status
 {
-    node_status left = node_status::core;
-    node_status right = node_status::core;
+    node_status left = node_status::core;   /**< Status at left edge node */
+    node_status right = node_status::core;  /**< Status at right edge node */
 
-    edge_nodes_status(node_status status)
-        : left(status), right(status)
-    {
-    }
-
-    edge_nodes_status(std::initializer_list<node_status> left_right)
-    {
-        if (left_right.size() != 2)
-        {
-            throw std::invalid_argument("edge nodes status list must have 2 elements: "
-                                        "{left, right}");
-        }
-
-        auto iter = left_right.begin();
-        left = *iter++;
-        right = *iter++;
-    }
+    edge_nodes_status(node_status status);
+    edge_nodes_status(std::initializer_list<node_status> left_right);
 };
 
+/**
+ * @name Constructors
+ */
+//@{
+/**
+ * Set the same status at both the left and right edge nodes.
+ */
+edge_nodes_status::edge_nodes_status(node_status status)
+    : left(status), right(status)
+{
+}
+
+/**
+ * List constructor: status at (left, right) edge nodes.
+ */
+edge_nodes_status::edge_nodes_status(std::initializer_list<node_status> left_right)
+{
+    if (left_right.size() != 2)
+    {
+        throw std::invalid_argument("edge nodes status list must have 2 elements: "
+                                    "{left, right}");
+    }
+
+    auto iter = left_right.begin();
+    left = *iter++;
+    right = *iter++;
+}
+//@}
+
+/**
+ * Node status at the border nodes (top, right, bottom, left) of a 2-d raster grid.
+ */
 struct border_nodes_status
 {
-    node_status top = node_status::core;
-    node_status right = node_status::core;
-    node_status bottom = node_status::core;
-    node_status left = node_status::core;
+    node_status top = node_status::core;     /**< Status at top border nodes */
+    node_status right = node_status::core;   /**< Status at right border nodes */
+    node_status bottom = node_status::core;  /**< Status at bottom border nodes */
+    node_status left = node_status::core;    /**< Status at left border nodes */
 
-    border_nodes_status(node_status status)
-        : top(status), right(status), bottom(status), left(status)
-    {
-    }
-
-    border_nodes_status(std::initializer_list<node_status> top_right_bottom_left)
-    {
-        if (top_right_bottom_left.size() != 4)
-        {
-            throw std::invalid_argument("border nodes status list must have 4 elements: "
-                                        "{top, right, bottom, left}");
-        }
-
-        auto iter = top_right_bottom_left.begin();
-        top = *iter++;
-        right = *iter++;
-        bottom = *iter++;
-        left = *iter++;
-    }
+    border_nodes_status(node_status status);
+    border_nodes_status(std::initializer_list<node_status> top_right_bottom_left);
 };
 
+/**
+ * @name Constructors
+ */
+//@{
+/**
+ * Set the same status at all grid border nodes.
+ */
+border_nodes_status::border_nodes_status(node_status status)
+    : top(status), right(status), bottom(status), left(status)
+{
+}
+
+/**
+ * List constructor: status at (top, right, left, bottom) border nodes.
+ */
+border_nodes_status::border_nodes_status(
+    std::initializer_list<node_status> top_right_bottom_left)
+{
+    if (top_right_bottom_left.size() != 4)
+    {
+        throw std::invalid_argument("border nodes status list must have 4 elements: "
+                                    "{top, right, bottom, left}");
+    }
+
+    auto iter = top_right_bottom_left.begin();
+    top = *iter++;
+    right = *iter++;
+    bottom = *iter++;
+    left = *iter++;
+}
+//@}
 
 //***************
 //* Grid elements
 //***************
 
-struct raster_node
-{
-    std::size_t row;
-    std::size_t col;
-    node_status status;
-};
-
+/**
+ * Grid/mesh node.
+ */
 struct node
 {
-    std::size_t idx;
-    node_status status;
+    std::size_t idx;     /**< Node index */
+    node_status status;  /**< Node status */
 };
 
-struct raster_neighbor
+/**
+ * Raster grid node.
+ */
+struct raster_node
 {
-    std::size_t flatten_idx;
-    std::size_t row;
-    std::size_t col;
-    node_status status;
-    double distance;
+    std::size_t row;     /**< Row index */
+    std::size_t col;     /**< Column index */
+    node_status status;  /**< Node status */
 };
 
+/**
+ * Neighbor node.
+ */
 struct neighbor
 {
-    std::size_t idx;
-    double distance;
-    node_status status;
+    std::size_t idx;     /**< Index of the neighbor node */
+    double distance;     /**< Distance to the neighbor node */
+    node_status status;  /**< Status at the neighbor node */
 };
 
+/**
+ * Neighbor node (on raster grids).
+ */
+struct raster_neighbor
+{
+    std::size_t flatten_idx;  /**< Flattened index of the neighbor node */
+    std::size_t row;          /**< Row index of the neighbor node */
+    std::size_t col;          /**< Column index of the neighbor node */
+    double distance;          /**< Distance to the neighbor node */
+    node_status status;       /**< Status at the neighbor node */
+};
+
+namespace detail
+{
+
+/**
+ * Add a given offset (positive, negative or zero) to a grid node index.
+ *
+ * This utility function is mainly to avoid signed/unsigned conversion
+ * warnings. Use it carefully.
+ */
 inline std::size_t add_offset(std::size_t idx, std::ptrdiff_t offset)
 {
     return static_cast<std::size_t>(static_cast<std::ptrdiff_t>(idx) + offset);
 }
 
+}
 
 //*******************
 //* Profile grid (1D)
 //*******************
 
-template <class Tag>
+/**
+ * @class profile_grid_xt
+ * @brief 1-dimensional uniform grid.
+ *
+ * Used for modeling single channel or hillslope profiles.
+ *
+ * @tparam X xtensor container selector for data members.
+ */
+template <class X>
 class profile_grid_xt
 {
 public:
 
-    using xt_container_tag = Tag;
-    static const std::size_t xt_container_ndims = 1;
-    using xt_node_status_t = xt_container_t<xt_container_tag,
-                                            fastscapelib::node_status,
-                                            xt_container_ndims>;
-    using neighbor_list = std::vector<neighbor>;
+    using xt_container_selector = X;
+    using xt_node_status_t = xt_container_t<
+        xt_container_selector, fastscapelib::node_status, 1>;
+    using neighbor_vec = std::vector<neighbor>;
 
     profile_grid_xt(std::size_t size,
-                    const double spacing,
+                    double spacing,
                     const edge_nodes_status& status_at_bounds,
                     const std::vector<node>& status_at_nodes = {});
 
-    neighbor_list neighbors(std::size_t idx) const;
+    const neighbor_vec& neighbors(std::size_t idx) const;
 
     std::size_t size() const noexcept;
     double spacing() const noexcept;
@@ -163,16 +228,28 @@ private:
     // TODO: make this "static" in some way? (like C++17 inline variables but in C++14)
     const std::array<std::ptrdiff_t, 3> offsets {0, -1, 1};
 
-    std::vector<neighbor_list> m_all_neighbors;
+    std::vector<neighbor_vec> m_all_neighbors;
     void precompute_neighbors();
 };
 
-
-template <class Tag>
-inline profile_grid_xt<Tag>::profile_grid_xt(std::size_t size,
-                                             const double spacing,
-                                             const edge_nodes_status& status_at_bounds,
-                                             const std::vector<node>& status_at_nodes)
+/**
+ * @name Constructors
+ */
+//@{
+/**
+ * Creates a new profile grid.
+ *
+ * @param size Total number of grid nodes.
+ * @param spacing Distance between two adjacent grid nodes.
+ * @param status_at_bounds Status at boundary nodes (left & right grid edges).
+ * @param status_at_nodes Manually define the status at any node on the grid.
+ * @exception std::invalid_argument when looped boundaries are set inconsistently.
+ */
+template <class X>
+inline profile_grid_xt<X>::profile_grid_xt(std::size_t size,
+                                           double spacing,
+                                           const edge_nodes_status& status_at_bounds,
+                                           const std::vector<node>& status_at_nodes)
     : m_size(size), m_spacing(spacing), m_status_at_edges(status_at_bounds)
 {
     m_node_status = xt::zeros<fastscapelib::node_status>({size});
@@ -198,9 +275,10 @@ inline profile_grid_xt<Tag>::profile_grid_xt(std::size_t size,
 
     precompute_neighbors();
 }
+//@}
 
-template <class Tag>
-void profile_grid_xt<Tag>::precompute_neighbors()
+template <class X>
+void profile_grid_xt<X>::precompute_neighbors()
 {
     m_all_neighbors.resize(m_size);
 
@@ -208,7 +286,7 @@ void profile_grid_xt<Tag>::precompute_neighbors()
     {
         for (std::size_t k=1; k<3; ++k)
         {
-            std::size_t nb_idx = add_offset(idx, offsets[k]);
+            std::size_t nb_idx = detail::add_offset(idx, offsets[k]);
             neighbor nb = {nb_idx, m_spacing, m_node_status[nb_idx]};
             m_all_neighbors[idx].push_back(nb);
         }
@@ -225,34 +303,67 @@ void profile_grid_xt<Tag>::precompute_neighbors()
     }
 }
 
-template <class Tag>
-inline std::size_t profile_grid_xt<Tag>::size() const noexcept
+/**
+ * @name Grid properties
+ */
+//@{
+/**
+ * Returns the total number of grid nodes.
+ */
+template <class X>
+inline std::size_t profile_grid_xt<X>::size() const noexcept
 {
     return m_size;
 }
 
-template <class Tag>
-inline double profile_grid_xt<Tag>::spacing() const noexcept
+/**
+ * Returns the (uniform) spacing between two adjacent grid nodes.
+ */
+template <class X>
+inline double profile_grid_xt<X>::spacing() const noexcept
 {
     return m_spacing;
 }
 
-template <class Tag>
-inline auto profile_grid_xt<Tag>::node_status() const
-    -> const profile_grid_xt<Tag>::xt_node_status_t&
+/**
+ * Returns a reference to the array of status at grid nodes.
+ */
+template <class X>
+inline auto profile_grid_xt<X>::node_status() const
+    -> const profile_grid_xt<X>::xt_node_status_t&
 {
     return m_node_status;
 }
+//@}
 
-template <class Tag>
-inline auto profile_grid_xt<Tag>::neighbors(std::size_t idx) const
-    -> profile_grid_xt<Tag>::neighbor_list
+/**
+ * @name Iterators
+ */
+/**
+ * Iterator trough the neighbors of a grid node.
+ *
+ * Follows looped boundary conditions, if any.
+ *
+ * @param idx Grid node index
+ * @return Reference to the vector of the neighbors of that grid node.
+ */
+template <class X>
+inline auto profile_grid_xt<X>::neighbors(std::size_t idx) const
+    -> const profile_grid_xt<X>::neighbor_vec&
 {
     return m_all_neighbors[idx];
 }
+//@}
 
-
-using profile_grid = profile_grid_xt<xtensor_tag>;
+/**
+ * @typedef profile_grid
+ * Alias template on profile_grid_xt with ``xt::xtensor`` used
+ * as array container type for data members.
+ *
+ * This is mainly for convenience when using in C++ applications.
+ *
+ */
+using profile_grid = profile_grid_xt<xtensor_selector>;
 
 
 //******************

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include <stdexcept>
 #include <vector>
 
@@ -230,7 +231,7 @@ private:
     double m_spacing;
 
     xt_node_status_t m_status_at_nodes;
-    const edge_nodes_status& m_status_at_edges;
+    edge_nodes_status m_status_at_edges;
     bool has_looped_boundaries = false;
 
     // TODO: make this "static" in some way? (like C++17 inline variables but in C++14)
@@ -344,8 +345,7 @@ inline double profile_grid_xt<X>::spacing() const noexcept
  * Returns a reference to the array of status at grid nodes.
  */
 template <class X>
-inline auto profile_grid_xt<X>::status_at_nodes() const
-    -> const profile_grid_xt<X>::xt_node_status_t&
+inline auto profile_grid_xt<X>::status_at_nodes() const -> const xt_node_status_t&
 {
     return m_status_at_nodes;
 }
@@ -363,8 +363,7 @@ inline auto profile_grid_xt<X>::status_at_nodes() const
  * @return Reference to the vector of the neighbors of that grid node.
  */
 template <class X>
-inline auto profile_grid_xt<X>::neighbors(std::size_t idx) const
-    -> const profile_grid_xt<X>::neighbor_vec&
+inline auto profile_grid_xt<X>::neighbors(std::size_t idx) const -> const neighbor_vec&
 {
     return m_all_neighbors[idx];
 }

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -159,9 +159,123 @@ inline std::size_t add_offset(std::size_t idx, std::ptrdiff_t offset)
 
 }
 
+//****************
+//* Grid interface
+//****************
+
+template <class G>
+struct grid_inner_types;
+
+/**
+ * @class grid_interface
+ * @brief Add a common interface to all grid types.
+ *
+ * This class only defines a basic interface for all grid types.
+ * It does not embed any data member, this responsibility
+ * is delegated to the inheriting grid classes.
+ *
+ * @tparam G Derived grid type.
+ */
+template <class G>
+class grid_interface
+{
+public:
+
+    using derived_grid_type = G;
+    using inner_types = grid_inner_types<derived_grid_type>;
+    using spacing_type = typename inner_types::spacing_type;
+    //using shape_type = typename grid_type::shape_type;
+    using node_status_type = typename inner_types::node_status_type;
+    using neighbors_type = typename inner_types::neighbors_type;
+
+    //shape_type shape() const noexcept;
+    std::size_t size() const noexcept;
+    spacing_type spacing() const noexcept;
+    const node_status_type& status_at_nodes() const;
+
+    const neighbors_type& neighbors(std::size_t idx) const;
+
+protected:
+    grid_interface() = default;
+    ~grid_interface() = default;
+
+    const derived_grid_type& derived_grid() const & noexcept;
+};
+
+template <class G>
+inline auto grid_interface<G>::derived_grid() const & noexcept -> const derived_grid_type&
+{
+    return *static_cast<const derived_grid_type*>(this);
+}
+
+/**
+ * @name Grid properties
+ */
+//@{
+/**
+ * Returns the total number of grid nodes.
+ */
+template <class G>
+inline std::size_t grid_interface<G>::size() const noexcept
+{
+    return derived_grid().m_size;
+}
+
+/**
+ * Returns the (uniform) spacing between two adjacent grid nodes.
+ */
+template <class G>
+inline auto grid_interface<G>::spacing() const noexcept -> spacing_type
+{
+    return derived_grid().m_spacing;
+}
+
+/**
+ * Returns a const reference to the array of status at grid nodes.
+ */
+template <class G>
+inline auto grid_interface<G>::status_at_nodes() const -> const node_status_type&
+{
+    return derived_grid().m_status_at_nodes;
+}
+//@}
+
+/**
+ * @name Iterators
+ */
+/**
+ * Iterate over the neighbors of a given grid node.
+ *
+ * Follows looped boundary conditions, if any.
+ *
+ * @param idx Index of the grid node.
+ * @return Reference to the vector of the neighbors of that grid node.
+ */
+template <class G>
+inline auto grid_interface<G>::neighbors(std::size_t idx) const -> const neighbors_type&
+{
+    return derived_grid().neighbors_impl(idx);
+}
+//@}
+
+
 //*******************
 //* Profile grid (1D)
 //*******************
+
+template <class XT>
+class profile_grid_xt;
+
+template <class XT>
+struct grid_inner_types<profile_grid_xt<XT>>
+{
+    static constexpr bool is_structured = true;
+    static constexpr bool is_uniform = true;
+
+    using spacing_type = double;
+    using node_status_type = xt_container_t<XT, node_status, 1>;
+    using neighbors_type = std::vector<neighbor>;
+};
 
 /**
  * @class profile_grid_xt
@@ -169,41 +283,42 @@ inline std::size_t add_offset(std::size_t idx, std::ptrdiff_t offset)
  *
  * Used for modeling single channel or hillslope profiles.
  *
- * @tparam X xtensor container selector for data array members.
+ * @tparam XT xtensor container selector for data array members.
  */
-template <class X>
-class profile_grid_xt
+template <class XT>
+class profile_grid_xt : public grid_interface<profile_grid_xt<XT>>
 {
 public:
 
-    using xt_container_selector = X;
-    using xt_node_status_t = xt_container_t<xt_container_selector, node_status, 1>;
-    using neighbor_vec = std::vector<neighbor>;
+    using self_type = profile_grid_xt<XT>;
+    using base_type = grid_interface<self_type>;
+
+    using spacing_type = typename base_type::spacing_type;
+    using node_status_type = typename base_type::node_status_type;
+    using neighbors_type = typename base_type::neighbors_type;
 
     profile_grid_xt(std::size_t size,
                     double spacing,
                     const boundary_status& status_at_bounds,
                     const std::vector<node>& status_at_nodes = {});
 
-    const neighbor_vec& neighbors(std::size_t idx) const;
-
-    std::size_t size() const noexcept;
-    double spacing() const noexcept;
-    const xt_node_status_t& status_at_nodes() const;
-
 private:
     std::size_t m_size;
     double m_spacing;
 
-    xt_node_status_t m_status_at_nodes;
+    node_status_type m_status_at_nodes;
     boundary_status m_status_at_bounds;
     bool has_looped_edges = false;
     void set_status_at_nodes(const std::vector<node>& status_at_nodes);
 
-    // TODO: make this "static" in some way? (like C++17 inline variables but in C++14)
-    const std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
-    std::vector<neighbor_vec> m_all_neighbors;
+    // TODO: may yield duplicate def? (-> C++17 inline variables but in C++14?)
+    static constexpr std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
+    std::vector<neighbors_type> m_all_neighbors;
     void precompute_neighbors();
+
+    const neighbors_type& neighbors_impl(std::size_t idx) const;
+
+    friend class grid_interface<self_type>;
 };
 
 /**
@@ -218,20 +333,20 @@ private:
  * @param status_at_bounds Status at boundary nodes (left & right grid edges).
  * @param status_at_nodes Manually define the status at any node on the grid.
  */
-template <class X>
-profile_grid_xt<X>::profile_grid_xt(std::size_t size,
-                                    double spacing,
-                                    const boundary_status& status_at_bounds,
-                                    const std::vector<node>& status_at_nodes)
-    : m_size(size), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
+template <class XT>
+profile_grid_xt<XT>::profile_grid_xt(std::size_t size,
+                                     double spacing,
+                                     const boundary_status& status_at_bounds,
+                                     const std::vector<node>& status_at_nodes)
+    : base_type(), m_size(size), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
 {
     set_status_at_nodes(status_at_nodes);
     precompute_neighbors();
 }
 //@}
 
-template <class X>
-void profile_grid_xt<X>::set_status_at_nodes(const std::vector<node>& status_at_nodes)
+template <class XT>
+void profile_grid_xt<XT>::set_status_at_nodes(const std::vector<node>& status_at_nodes)
 {
     std::array<std::size_t, 1> shape {m_size};
     m_status_at_nodes.resize(shape);
@@ -258,8 +373,8 @@ void profile_grid_xt<X>::set_status_at_nodes(const std::vector<node>& status_at_
     }
 }
 
-template <class X>
-void profile_grid_xt<X>::precompute_neighbors()
+template <class XT>
+void profile_grid_xt<XT>::precompute_neighbors()
 {
     m_all_neighbors.resize(m_size);
 
@@ -268,7 +383,7 @@ void profile_grid_xt<X>::precompute_neighbors()
         for (std::size_t k=1; k<3; ++k)
         {
             std::size_t nb_idx = detail::add_offset(idx, offsets[k]);
-            neighbor nb = {nb_idx, m_spacing, m_status_at_nodes[nb_idx]};
+            neighbor nb {nb_idx, m_spacing, m_status_at_nodes[nb_idx]};
             m_all_neighbors[idx].push_back(nb);
         }
     }
@@ -288,55 +403,12 @@ void profile_grid_xt<X>::precompute_neighbors()
     }
 }
 
-/**
- * @name Grid properties
- */
-//@{
-/**
- * Returns the total number of grid nodes.
- */
-template <class X>
-inline std::size_t profile_grid_xt<X>::size() const noexcept
-{
-    return m_size;
-}
-
-/**
- * Returns the (uniform) spacing between two adjacent grid nodes.
- */
-template <class X>
-inline double profile_grid_xt<X>::spacing() const noexcept
-{
-    return m_spacing;
-}
-
-/**
- * Returns a const reference to the array of status at grid nodes.
- */
-template <class X>
-inline auto profile_grid_xt<X>::status_at_nodes() const -> const xt_node_status_t&
-{
-    return m_status_at_nodes;
-}
-//@}
-
-/**
- * @name Iterators
- */
-/**
- * Iterator trough the neighbors of a grid node.
- *
- * Follows looped boundary conditions, if any.
- *
- * @param idx Grid node index
- * @return Reference to the vector of the neighbors of that grid node.
- */
-template <class X>
-inline auto profile_grid_xt<X>::neighbors(std::size_t idx) const -> const neighbor_vec&
+template <class XT>
+inline auto profile_grid_xt<XT>::neighbors_impl(std::size_t idx) const
+    -> const neighbors_type&
 {
     return m_all_neighbors[idx];
 }
-//@}
 
 /**
  * @typedef profile_grid

--- a/include/fastscapelib/utils.hpp
+++ b/include/fastscapelib/utils.hpp
@@ -44,7 +44,16 @@ bool in_bounds(const S& shape, index_t row, index_t col)
     return false;
 }
 
+/**
+ * Static cast to strongly typed enum's underlying type.
+ */
+template <typename E>
+constexpr auto cast_underlying(E e) noexcept
+{
+    return static_cast<std::underlying_type_t<E>>(e);
+}
 
 }  // namespace detail
+
 
 }  // namespace fastscapelib

--- a/include/fastscapelib/xtensor_utils.hpp
+++ b/include/fastscapelib/xtensor_utils.hpp
@@ -12,29 +12,29 @@
 namespace fastscapelib
 {
 
-struct xtensor_tag;
-struct xarray_tag;
+struct xtensor_selector;
+struct xarray_selector;
 
 
-template <class Tag, class T, std::size_t N = 0>
+template <class X, class T, std::size_t N = 0>
 struct xt_container;
 
 
 template <class T, std::size_t N>
-struct xt_container<xtensor_tag, T, N>
+struct xt_container<xtensor_selector, T, N>
 {
     using type = xt::xtensor<T, N>;
 };
 
 
 template <class T>
-struct xt_container<xarray_tag, T>
+struct xt_container<xarray_selector, T>
 {
     using type = xt::xarray<T>;
 };
 
 
-template <class Tag, class T, std::size_t N = 0>
-using xt_container_t = typename xt_container<Tag, T, N>::type;
+template <class X, class T, std::size_t N = 0>
+using xt_container_t = typename xt_container<X, T, N>::type;
 
-} // namespace
+} // namespace fastscapelib

--- a/include/fastscapelib/xtensor_utils.hpp
+++ b/include/fastscapelib/xtensor_utils.hpp
@@ -1,0 +1,40 @@
+/**
+ * xtensor utils (container tags, etc.)
+ */
+#pragma once
+
+#include <cstddef>
+
+#include "xtensor/xarray.hpp"
+#include "xtensor/xtensor.hpp"
+
+
+namespace fastscapelib
+{
+
+struct xtensor_tag;
+struct xarray_tag;
+
+
+template <class Tag, class T, std::size_t N = 0>
+struct xt_container;
+
+
+template <class T, std::size_t N>
+struct xt_container<xtensor_tag, T, N>
+{
+    using type = xt::xtensor<T, N>;
+};
+
+
+template <class T>
+struct xt_container<xarray_tag, T>
+{
+    using type = xt::xarray<T>;
+};
+
+
+template <class Tag, class T, std::size_t N = 0>
+using xt_container_t = typename xt_container<Tag, T, N>::type;
+
+} // namespace

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -28,7 +28,10 @@ include_directories(${NUMPY_INCLUDE_DIRS})
 
 set(FASTSCAPELIB_PYTHON_TARGET _fastscapelib_py)
 
-pybind11_add_module(${FASTSCAPELIB_PYTHON_TARGET} src/main.cpp)
+pybind11_add_module(${FASTSCAPELIB_PYTHON_TARGET}
+  src/grid.cpp
+  src/main.cpp
+  )
 
 target_link_libraries(${FASTSCAPELIB_PYTHON_TARGET}
   INTERFACE xtensor xtensor-python fastscapelib)

--- a/python/fastscapelib/tests/test_grid.py
+++ b/python/fastscapelib/tests/test_grid.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+import fastscapelib
+
+
+def test_profile_grid():
+    es = [fastscapelib.NodeStatus.FIXED_VALUE_BOUNDARY,
+          fastscapelib.NodeStatus.FIXED_VALUE_BOUNDARY]
+    g = fastscapelib.ProfileGrid(
+        10, 2, es, [(5, fastscapelib.NodeStatus.FIXED_VALUE_BOUNDARY)]
+    )
+
+    assert g.size == 10
+    assert g.spacing == 2.
+    np.testing.assert_equal(g.node_status,
+                            np.array([1, 0, 0, 0, 0, 1, 0, 0, 0, 1]))

--- a/python/fastscapelib/tests/test_grid.py
+++ b/python/fastscapelib/tests/test_grid.py
@@ -4,10 +4,10 @@ import fastscapelib
 
 
 def test_profile_grid():
-    es = [fastscapelib.NodeStatus.FIXED_VALUE_BOUNDARY,
+    bs = [fastscapelib.NodeStatus.FIXED_VALUE_BOUNDARY,
           fastscapelib.NodeStatus.FIXED_VALUE_BOUNDARY]
     g = fastscapelib.ProfileGrid(
-        10, 2, es, [(5, fastscapelib.NodeStatus.FIXED_VALUE_BOUNDARY)]
+        10, 2, bs, [(5, fastscapelib.NodeStatus.FIXED_VALUE_BOUNDARY)]
     )
 
     assert g.size == 10

--- a/python/fastscapelib/tests/test_grid.py
+++ b/python/fastscapelib/tests/test_grid.py
@@ -12,5 +12,5 @@ def test_profile_grid():
 
     assert g.size == 10
     assert g.spacing == 2.
-    np.testing.assert_equal(g.node_status,
+    np.testing.assert_equal(g.status_at_nodes,
                             np.array([1, 0, 0, 0, 0, 1, 0, 0, 0, 1]))

--- a/python/src/grid.cpp
+++ b/python/src/grid.cpp
@@ -1,0 +1,46 @@
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+#include "fastscapelib/utils.hpp"
+#include "fastscapelib/grid.hpp"
+
+#include "xtensor_utils.hpp"
+
+
+namespace py = pybind11;
+namespace fs = fastscapelib;
+
+
+void add_grid_bindings(py::module& m);
+
+
+void add_grid_bindings(py::module& m) {
+
+    using profile_grid_py = fs::profile_grid_xt<fs::pytensor_selector>;
+
+    py::enum_<fs::node_status>(m, "NodeStatus", py::arithmetic(),
+                               "Status of grid/mesh nodes either inside the domain "
+                               "or on the domain boundary.")
+        .value("CORE", fs::node_status::core)
+        .value("FIXED_VALUE_BOUNDARY", fs::node_status::fixed_value_boundary)
+        .value("FIXED_GRADIENT_BOUNDARY", fs::node_status::fixed_gradient_boundary)
+        .value("LOOPED_BOUNDARY", fs::node_status::looped_boundary);
+
+    py::class_<fs::edge_nodes_status>(m, "EdgeNodesStatus")
+        .def(py::init<fs::node_status, fs::node_status>())
+        .def_readonly("left", &fs::edge_nodes_status::left)
+        .def_readonly("right", &fs::edge_nodes_status::right);
+
+    py::class_<fs::node>(m, "Node")
+        .def(py::init<std::size_t, fs::node_status>())
+        .def_readonly("idx", &fs::node::idx)
+        .def_readonly("status", &fs::node::status);
+
+    py::class_<profile_grid_py>(m, "ProfileGrid")
+        .def(py::init<std::size_t, double, const fs::edge_nodes_status,
+                      const std::vector<fs::node>&>())
+        .def_property_readonly("size", &profile_grid_py::size)
+        .def_property_readonly("spacing", &profile_grid_py::spacing)
+        .def_property_readonly("node_status", &profile_grid_py::node_status);
+
+}

--- a/python/src/grid.cpp
+++ b/python/src/grid.cpp
@@ -35,15 +35,17 @@ void add_grid_bindings(py::module& m) {
         .def(py::init(
                  [](std::size_t size,
                     double spacing,
-                    const std::array<fs::node_status, 2>& es,
+                    const std::array<fs::node_status, 2>& bs,
                     const std::vector<std::pair<std::size_t, fs::node_status>>& ns)
                  {
-                     std::vector<fs::node> vec;
-                     for (auto&& p : ns)
+                     std::vector<fs::node> node_vec;
+                     for (auto&& node : ns)
                      {
-                         vec.push_back({p.first, p.second});
+                         node_vec.push_back({node.first, node.second});
                      }
-                     return std::make_unique<profile_grid_py>(size, spacing, es, vec);
+                     return std::make_unique<profile_grid_py>(
+                         size, spacing, fs::set_boundaries(bs),
+                         node_vec);
                  }))
         .def_property_readonly("size", &profile_grid_py::size)
         .def_property_readonly("spacing", &profile_grid_py::spacing)

--- a/python/src/grid.cpp
+++ b/python/src/grid.cpp
@@ -41,7 +41,7 @@ void add_grid_bindings(py::module& m) {
                      std::vector<fs::node> vec;
                      for (auto&& p : ns)
                      {
-                         vec.push_back({std::get<0>(p), std::get<1>(p)});
+                         vec.push_back({p.first, p.second});
                      }
                      return std::make_unique<profile_grid_py>(size, spacing, es, vec);
                  }))

--- a/python/src/grid.cpp
+++ b/python/src/grid.cpp
@@ -47,5 +47,5 @@ void add_grid_bindings(py::module& m) {
                  }))
         .def_property_readonly("size", &profile_grid_py::size)
         .def_property_readonly("spacing", &profile_grid_py::spacing)
-        .def_property_readonly("node_status", &profile_grid_py::node_status);
+        .def_property_readonly("status_at_nodes", &profile_grid_py::status_at_nodes);
 }

--- a/python/src/grid.cpp
+++ b/python/src/grid.cpp
@@ -16,7 +16,7 @@ namespace py = pybind11;
 namespace fs = fastscapelib;
 
 
-using profile_grid_py = fs::profile_grid_xt<fs::pytensor_selector>;
+using profile_grid = fs::profile_grid_xt<fs::pytensor_selector>;
 
 void add_grid_bindings(py::module& m);
 
@@ -31,7 +31,7 @@ void add_grid_bindings(py::module& m) {
         .value("FIXED_GRADIENT_BOUNDARY", fs::node_status::fixed_gradient_boundary)
         .value("LOOPED_BOUNDARY", fs::node_status::looped_boundary);
 
-    py::class_<profile_grid_py>(m, "ProfileGrid")
+    py::class_<profile_grid>(m, "ProfileGrid")
         .def(py::init(
                  [](std::size_t size,
                     double spacing,
@@ -43,11 +43,9 @@ void add_grid_bindings(py::module& m) {
                      {
                          node_vec.push_back({node.first, node.second});
                      }
-                     return std::make_unique<profile_grid_py>(
-                         size, spacing, fs::set_boundaries(bs),
-                         node_vec);
+                     return std::make_unique<profile_grid>(size, spacing, bs, node_vec);
                  }))
-        .def_property_readonly("size", &profile_grid_py::size)
-        .def_property_readonly("spacing", &profile_grid_py::spacing)
-        .def_property_readonly("status_at_nodes", &profile_grid_py::status_at_nodes);
+        .def_property_readonly("size", &profile_grid::size)
+        .def_property_readonly("spacing", &profile_grid::spacing)
+        .def_property_readonly("status_at_nodes", &profile_grid::status_at_nodes);
 }

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -164,6 +164,14 @@ PYBIND11_MODULE(_fastscapelib_py, m)
     m.def("get_versions", &get_versions,
           "Get version info.");
 
+    py::enum_<fs::node_status>(m, "NodeStatus", py::arithmetic(),
+                               "Status of grid/mesh nodes either inside the domain "
+                               "or on the domain boundary.")
+        .value("CORE", fs::node_status::core)
+        .value("FIXED_VALUE_BOUNDARY", fs::node_status::fixed_value_boundary)
+        .value("FIXED_GRADIENT_BOUNDARY", fs::node_status::fixed_gradient_boundary)
+        .value("LOOPED_BOUNDARY", fs::node_status::looped_boundary);
+
     m.def("compute_receivers_d8_d", &compute_receivers_d8_py<double>,
           "Compute D8 flow receivers, a single receiver for each grid node.");
 

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -157,6 +157,9 @@ void erode_linear_diffusion_py(xt::pytensor<T, 2>& erosion,
 }
 
 
+void add_grid_bindings(py::module &);
+
+
 PYBIND11_MODULE(_fastscapelib_py, m)
 {
     m.doc() = "A collection of efficient algorithms"
@@ -164,39 +167,10 @@ PYBIND11_MODULE(_fastscapelib_py, m)
 
     xt::import_numpy();
 
+    add_grid_bindings(m);
+
     m.def("get_versions", &get_versions,
           "Get version info.");
-
-    //*******
-    //* Grid
-    //*******
-
-    using profile_grid_py = fs::profile_grid_xt<fs::pytensor_selector>;
-
-    py::enum_<fs::node_status>(m, "NodeStatus", py::arithmetic(),
-                               "Status of grid/mesh nodes either inside the domain "
-                               "or on the domain boundary.")
-        .value("CORE", fs::node_status::core)
-        .value("FIXED_VALUE_BOUNDARY", fs::node_status::fixed_value_boundary)
-        .value("FIXED_GRADIENT_BOUNDARY", fs::node_status::fixed_gradient_boundary)
-        .value("LOOPED_BOUNDARY", fs::node_status::looped_boundary);
-
-    py::class_<fs::edge_nodes_status>(m, "EdgeNodesStatus")
-        .def(py::init<fs::node_status, fs::node_status>())
-        .def_readonly("left", &fs::edge_nodes_status::left)
-        .def_readonly("right", &fs::edge_nodes_status::right);
-
-    py::class_<fs::node>(m, "Node")
-        .def(py::init<std::size_t, fs::node_status>())
-        .def_readonly("idx", &fs::node::idx)
-        .def_readonly("status", &fs::node::status);
-
-    py::class_<profile_grid_py>(m, "ProfileGrid")
-        .def(py::init<std::size_t, double, const fs::edge_nodes_status,
-                      const std::vector<fs::node>&>())
-        .def_property_readonly("size", &profile_grid_py::size)
-        .def_property_readonly("spacing", &profile_grid_py::spacing)
-        .def_property_readonly("node_status", &profile_grid_py::node_status);
 
     m.def("compute_receivers_d8_d", &compute_receivers_d8_py<double>,
           "Compute D8 flow receivers, a single receiver for each grid node.");

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -5,12 +5,15 @@
 #include <cstdint>
 
 #include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 #define FORCE_IMPORT_ARRAY
 #include "xtensor-python/pytensor.hpp"
 #include "xtensor-python/pyarray.hpp"
 
 #include "fastscapelib/utils.hpp"
 #include "fastscapelib/fastscapelib.hpp"
+
+#include "xtensor_utils.hpp"
 
 
 namespace py = pybind11;
@@ -164,6 +167,12 @@ PYBIND11_MODULE(_fastscapelib_py, m)
     m.def("get_versions", &get_versions,
           "Get version info.");
 
+    //*******
+    //* Grid
+    //*******
+
+    using profile_grid_py = fs::profile_grid_xt<fs::pytensor_selector>;
+
     py::enum_<fs::node_status>(m, "NodeStatus", py::arithmetic(),
                                "Status of grid/mesh nodes either inside the domain "
                                "or on the domain boundary.")
@@ -171,6 +180,23 @@ PYBIND11_MODULE(_fastscapelib_py, m)
         .value("FIXED_VALUE_BOUNDARY", fs::node_status::fixed_value_boundary)
         .value("FIXED_GRADIENT_BOUNDARY", fs::node_status::fixed_gradient_boundary)
         .value("LOOPED_BOUNDARY", fs::node_status::looped_boundary);
+
+    py::class_<fs::edge_nodes_status>(m, "EdgeNodesStatus")
+        .def(py::init<fs::node_status, fs::node_status>())
+        .def_readonly("left", &fs::edge_nodes_status::left)
+        .def_readonly("right", &fs::edge_nodes_status::right);
+
+    py::class_<fs::node>(m, "Node")
+        .def(py::init<std::size_t, fs::node_status>())
+        .def_readonly("idx", &fs::node::idx)
+        .def_readonly("status", &fs::node::status);
+
+    py::class_<profile_grid_py>(m, "ProfileGrid")
+        .def(py::init<std::size_t, double, const fs::edge_nodes_status,
+                      const std::vector<fs::node>&>())
+        .def_property_readonly("size", &profile_grid_py::size)
+        .def_property_readonly("spacing", &profile_grid_py::spacing)
+        .def_property_readonly("node_status", &profile_grid_py::node_status);
 
     m.def("compute_receivers_d8_d", &compute_receivers_d8_py<double>,
           "Compute D8 flow receivers, a single receiver for each grid node.");

--- a/python/src/xtensor_utils.hpp
+++ b/python/src/xtensor_utils.hpp
@@ -1,0 +1,32 @@
+/**
+ * xtensor utils (container tags, etc.)
+ */
+#pragma once
+
+#include <cstddef>
+
+#include "xtensor-python/pyarray.hpp"
+#include "xtensor-python/pytensor.hpp"
+
+#include "fastscapelib/xtensor_utils.hpp"
+
+
+namespace fastscapelib
+{
+
+struct pytensor_selector;
+struct pyarray_selector;
+
+template <class T, std::size_t N>
+struct xt_container<pytensor_selector, T, N>
+{
+    using type = xt::pytensor<T, N>;
+};
+
+template <class T>
+struct xt_container<pyarray_selector, T>
+{
+    using type = xt::pyarray<T>;
+};
+
+} // namespace fastscapelib

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,6 +89,7 @@ include_directories(${GTEST_INCLUDE_DIRS})
 
 set(FASTSCAPELIB_TEST_SRC
   main.cpp
+  test_grid.cpp
   test_hillslope.cpp
   test_flow_routing.cpp
   test_sinks.cpp

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -60,3 +60,72 @@ TEST(grid, border_nodes_status)
                      std::invalid_argument);
     }
 }
+
+TEST(grid, profile_grid_constructor)
+{
+    auto es = fs::edge_nodes_status(fs::node_status::fixed_value_boundary);
+    auto g = fs::profile_grid(10, 2, es);
+
+    EXPECT_EQ(g.size(), 10);
+    EXPECT_EQ(g.spacing(), 2);
+    EXPECT_EQ(g.node_status().size(), 10);
+    EXPECT_EQ(g.node_status()(0), fs::node_status::fixed_value_boundary);
+    EXPECT_EQ(g.node_status()(5), fs::node_status::core);
+    EXPECT_EQ(g.node_status()(9), fs::node_status::fixed_value_boundary);
+
+    {
+        SCOPED_TRACE("test status_at_nodes parameter");
+
+        auto g = fs::profile_grid(10, 2, es,
+                                  {{5, fs::node_status::fixed_value_boundary}});
+
+        EXPECT_EQ(g.node_status()(5), fs::node_status::fixed_value_boundary);
+    }
+
+    {
+        SCOPED_TRACE("test invalid looped boundary status");
+
+        fs::edge_nodes_status es {fs::node_status::fixed_value_boundary,
+                                  fs::node_status::looped_boundary};
+
+        EXPECT_THROW(fs::profile_grid(10, 2, es), std::invalid_argument);
+    }
+}
+
+TEST(grid, profile_grid_neighbors)
+{
+    auto es = fs::edge_nodes_status(fs::node_status::fixed_value_boundary);
+    auto g = fs::profile_grid(10, 2, es);
+
+    auto n0 = g.neighbors(0);
+    EXPECT_EQ(n0.size(), 1);
+    EXPECT_EQ(n0[0].idx, 1);
+    EXPECT_EQ(n0[0].distance, 2);
+    EXPECT_EQ(n0[0].status, fs::node_status::core);
+
+    auto n9 = g.neighbors(9);
+    EXPECT_EQ(n9.size(), 1);
+    EXPECT_EQ(n9[0].idx, 8);
+
+    auto n5 = g.neighbors(5);
+    EXPECT_EQ(n5.size(), 2);
+    EXPECT_EQ(n5[0].idx, 4);
+    EXPECT_EQ(n5[1].idx, 6);
+
+    {
+        SCOPED_TRACE("test looped boundary neighbors");
+
+        auto es = fs::edge_nodes_status(fs::node_status::looped_boundary);
+        auto g = fs::profile_grid(10, 2, es);
+
+        auto n0 = g.neighbors(0);
+        EXPECT_EQ(n0.size(), 2);
+        EXPECT_EQ(n0[0].idx, 9);
+        EXPECT_EQ(n0[1].idx, 1);
+
+        auto n9 = g.neighbors(9);
+        EXPECT_EQ(n9.size(), 2);
+        EXPECT_EQ(n9[0].idx, 8);
+        EXPECT_EQ(n9[1].idx, 0);
+    }
+}

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -68,10 +68,10 @@ TEST(grid, profile_grid_constructor)
 
     EXPECT_EQ(g.size(), 10);
     EXPECT_EQ(g.spacing(), 2);
-    EXPECT_EQ(g.node_status().size(), 10);
-    EXPECT_EQ(g.node_status()(0), fs::node_status::fixed_value_boundary);
-    EXPECT_EQ(g.node_status()(5), fs::node_status::core);
-    EXPECT_EQ(g.node_status()(9), fs::node_status::fixed_value_boundary);
+    EXPECT_EQ(g.status_at_nodes().size(), 10);
+    EXPECT_EQ(g.status_at_nodes()(0), fs::node_status::fixed_value_boundary);
+    EXPECT_EQ(g.status_at_nodes()(5), fs::node_status::core);
+    EXPECT_EQ(g.status_at_nodes()(9), fs::node_status::fixed_value_boundary);
 
     {
         SCOPED_TRACE("test status_at_nodes parameter");
@@ -79,7 +79,7 @@ TEST(grid, profile_grid_constructor)
         auto g = fs::profile_grid(10, 2, es,
                                   {{5, fs::node_status::fixed_value_boundary}});
 
-        EXPECT_EQ(g.node_status()(5), fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(g.status_at_nodes()(5), fs::node_status::fixed_value_boundary);
     }
 
     {

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -1,3 +1,62 @@
 #include "gtest/gtest.h"
 
 #include "fastscapelib/grid.hpp"
+
+
+namespace fs = fastscapelib;
+
+TEST(grid, edge_nodes_status)
+{
+    {
+        SCOPED_TRACE("single status constructor");
+
+        auto es = fs::edge_nodes_status(fs::node_status::fixed_value_boundary);
+
+        EXPECT_EQ(es.left, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(es.right, fs::node_status::fixed_value_boundary);
+    }
+
+    {
+        SCOPED_TRACE("initializer constructor");
+
+        fs::edge_nodes_status es {fs::node_status::fixed_value_boundary,
+                                  fs::node_status::fixed_gradient_boundary};
+
+        EXPECT_EQ(es.left, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(es.right, fs::node_status::fixed_gradient_boundary);
+
+        EXPECT_THROW(fs::edge_nodes_status es2 {fs::node_status::core},
+                     std::invalid_argument);
+    }
+}
+
+TEST(grid, border_nodes_status)
+{
+    {
+        SCOPED_TRACE("single status constructor");
+
+        auto bs = fs::border_nodes_status(fs::node_status::fixed_value_boundary);
+
+        EXPECT_EQ(bs.top, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(bs.right, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(bs.bottom, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(bs.left, fs::node_status::fixed_value_boundary);
+    }
+
+    {
+        SCOPED_TRACE("initializer constructor");
+
+        fs::border_nodes_status bs {fs::node_status::fixed_value_boundary,
+                                    fs::node_status::looped_boundary,
+                                    fs::node_status::fixed_value_boundary,
+                                    fs::node_status::looped_boundary};
+
+        EXPECT_EQ(bs.top, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(bs.right, fs::node_status::looped_boundary);
+        EXPECT_EQ(bs.bottom, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(bs.left, fs::node_status::looped_boundary);
+
+        EXPECT_THROW(fs::border_nodes_status bs2 {fs::node_status::core},
+                     std::invalid_argument);
+    }
+}

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -1,0 +1,3 @@
+#include "gtest/gtest.h"
+
+#include "fastscapelib/grid.hpp"

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -97,17 +97,17 @@ TEST(grid, profile_grid_neighbors)
     auto es = fs::edge_nodes_status(fs::node_status::fixed_value_boundary);
     auto g = fs::profile_grid(10, 2, es);
 
-    auto n0 = g.neighbors(0);
+    auto& n0 = g.neighbors(0);
     EXPECT_EQ(n0.size(), 1);
     EXPECT_EQ(n0[0].idx, 1);
     EXPECT_EQ(n0[0].distance, 2);
     EXPECT_EQ(n0[0].status, fs::node_status::core);
 
-    auto n9 = g.neighbors(9);
+    auto& n9 = g.neighbors(9);
     EXPECT_EQ(n9.size(), 1);
     EXPECT_EQ(n9[0].idx, 8);
 
-    auto n5 = g.neighbors(5);
+    auto& n5 = g.neighbors(5);
     EXPECT_EQ(n5.size(), 2);
     EXPECT_EQ(n5[0].idx, 4);
     EXPECT_EQ(n5[1].idx, 6);
@@ -118,12 +118,12 @@ TEST(grid, profile_grid_neighbors)
         auto es = fs::edge_nodes_status(fs::node_status::looped_boundary);
         auto g = fs::profile_grid(10, 2, es);
 
-        auto n0 = g.neighbors(0);
+        auto& n0 = g.neighbors(0);
         EXPECT_EQ(n0.size(), 2);
         EXPECT_EQ(n0[0].idx, 9);
         EXPECT_EQ(n0[1].idx, 1);
 
-        auto n9 = g.neighbors(9);
+        auto& n9 = g.neighbors(9);
         EXPECT_EQ(n9.size(), 2);
         EXPECT_EQ(n9[0].idx, 8);
         EXPECT_EQ(n9[1].idx, 0);

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -19,13 +19,13 @@ TEST(grid, edge_nodes_status)
     {
         SCOPED_TRACE("initializer constructor");
 
-        fs::edge_nodes_status es {fs::node_status::fixed_value_boundary,
-                                  fs::node_status::fixed_gradient_boundary};
+        fs::edge_nodes_status es2 {fs::node_status::fixed_value_boundary,
+                                   fs::node_status::fixed_gradient_boundary};
 
-        EXPECT_EQ(es.left, fs::node_status::fixed_value_boundary);
-        EXPECT_EQ(es.right, fs::node_status::fixed_gradient_boundary);
+        EXPECT_EQ(es2.left, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(es2.right, fs::node_status::fixed_gradient_boundary);
 
-        EXPECT_THROW(fs::edge_nodes_status es2 {fs::node_status::core},
+        EXPECT_THROW(fs::edge_nodes_status es3 {fs::node_status::core},
                      std::invalid_argument);
     }
 }
@@ -46,17 +46,17 @@ TEST(grid, border_nodes_status)
     {
         SCOPED_TRACE("initializer constructor");
 
-        fs::border_nodes_status bs {fs::node_status::fixed_value_boundary,
-                                    fs::node_status::looped_boundary,
-                                    fs::node_status::fixed_value_boundary,
-                                    fs::node_status::looped_boundary};
+        fs::border_nodes_status bs2 {fs::node_status::fixed_value_boundary,
+                                     fs::node_status::looped_boundary,
+                                     fs::node_status::fixed_value_boundary,
+                                     fs::node_status::looped_boundary};
 
-        EXPECT_EQ(bs.top, fs::node_status::fixed_value_boundary);
-        EXPECT_EQ(bs.right, fs::node_status::looped_boundary);
-        EXPECT_EQ(bs.bottom, fs::node_status::fixed_value_boundary);
-        EXPECT_EQ(bs.left, fs::node_status::looped_boundary);
+        EXPECT_EQ(bs2.top, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(bs2.right, fs::node_status::looped_boundary);
+        EXPECT_EQ(bs2.bottom, fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(bs2.left, fs::node_status::looped_boundary);
 
-        EXPECT_THROW(fs::border_nodes_status bs2 {fs::node_status::core},
+        EXPECT_THROW(fs::border_nodes_status bs3 {fs::node_status::core},
                      std::invalid_argument);
     }
 }
@@ -64,11 +64,11 @@ TEST(grid, border_nodes_status)
 TEST(grid, profile_grid_constructor)
 {
     auto es = fs::edge_nodes_status(fs::node_status::fixed_value_boundary);
-    auto g = fs::profile_grid(10, 2, es);
+    auto g = fs::profile_grid(10, 2.0, es);
 
-    EXPECT_EQ(g.size(), 10);
-    EXPECT_EQ(g.spacing(), 2);
-    EXPECT_EQ(g.status_at_nodes().size(), 10);
+    EXPECT_EQ(g.size(), size_t(10));
+    EXPECT_EQ(g.spacing(), 2.0);
+    EXPECT_EQ(g.status_at_nodes().size(), size_t(10));
     EXPECT_EQ(g.status_at_nodes()(0), fs::node_status::fixed_value_boundary);
     EXPECT_EQ(g.status_at_nodes()(5), fs::node_status::core);
     EXPECT_EQ(g.status_at_nodes()(9), fs::node_status::fixed_value_boundary);
@@ -76,56 +76,56 @@ TEST(grid, profile_grid_constructor)
     {
         SCOPED_TRACE("test status_at_nodes parameter");
 
-        auto g = fs::profile_grid(10, 2, es,
-                                  {{5, fs::node_status::fixed_value_boundary}});
+        auto g2 = fs::profile_grid(10, 2.0, es,
+                                   {{5, fs::node_status::fixed_value_boundary}});
 
-        EXPECT_EQ(g.status_at_nodes()(5), fs::node_status::fixed_value_boundary);
+        EXPECT_EQ(g2.status_at_nodes()(5), fs::node_status::fixed_value_boundary);
     }
 
     {
         SCOPED_TRACE("test invalid looped boundary status");
 
-        fs::edge_nodes_status es {fs::node_status::fixed_value_boundary,
-                                  fs::node_status::looped_boundary};
+        fs::edge_nodes_status es2 {fs::node_status::fixed_value_boundary,
+                                   fs::node_status::looped_boundary};
 
-        EXPECT_THROW(fs::profile_grid(10, 2, es), std::invalid_argument);
+        EXPECT_THROW(fs::profile_grid(10, 2.0, es2), std::invalid_argument);
     }
 }
 
 TEST(grid, profile_grid_neighbors)
 {
     auto es = fs::edge_nodes_status(fs::node_status::fixed_value_boundary);
-    auto g = fs::profile_grid(10, 2, es);
+    auto g = fs::profile_grid(10, 2.0, es);
 
     auto& n0 = g.neighbors(0);
-    EXPECT_EQ(n0.size(), 1);
-    EXPECT_EQ(n0[0].idx, 1);
-    EXPECT_EQ(n0[0].distance, 2);
+    EXPECT_EQ(n0.size(), size_t(1));
+    EXPECT_EQ(n0[0].idx, size_t(1));
+    EXPECT_EQ(n0[0].distance, 2.0);
     EXPECT_EQ(n0[0].status, fs::node_status::core);
 
     auto& n9 = g.neighbors(9);
-    EXPECT_EQ(n9.size(), 1);
-    EXPECT_EQ(n9[0].idx, 8);
+    EXPECT_EQ(n9.size(), size_t(1));
+    EXPECT_EQ(n9[0].idx, size_t(8));
 
     auto& n5 = g.neighbors(5);
-    EXPECT_EQ(n5.size(), 2);
-    EXPECT_EQ(n5[0].idx, 4);
-    EXPECT_EQ(n5[1].idx, 6);
+    EXPECT_EQ(n5.size(), size_t(2));
+    EXPECT_EQ(n5[0].idx, size_t(4));
+    EXPECT_EQ(n5[1].idx, size_t(6));
 
     {
         SCOPED_TRACE("test looped boundary neighbors");
 
-        auto es = fs::edge_nodes_status(fs::node_status::looped_boundary);
-        auto g = fs::profile_grid(10, 2, es);
+        auto es2 = fs::edge_nodes_status(fs::node_status::looped_boundary);
+        auto g2 = fs::profile_grid(10, 2.0, es2);
 
-        auto& n0 = g.neighbors(0);
-        EXPECT_EQ(n0.size(), 2);
-        EXPECT_EQ(n0[0].idx, 9);
-        EXPECT_EQ(n0[1].idx, 1);
+        auto& n20 = g2.neighbors(0);
+        EXPECT_EQ(n20.size(), size_t(2));
+        EXPECT_EQ(n20[0].idx, size_t(9));
+        EXPECT_EQ(n20[1].idx, size_t(1));
 
-        auto& n9 = g.neighbors(9);
-        EXPECT_EQ(n9.size(), 2);
-        EXPECT_EQ(n9[0].idx, 8);
-        EXPECT_EQ(n9[1].idx, 0);
+        auto& n29 = g2.neighbors(9);
+        EXPECT_EQ(n29.size(), size_t(2));
+        EXPECT_EQ(n29[0].idx, size_t(8));
+        EXPECT_EQ(n29[1].idx, size_t(0));
     }
 }

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -135,7 +135,7 @@ TEST(grid, profile_grid_status_at_nodes)
     EXPECT_EQ(g.status_at_nodes()(9), fs::node_status::fixed_value_boundary);
 
     {
-        SCOPED_TRACE("test status_at_nodes grid constructor parameter");
+        SCOPED_TRACE("test status for user-defined nodes");
 
         auto g2 = fs::profile_grid(
             10, 2.0,
@@ -144,6 +144,8 @@ TEST(grid, profile_grid_status_at_nodes)
 
         EXPECT_EQ(g2.status_at_nodes()(5), fs::node_status::fixed_value_boundary);
     }
+
+    // TODO: test exceptions
 }
 
 TEST(grid, profile_grid_neighbors)

--- a/test/test_grid.cpp
+++ b/test/test_grid.cpp
@@ -70,6 +70,48 @@ TEST(grid, boundary_status_constructors)
         EXPECT_EQ(bsa4.top, fs::node_status::looped_boundary);
         EXPECT_EQ(bsa4.bottom, fs::node_status::looped_boundary);
     }
+
+    {
+        SCOPED_TRACE("check throw looped boundaries");
+
+        EXPECT_THROW(
+            fs::boundary_status({fs::node_status::looped_boundary,
+                                 fs::node_status::core}),
+            std::invalid_argument
+        );
+
+        EXPECT_THROW(
+            fs::boundary_status({fs::node_status::looped_boundary,
+                                 fs::node_status::core,
+                                 fs::node_status::looped_boundary,
+                                 fs::node_status::core}),
+            std::invalid_argument
+        );
+
+        EXPECT_THROW(
+            fs::boundary_status({fs::node_status::core,
+                                 fs::node_status::core,
+                                 fs::node_status::looped_boundary,
+                                 fs::node_status::core}),
+            std::invalid_argument
+        );
+    }
+}
+
+TEST(grid, boundary_status_looped)
+{
+    fs::boundary_status bs4v = {fs::node_status::fixed_value_boundary,
+                                fs::node_status::fixed_gradient_boundary,
+                                fs::node_status::looped_boundary,
+                                fs::node_status::looped_boundary};
+
+    fs::boundary_status bs4h = {fs::node_status::looped_boundary,
+                                fs::node_status::looped_boundary,
+                                fs::node_status::fixed_value_boundary,
+                                fs::node_status::fixed_gradient_boundary};
+
+    EXPECT_TRUE(bs4v.is_vertical_looped());
+    EXPECT_TRUE(bs4h.is_horizontal_looped());
 }
 
 TEST(grid, profile_grid_constructor)
@@ -101,15 +143,6 @@ TEST(grid, profile_grid_status_at_nodes)
             {{5, fs::node_status::fixed_value_boundary}});
 
         EXPECT_EQ(g2.status_at_nodes()(5), fs::node_status::fixed_value_boundary);
-    }
-
-    {
-        SCOPED_TRACE("test invalid looped boundary status");
-
-        fs::boundary_status bs {fs::node_status::fixed_value_boundary,
-                                fs::node_status::looped_boundary};
-
-        EXPECT_THROW(fs::profile_grid(10, 2.0, bs), std::invalid_argument);
     }
 }
 


### PR DESCRIPTION
Grid classes hold information about grid geometry, topology and node status
(boundary conditions) and implement some iterators over node neighbors exposed
by a common API.

Two kinds of grid are added:

- Profile grid (1D uniform)
- Raster grid (2D rectangular uniform)