### PR TITLE
Add interface and profile (1d) grids

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(FASTSCAPELIB_HEADERS
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/version.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/fastscapelib.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/utils.hpp
+  ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/profile_grid.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/consts.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/sinks.hpp
   ${FASTSCAPELIB_INCLUDE_DIR}/fastscapelib/flow_routing.hpp

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -118,18 +118,25 @@ endif()
 # Build
 # =====
 
+set(FASTSCAPELIB_BENCHMARK_HEADERS benchmark_setup.hpp)
+
 set(FASTSCAPELIB_BENCHMARK_SRC
-  benchmark_setup.hpp
   benchmark_bedrock_channel.cpp
+  benchmark_grid.cpp
   benchmark_hillslope.cpp
   benchmark_sinks.cpp
-  main.cpp
 )
 
-set(FASTSCAPELIB_BENCHMARK_TARGET benchmark_fastscapelib)
+# -- build a target for each benchmark
+foreach(filename IN LISTS FASTSCAPELIB_BENCHMARK_SRC)
+    string(REPLACE ".cpp" "" targetname ${filename})
+    add_executable(${targetname} ${filename} ${FASTSCAPELIB_BENCHMARK_HEADERS} main.cpp)
+    target_link_libraries(${targetname} PRIVATE fastscapelib ${GBENCHMARK_LIBRARIES})
+endforeach()
 
-add_executable(${FASTSCAPELIB_BENCHMARK_TARGET}
-  ${FASTSCAPELIB_BENCHMARK_SRC})
+# -- build a global target for all benchmarks
+add_executable(benchmark_fastscapelib
+        ${FASTSCAPELIB_BENCHMARK_SRC} ${FASTSCAPELIB_BENCHMARK_HEADERS} main.cpp)
 
-target_link_libraries(${FASTSCAPELIB_BENCHMARK_TARGET}
-  fastscapelib ${GBENCHMARK_LIBRARIES})
+target_link_libraries(benchmark_fastscapelib
+        PRIVATE fastscapelib ${GBENCHMARK_LIBRARIES})

--- a/benchmark/benchmark_grid.cpp
+++ b/benchmark/benchmark_grid.cpp
@@ -1,0 +1,128 @@
+#include "benchmark_setup.hpp"
+
+#include "fastscapelib/consts.hpp"
+#include "fastscapelib/profile_grid.hpp"
+
+#include "xtensor/xfixed.hpp"
+#include "xtensor/xtensor.hpp"
+
+#include <benchmark/benchmark.h>
+
+
+namespace fs = fastscapelib;
+namespace bms = benchmark_setup;
+
+
+namespace fastscapelib
+{
+    namespace bench
+    {
+
+        template <class XT>
+        void profile_grid__ctor(benchmark::State& state)
+        {
+            using grid_type = fs::profile_grid_xt<XT>;
+            using size_type = typename grid_type::size_type;
+
+            auto shape = static_cast<size_type>(state.range(0));
+
+            for (auto _ : state)
+            {
+                auto grid = grid_type(shape, 1.3, fs::node_status::fixed_value_boundary);
+            }
+        }
+
+        template <class XT>
+        void profile_grid__neighbors(benchmark::State& state)
+        {
+            using grid_type = fs::profile_grid_xt<XT>;
+            using size_type = typename grid_type::size_type;
+
+            auto size = static_cast<size_type>(state.range(0));
+            auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
+
+            for (auto _ : state)
+            {
+                for (size_type idx = 0; idx < size; ++idx)
+                {
+                    auto neighbors = grid.neighbors(idx);
+                }
+            }
+        }
+
+        template <class XT>
+        void profile_grid__neighbors_iterate(benchmark::State& state)
+        {
+            using grid_type = fs::profile_grid_xt<XT>;
+            using size_type = typename grid_type::size_type;
+
+            auto size = static_cast<size_type>(state.range(0));
+            auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
+
+            for (auto _ : state)
+            {
+                for (size_type idx = 0; idx < size; ++idx)
+                {
+                    for (auto neighbor : grid.neighbors(idx))
+                    {
+                        auto idx = neighbor.idx;
+                        auto distance = neighbor.distance;
+                        auto status = neighbor.status;
+
+                        benchmark::DoNotOptimize(idx);
+                        benchmark::DoNotOptimize(distance);
+                        benchmark::DoNotOptimize(status);
+                    }
+                }
+            }
+        }
+
+        template <class XT>
+        void profile_grid__spacing(benchmark::State& state)
+        {
+            using grid_type = fs::profile_grid_xt<XT>;
+            using size_type = typename grid_type::size_type;
+
+            auto size = static_cast<size_type>(state.range(0));
+            auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
+
+            for (auto _ : state)
+            {
+                auto spacing = grid.spacing();
+                benchmark::DoNotOptimize(spacing);
+            }
+        }
+
+        template <class XT>
+        void profile_grid__size(benchmark::State& state)
+        {
+            using grid_type = fs::profile_grid_xt<XT>;
+            using size_type = typename grid_type::size_type;
+
+            auto size = static_cast<size_type>(state.range(0));
+            auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
+
+            for (auto _ : state)
+            {
+                auto s = grid.size();
+                benchmark::DoNotOptimize(s);
+            }
+        }
+
+        BENCHMARK_TEMPLATE(profile_grid__ctor, fs::xtensor_selector)
+        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+
+        BENCHMARK_TEMPLATE(profile_grid__neighbors, fs::xtensor_selector)
+        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+
+        BENCHMARK_TEMPLATE(profile_grid__neighbors_iterate, fs::xtensor_selector)
+        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+
+        BENCHMARK_TEMPLATE(profile_grid__spacing, fs::xtensor_selector)
+        ->Apply(bms::grid_sizes<benchmark::kNanosecond>);
+
+        BENCHMARK_TEMPLATE(profile_grid__size, fs::xtensor_selector)
+        ->Apply(bms::grid_sizes<benchmark::kNanosecond>);
+        
+    } // namespace bench
+} // namespace fastscapelib

--- a/include/fastscapelib/fastscapelib.hpp
+++ b/include/fastscapelib/fastscapelib.hpp
@@ -9,5 +9,8 @@
 #include "fastscapelib/version.hpp"
 #include "fastscapelib/bedrock_channel.hpp"
 #include "fastscapelib/flow_routing.hpp"
+#include "fastscapelib/structured_grid.hpp"
+#include "fastscapelib/profile_grid.hpp"
+#include "fastscapelib/sinks.hpp"
 #include "fastscapelib/hillslope.hpp"
 #include "fastscapelib/sinks.hpp"

--- a/include/fastscapelib/profile_grid.hpp
+++ b/include/fastscapelib/profile_grid.hpp
@@ -1,0 +1,283 @@
+/**
+ * A profile grid is a one dimensional grid.
+ */
+#pragma once
+
+#include "fastscapelib/structured_grid.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+#include <map>
+#include <vector>
+
+
+namespace fastscapelib
+{
+
+    /**
+     * Status at grid boundary nodes.
+     */
+    class profile_boundary_status: public boundary_status
+    {
+    public:
+
+        node_status left = node_status::core;    /**< Status at left edge/border node(s) */
+        node_status right = node_status::core;   /**< Status at right edge/border node(s) */
+
+        profile_boundary_status(const node_status status);
+        profile_boundary_status(const node_status left_status, const node_status right_status);
+        profile_boundary_status(const std::array<node_status, 2>& status);
+
+        bool is_horizontal_looped();
+
+    protected:
+
+        void check_looped_symmetrical();
+    };
+
+    /**
+     * @name Constructors
+     */
+    //@{
+    /**
+     * Set the same status for all boundary nodes.
+     */
+    inline profile_boundary_status::profile_boundary_status(node_status status)
+        : left(status), right(status)
+    {
+        check_looped_symmetrical();
+    }
+
+    /**
+     * Set the same status for all boundary nodes.
+     */
+    inline profile_boundary_status::profile_boundary_status(node_status left_status, node_status right_status)
+        : left(left_status), right(right_status)
+    {
+        check_looped_symmetrical();
+    }
+
+    /**
+     * Set status at the left and right edge nodes of a profile grid.
+     */
+    inline profile_boundary_status::profile_boundary_status(const std::array<node_status, 2>& status)
+        : left(status[0]), right(status[1])
+    {
+        check_looped_symmetrical();
+    }
+    //@}
+
+    /**
+     * Return true if periodic (looped) conditions are set for ``left`` and ``right``.
+     */
+    inline bool profile_boundary_status::is_horizontal_looped()
+    {
+        return is_looped(left) && is_looped(right);
+    }
+
+    inline void profile_boundary_status::check_looped_symmetrical()
+    {
+        if (is_looped(left) ^ is_looped(right))
+        {
+            throw std::invalid_argument("looped boundaries are not symmetrical");
+        }
+    }
+
+    //*******************
+    //* Profile grid (1D)
+    //*******************
+
+    template <class XT>
+    class profile_grid_xt;
+
+    template <class XT>
+    struct grid_inner_types<profile_grid_xt<XT>>
+    {
+        using xt_selector = XT;
+
+        struct xt_ndims
+        {
+            static constexpr std::size_t value = 1;
+        };
+
+        using xt_type = xt_container_t<xt_selector, int, xt_ndims::value>;
+
+        using size_type = typename xt_type::size_type;
+        using shape_type = typename xt_type::shape_type;
+
+        struct is_structured
+        {
+            static constexpr bool value = true;
+        };
+
+        struct is_uniform
+        {
+            static constexpr bool value = true;
+        };
+
+        using boundary_status_type = profile_boundary_status;
+        using spacing_type = double;
+        using node_status_type = xt_container_t<xt_selector, node_status, xt_ndims::value>;
+        using neighbors_type = std::vector<neighbor>;
+    };
+
+    /**
+     * @class profile_grid_xt
+     * @brief 1-dimensional uniform grid.
+     *
+     * Used for modeling single channel or hillslope profiles.
+     *
+     * @tparam XT xtensor container selector for data array members.
+     */
+    template <class XT>
+    class profile_grid_xt : public structured_grid<profile_grid_xt<XT>>
+    {
+    public:
+
+        using self_type = profile_grid_xt<XT>;
+        using base_type = structured_grid<self_type>;
+        using inner_types = grid_inner_types<self_type>;
+
+        using xt_selector = typename inner_types::xt_selector;
+        using xt_ndims = typename inner_types::xt_ndims;
+
+        using size_type = typename inner_types::size_type;
+        using shape_type = typename inner_types::shape_type;
+
+        using spacing_type = typename inner_types::spacing_type;
+        using neighbors_type = typename inner_types::neighbors_type;
+
+        using boundary_status_type = typename inner_types::boundary_status_type;
+        using node_status_type = typename inner_types::node_status_type;
+
+        profile_grid_xt(size_type size,
+                        spacing_type spacing,
+                        const boundary_status_type& status_at_bounds,
+                        const std::vector<node>& status_at_nodes = {});
+
+    protected:
+
+        shape_type m_shape;
+        size_type m_size;
+        spacing_type m_spacing;
+
+        node_status_type m_status_at_nodes;
+        boundary_status_type m_status_at_bounds;
+        void set_status_at_nodes(const std::vector<node>& status_at_nodes);
+
+        static constexpr std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
+        std::vector<neighbors_type> m_all_neighbors;
+        void precompute_neighbors();
+
+        const neighbors_type& neighbors_impl(std::size_t idx) const;
+
+        friend class structured_grid<self_type>;
+    };
+
+    template <class XT>
+    constexpr std::array<std::ptrdiff_t, 3> profile_grid_xt<XT>::offsets;
+
+    /**
+     * @name Constructors
+     */
+    //@{
+    /**
+     * Creates a new profile grid.
+     *
+     * @param size Total number of grid nodes.
+     * @param spacing Distance between two adjacent grid nodes.
+     * @param status_at_bounds Status at boundary nodes (left & right grid edges).
+     * @param status_at_nodes Manually define the status at any node on the grid.
+     */
+    template <class XT>
+    profile_grid_xt<XT>::profile_grid_xt(size_type size,
+                                        spacing_type spacing,
+                                        const boundary_status_type& status_at_bounds,
+                                        const std::vector<node>& status_at_nodes)
+        : base_type(), m_size(size), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
+    {
+        m_shape = {static_cast<typename shape_type::value_type>(m_size)};
+        set_status_at_nodes(status_at_nodes);
+        precompute_neighbors();
+    }
+    //@}
+
+    template <class XT>
+    void profile_grid_xt<XT>::set_status_at_nodes(const std::vector<node>& status_at_nodes)
+    {
+        node_status_type temp_status_at_nodes(m_shape, node_status::core);
+
+        temp_status_at_nodes(0) = m_status_at_bounds.left;
+        temp_status_at_nodes(m_size-1) = m_status_at_bounds.right;
+
+        for (const node& n : status_at_nodes)
+        {
+            if (n.status == node_status::looped_boundary)
+            {
+                throw std::invalid_argument("node_status::looped_boundary is not allowed in "
+                                            "'status_at_nodes' "
+                                            "(use 'status_at_bounds' instead)");
+            }
+            else if (temp_status_at_nodes.at(n.idx) == node_status::looped_boundary)
+            {
+                throw std::invalid_argument("cannot overwrite the status of a "
+                                            "looped boundary node");
+            }
+
+            temp_status_at_nodes.at(n.idx) = n.status;
+        }
+
+        m_status_at_nodes = temp_status_at_nodes;
+    }
+
+    template <class XT>
+    void profile_grid_xt<XT>::precompute_neighbors()
+    {
+        m_all_neighbors.resize(m_size);
+
+        for (std::size_t idx=1; idx<m_size-1; ++idx)
+        {
+            for (std::size_t k=1; k<3; ++k)
+            {
+                std::size_t nb_idx = detail::add_offset(idx, offsets[k]);
+                neighbor nb {nb_idx, m_spacing, m_status_at_nodes[nb_idx]};
+                m_all_neighbors[idx].push_back(nb);
+            }
+        }
+
+        m_all_neighbors[0].push_back(
+            {1, m_spacing, m_status_at_nodes[1]});
+        m_all_neighbors[m_size-1].push_back(
+            {m_size-2, m_spacing, m_status_at_nodes[m_size-2]});
+
+        if (m_status_at_bounds.is_horizontal_looped())
+        {
+            m_all_neighbors[0].insert(
+                m_all_neighbors[0].begin(),
+                {m_size-1, m_spacing, m_status_at_nodes[m_size-1]});
+            m_all_neighbors[m_size-1].push_back(
+                {0, m_spacing, m_status_at_nodes[0]});
+        }
+    }
+
+    template <class XT>
+    inline auto profile_grid_xt<XT>::neighbors_impl(std::size_t idx) const
+        -> const neighbors_type&
+    {
+        return m_all_neighbors.at(idx);
+    }
+
+    /**
+     * @typedef profile_grid
+     * Alias template on profile_grid_xt with ``xt::xtensor`` used
+     * as array container type for data members.
+     *
+     * This is mainly for convenience when using in C++ applications.
+     *
+     */
+    using profile_grid = profile_grid_xt<xtensor_selector>;
+}

--- a/include/fastscapelib/structured_grid.hpp
+++ b/include/fastscapelib/structured_grid.hpp
@@ -1,0 +1,232 @@
+/**
+ * grids (channel, raster, etc.) hold and manage grid/mesh geometry,
+ * topology and boundary conditions.
+ */
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <stdexcept>
+#include <type_traits>
+#include <map>
+#include <vector>
+
+#include "xtensor/xbuilder.hpp"
+#include "xtensor/xarray.hpp"
+#include "xtensor/xfixed.hpp"
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xview.hpp"
+#include "xtensor/xindex_view.hpp"
+#include "xtensor/xnoalias.hpp"
+
+#include "fastscapelib/utils.hpp"
+#include "fastscapelib/xtensor_utils.hpp"
+
+
+namespace fastscapelib
+{
+
+    //*****************
+    //* Grid boundaries
+    //*****************
+
+    /**
+     * Status at a grid/mesh node.
+     */
+    enum class node_status: std::uint8_t
+    {
+        core = 0,
+        fixed_value_boundary = 1,
+        fixed_gradient_boundary = 2,
+        looped_boundary = 3
+    };
+
+
+    namespace detail
+    {
+
+        inline bool node_status_cmp(node_status a, node_status b)
+        {
+            static std::map<node_status, int> priority {
+                {node_status::core, 0},
+                {node_status::looped_boundary, 1},
+                {node_status::fixed_gradient_boundary, 2},
+                {node_status::fixed_value_boundary, 3}
+            };
+
+            return priority[a] < priority[b];
+        }
+
+    }  // namespace detail
+
+
+    /**
+     * Status at grid boundary nodes.
+     */
+    class boundary_status
+    {
+    protected:
+
+        bool is_looped(node_status status);
+    };
+
+    inline bool boundary_status::is_looped(node_status status)
+    {
+        return status == node_status::looped_boundary;
+    }
+
+
+    //***************
+    //* Grid elements
+    //***************
+
+    /**
+     * Grid/mesh node.
+     */
+    struct node
+    {
+        std::size_t idx;     /**< Node index */
+        node_status status;  /**< Node status */
+    };
+
+    /**
+     * Neighbor node.
+     */
+    struct neighbor
+    {
+        std::size_t idx;     /**< Index of the neighbor node */
+        double distance;     /**< Distance to the neighbor node */
+        node_status status;  /**< Status at the neighbor node */
+
+        bool operator==(const neighbor& rhs) const
+        {
+            return (idx == rhs.idx) && (distance == rhs.distance) && (status == rhs.status);
+        }
+    };
+
+    namespace detail
+    {
+        /**
+         * Add a given offset (positive, negative or zero) to a grid node index.
+         *
+         * This utility function is mainly to avoid signed/unsigned conversion
+         * warnings. Use it carefully.
+         */
+        inline std::size_t add_offset(std::size_t idx, std::ptrdiff_t offset)
+        {
+            return static_cast<std::size_t>(static_cast<std::ptrdiff_t>(idx) + offset);
+        }
+    }
+
+    //***************************
+    //* Structured grid interface
+    //***************************
+
+    template <class G>
+    struct grid_inner_types;
+
+    /**
+     * @class structured_grid
+     * @brief Add a common interface to all structured grid types.
+     *
+     * This class only defines a basic interface for all structured grid types.
+     * It does not embed any data member, this responsibility
+     * is delegated to the inheriting classes.
+     *
+     * @tparam G Derived grid type.
+     */
+    template <class G>
+    class structured_grid
+    {
+    public:
+
+        using derived_grid_type = G;
+        using inner_types = grid_inner_types<derived_grid_type>;
+
+        using size_type = typename inner_types::size_type;
+        using shape_type = typename inner_types::shape_type;
+        using spacing_type = typename inner_types::spacing_type;
+        using neighbors_type = typename inner_types::neighbors_type;
+
+        using spacing_t = std::conditional_t<std::is_arithmetic<spacing_type>::value,
+                                            spacing_type,
+                                            const spacing_type&>;
+
+        using node_status_type = typename inner_types::node_status_type;
+
+        //shape_type shape() const noexcept;
+        size_type size() const noexcept;
+        spacing_t spacing() const noexcept;
+        const node_status_type& status_at_nodes() const;
+
+        const neighbors_type& neighbors(std::size_t idx) const;
+
+    protected:
+        structured_grid() = default;
+        ~structured_grid() = default;
+
+        const derived_grid_type& derived_grid() const & noexcept;
+    };
+
+    template <class G>
+    inline auto structured_grid<G>::derived_grid() const & noexcept -> const derived_grid_type&
+    {
+        return *static_cast<const derived_grid_type*>(this);
+    }
+
+    /**
+     * @name Grid properties
+     */
+    //@{
+    /**
+     * Returns the total number of grid nodes.
+     */
+    template <class G>
+    inline auto structured_grid<G>::size() const noexcept -> size_type
+    {
+        return derived_grid().m_size;
+    }
+
+    /**
+     * Returns the (uniform) spacing between two adjacent grid nodes.
+     *
+     * Returns a copy of the value for 1-d grids or a constant reference otherwise.
+     */
+    template <class G>
+
+    inline auto structured_grid<G>::spacing() const noexcept -> spacing_t
+    {
+        return derived_grid().m_spacing;
+    }
+
+    /**
+     * Returns a constant reference to the array of status at grid nodes.
+     */
+    template <class G>
+    inline auto structured_grid<G>::status_at_nodes() const -> const node_status_type&
+    {
+        return derived_grid().m_status_at_nodes;
+    }
+
+    /**
+     * @name Iterators
+     */
+    /**
+     * Iterate over the neighbors of a given grid node.
+     *
+     * Follows looped boundary conditions, if any.
+     *
+     * @param idx Index of the grid node.
+     * @return Reference to the vector of the neighbors of that grid node.
+     */
+    template <class G>
+    inline auto structured_grid<G>::neighbors(std::size_t idx) const -> const neighbors_type&
+    {
+        return derived_grid().neighbors_impl(idx);
+    }
+    //@}
+}

--- a/include/fastscapelib/xtensor_utils.hpp
+++ b/include/fastscapelib/xtensor_utils.hpp
@@ -1,0 +1,40 @@
+/**
+ * xtensor utils (container tags, etc.)
+ */
+#pragma once
+
+#include <cstddef>
+
+#include "xtensor/xarray.hpp"
+#include "xtensor/xtensor.hpp"
+
+
+namespace fastscapelib
+{
+
+    struct xtensor_selector;
+    struct xarray_selector;
+
+
+    template <class X, class T, std::size_t N = 0>
+    struct xt_container;
+
+
+    template <class T, std::size_t N>
+    struct xt_container<xtensor_selector, T, N>
+    {
+        using type = xt::xtensor<T, N>;
+    };
+
+
+    template <class T>
+    struct xt_container<xarray_selector, T>
+    {
+        using type = xt::xarray<T>;
+    };
+
+
+    template <class X, class T, std::size_t N = 0>
+    using xt_container_t = typename xt_container<X, T, N>::type;
+
+} // namespace fastscapelib

--- a/python/fastscapelib/tests/test_grid.py
+++ b/python/fastscapelib/tests/test_grid.py
@@ -1,0 +1,103 @@
+import pytest
+import numpy as np
+import numpy.testing as npt
+
+import fastscapelib
+from _fastscapelib_py.grid import NodeStatus, ProfileBoundaryStatus, ProfileGrid, Node, Neighbor
+
+
+class TestProfileBoundaryStatus():
+
+    def setup_method(self, method):
+        self.bs1 = ProfileBoundaryStatus([NodeStatus.CORE, NodeStatus.FIXED_VALUE_BOUNDARY])
+        self.bs2 = ProfileBoundaryStatus(NodeStatus.FIXED_VALUE_BOUNDARY, NodeStatus.CORE)
+        self.bs3 = ProfileBoundaryStatus(NodeStatus.CORE)
+        self.bs4 = ProfileBoundaryStatus(NodeStatus.LOOPED_BOUNDARY)
+
+    def test__init__(self):
+        # call the setup_method
+        pass
+
+    def test_left(self):
+        assert self.bs1.left == NodeStatus.CORE
+        assert self.bs2.left == NodeStatus.FIXED_VALUE_BOUNDARY
+        assert self.bs3.left == NodeStatus.CORE
+        assert self.bs4.left == NodeStatus.LOOPED_BOUNDARY
+
+    def test_right(self):
+        assert self.bs1.right == NodeStatus.FIXED_VALUE_BOUNDARY
+        assert self.bs2.right == NodeStatus.CORE
+        assert self.bs3.right == NodeStatus.CORE
+        assert self.bs4.right == NodeStatus.LOOPED_BOUNDARY
+
+    def test_is_horizontal_looped(self):
+        assert not self.bs1.is_horizontal_looped
+        assert not self.bs2.is_horizontal_looped
+        assert not self.bs3.is_horizontal_looped
+        assert self.bs4.is_horizontal_looped
+
+
+class TestNeighbor():
+
+    def setup_method(self, method):
+        self.n = Neighbor(5, 1.35, NodeStatus.CORE)
+
+    def test__init__(self):
+        # call the setup_method
+        assert self.n == Neighbor(5, 1.35, NodeStatus.CORE)
+        pass
+
+    def test_idx(self):
+        assert self.n.idx == 5
+
+        self.n.idx = 8
+        assert self.n.idx == 8
+
+    def test_distance(self):
+        assert self.n.distance == 1.35
+
+        self.n.distance = 1.38
+        assert self.n.distance == 1.38
+
+    def test_status(self):
+        assert self.n.status == NodeStatus.CORE
+
+        self.n.status = NodeStatus.FIXED_VALUE_BOUNDARY
+        assert self.n.status == NodeStatus.FIXED_VALUE_BOUNDARY
+
+
+class TestProfileGrid():
+
+    def setup_method(self, method):
+        bs = [NodeStatus.FIXED_VALUE_BOUNDARY]*2
+        self.g = ProfileGrid(10, 2.2, bs, [(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+
+    def test___init__(self):
+        bs = [NodeStatus.FIXED_VALUE_BOUNDARY]*2
+        g = ProfileGrid(10, 2, bs, [(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+        assert g.size == 10
+        assert g.spacing == 2.
+
+        g = ProfileGrid(15, 3., ProfileBoundaryStatus(bs), [Node(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+        assert g.size == 15
+        assert g.spacing == 3.
+
+        with pytest.raises(IndexError):
+            ProfileGrid(10, 2, bs, [(15, NodeStatus.FIXED_VALUE_BOUNDARY)])
+
+    def test_size(self):
+        assert self.g.size == 10
+
+    def test_spacing(self):
+        assert self.g.spacing == 2.2
+
+    def test_status_at_nodes(self):
+        npt.assert_equal(self.g.status_at_nodes, np.array([1, 0, 0, 0, 0, 1, 0, 0, 0, 1]))
+
+    def test_neighbors(self):
+        assert self.g.neighbors(0) == [Neighbor(1, 2.2, NodeStatus.CORE)]
+        assert self.g.neighbors(1) == [Neighbor(0, 2.2, NodeStatus.FIXED_VALUE_BOUNDARY), Neighbor(2, 2.2, NodeStatus.CORE)]
+        assert self.g.neighbors(6) == [Neighbor(5, 2.2, NodeStatus.FIXED_VALUE_BOUNDARY), Neighbor(7, 2.2, NodeStatus.CORE)]
+        
+        with pytest.raises(IndexError):
+            self.g.neighbors(11)

--- a/python/src/main.cpp
+++ b/python/src/main.cpp
@@ -12,139 +12,12 @@
 #include "fastscapelib/utils.hpp"
 #include "fastscapelib/fastscapelib.hpp"
 
+#include "grid.cpp"
+#include "modelings.cpp"
+
 
 namespace py = pybind11;
-using namespace pybind11::literals;  // use the `_a` literal
-
 namespace fs = fastscapelib;
-
-
-template<class T>
-void fill_sinks_flat_py(xt::pytensor<T, 2>& elevation)
-{
-    py::gil_scoped_release release;
-    fs::fill_sinks_flat(elevation);
-}
-
-
-template<class T>
-void fill_sinks_sloped_py(xt::pytensor<T, 2>& elevation)
-{
-    py::gil_scoped_release release;
-    fs::fill_sinks_sloped(elevation);
-}
-
-
-template<class T>
-void compute_receivers_d8_py(xt::pytensor<index_t, 1>& receivers,
-                             xt::pytensor<T, 1>& dist2receivers,
-                             const xt::pytensor<T, 2>& elevation,
-                             const xt::pytensor<bool, 2>& active_nodes,
-                             double dx,
-                             double dy)
-{
-    py::gil_scoped_release release;
-    fs::compute_receivers_d8(receivers, dist2receivers,
-                             elevation, active_nodes,
-                             dx, dy);
-}
-
-
-void compute_donors_py(xt::pytensor<index_t, 1>& ndonors,
-                       xt::pytensor<index_t, 2>& donors,
-                       const xt::pytensor<index_t, 1>& receivers)
-{
-    py::gil_scoped_release release;
-    fs::compute_donors(ndonors, donors, receivers);
-}
-
-
-void compute_stack_py(xt::pytensor<index_t, 1>& stack,
-                      const xt::pytensor<index_t, 1>& ndonors,
-                      const xt::pytensor<index_t, 2>& donors,
-                      const xt::pytensor<index_t, 1>& receivers)
-{
-    py::gil_scoped_release release;
-    fs::compute_stack(stack, ndonors, donors, receivers);
-}
-
-
-index_t compute_basins_py(xt::pytensor<index_t, 1>& basins,
-                          xt::pytensor<index_t, 1>& outlets_or_pits,
-                          const xt::pytensor<index_t, 1>& stack,
-                          const xt::pytensor<index_t, 1>& receivers)
-{
-    py::gil_scoped_release release;
-    return fs::compute_basins(basins, outlets_or_pits, stack, receivers);
-}
-
-
-index_t find_pits_py(xt::pytensor<index_t, 1>& pits,
-                     const xt::pytensor<index_t, 1>& outlets_or_pits,
-                     const xt::pytensor<bool, 2>& active_nodes,
-                     index_t nbasins)
-{
-    py::gil_scoped_release release;
-    return fs::find_pits(pits, outlets_or_pits, active_nodes, nbasins);
-}
-
-
-template<class T>
-void compute_drainage_area_mesh_py(xt::pytensor<T, 1>& drainage_area,
-                                   const xt::pytensor<T, 1>& cell_area,
-                                   const xt::pytensor<index_t, 1>& stack,
-                                   const xt::pytensor<index_t, 1>& receivers)
-{
-    py::gil_scoped_release release;
-    fs::compute_drainage_area(drainage_area, cell_area, stack, receivers);
-}
-
-
-template<class T>
-void compute_drainage_area_grid_py(xt::pytensor<T, 2>& drainage_area,
-                                   const xt::pytensor<index_t, 1>& stack,
-                                   const xt::pytensor<index_t, 1>& receivers,
-                                   double dx,
-                                   double dy)
-{
-    py::gil_scoped_release release;
-    fs::compute_drainage_area(drainage_area, stack, receivers, dx, dy);
-}
-
-
-template<class K, class T>
-index_t erode_stream_power_py(xt::pyarray<T>& erosion,
-                              const xt::pyarray<T>& elevation,
-                              const xt::pytensor<index_t, 1>& stack,
-                              const xt::pytensor<index_t, 1>& receivers,
-                              const xt::pytensor<T, 1>& dist2receivers,
-                              const xt::pyarray<T>& drainage_area,
-                              const K k_coef,
-                              double m_exp,
-                              double n_exp,
-                              double dt,
-                              double tolerance)
-{
-    py::gil_scoped_release release;
-    return fs::erode_stream_power(erosion, elevation,
-                                  stack, receivers,
-                                  dist2receivers, drainage_area,
-                                  k_coef, m_exp, n_exp,
-                                  dt, tolerance);
-}
-
-
-template<class K, class T>
-void erode_linear_diffusion_py(xt::pytensor<T, 2>& erosion,
-                               const xt::pytensor<T, 2>& elevation,
-                               const K k_coef,
-                               double dt,
-                               double dx,
-                               double dy)
-{
-    py::gil_scoped_release release;
-    fs::erode_linear_diffusion(erosion, elevation, k_coef, dt, dx, dy);
-}
 
 
 PYBIND11_MODULE(_fastscapelib_py, m)
@@ -156,54 +29,6 @@ PYBIND11_MODULE(_fastscapelib_py, m)
 
     m.attr("__version__") = fs::version::version_str;
 
-    m.def("compute_receivers_d8_d", &compute_receivers_d8_py<double>,
-          "Compute D8 flow receivers, a single receiver for each grid node.");
-
-    m.def("compute_donors", &compute_donors_py,
-          "Compute flow donors (invert flow receivers).");
-
-    m.def("compute_stack", &compute_stack_py,
-          "Build a stack of grid node ids such that each node in the stack "
-          "is visited before any of its upstream nodes.");
-
-    m.def("compute_basins", &compute_basins_py,
-          "Compute basin ids. Return total number of basins");
-
-    m.def("find_pits", &find_pits_py,
-          "Find pit node ids. Return total number of pit nodes");
-
-    m.def("compute_drainage_area_mesh_d",
-          &compute_drainage_area_mesh_py<double>,
-          "Compute drainage area on a mesh.");
-
-    m.def("compute_drainage_area_grid_d",
-          &compute_drainage_area_grid_py<double>,
-          "Compute drainage area on a 2D grid.");
-
-    m.def("fill_sinks_flat_d", &fill_sinks_flat_py<double>,
-          "Fill depressions in elevation data (flat surfaces).");
-
-    m.def("fill_sinks_sloped_d", &fill_sinks_sloped_py<double>,
-          "Fill depressions in elevation data (slightly sloped surfaces).");
-
-    m.def("erode_stream_power_d", &erode_stream_power_py<double, double>,
-          "Compute bedrock channel erosion during a single time step "
-          "using the Stream Power Law.");
-
-    m.def("erode_stream_power_var_d", &erode_stream_power_py<xt::pyarray<double>&, double>,
-          "Compute bedrock channel erosion during a single time step "
-          "using the Stream Power Law.\n\n"
-          "Version with spatially variable stream power coefficient.");
-
-    m.def("erode_linear_diffusion_d", &erode_linear_diffusion_py<double, double>,
-          "Compute hillslope erosion by linear diffusion on a 2-d regular "
-          "grid using finite differences with an Alternating Direction"
-          "Implicit (ADI) scheme.");
-
-    m.def("erode_linear_diffusion_var_d",
-          &erode_linear_diffusion_py<xt::pytensor<double, 2>&, double>,
-          "Compute hillslope erosion by linear diffusion on a 2-d regular "
-          "grid using finite differences with an Alternating Direction"
-          "Implicit (ADI) scheme.\n\n"
-          "Version with spatially variable diffusion coefficient.");
+    add_grid_bindings(m);
+    add_modelings_bindings(m);
 }

--- a/python/src/modelings.cpp
+++ b/python/src/modelings.cpp
@@ -1,0 +1,193 @@
+/**
+ * @file
+ * @brief Fastscapelib modelings Python bindings.
+*/
+
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+namespace py = pybind11;
+namespace fs = fastscapelib;
+
+
+template<class T>
+void fill_sinks_flat_py(xt::pytensor<T, 2>& elevation)
+{
+    py::gil_scoped_release release;
+    fs::fill_sinks_flat(elevation);
+}
+
+
+template<class T>
+void fill_sinks_sloped_py(xt::pytensor<T, 2>& elevation)
+{
+    py::gil_scoped_release release;
+    fs::fill_sinks_sloped(elevation);
+}
+
+
+template<class T>
+void compute_receivers_d8_py(xt::pytensor<index_t, 1>& receivers,
+                             xt::pytensor<T, 1>& dist2receivers,
+                             const xt::pytensor<T, 2>& elevation,
+                             const xt::pytensor<bool, 2>& active_nodes,
+                             double dx,
+                             double dy)
+{
+    py::gil_scoped_release release;
+    fs::compute_receivers_d8(receivers, dist2receivers,
+                             elevation, active_nodes,
+                             dx, dy);
+}
+
+
+void compute_donors_py(xt::pytensor<index_t, 1>& ndonors,
+                       xt::pytensor<index_t, 2>& donors,
+                       const xt::pytensor<index_t, 1>& receivers)
+{
+    py::gil_scoped_release release;
+    fs::compute_donors(ndonors, donors, receivers);
+}
+
+
+void compute_stack_py(xt::pytensor<index_t, 1>& stack,
+                      const xt::pytensor<index_t, 1>& ndonors,
+                      const xt::pytensor<index_t, 2>& donors,
+                      const xt::pytensor<index_t, 1>& receivers)
+{
+    py::gil_scoped_release release;
+    fs::compute_stack(stack, ndonors, donors, receivers);
+}
+
+
+index_t compute_basins_py(xt::pytensor<index_t, 1>& basins,
+                          xt::pytensor<index_t, 1>& outlets_or_pits,
+                          const xt::pytensor<index_t, 1>& stack,
+                          const xt::pytensor<index_t, 1>& receivers)
+{
+    py::gil_scoped_release release;
+    return fs::compute_basins(basins, outlets_or_pits, stack, receivers);
+}
+
+
+index_t find_pits_py(xt::pytensor<index_t, 1>& pits,
+                     const xt::pytensor<index_t, 1>& outlets_or_pits,
+                     const xt::pytensor<bool, 2>& active_nodes,
+                     index_t nbasins)
+{
+    py::gil_scoped_release release;
+    return fs::find_pits(pits, outlets_or_pits, active_nodes, nbasins);
+}
+
+
+template<class T>
+void compute_drainage_area_mesh_py(xt::pytensor<T, 1>& drainage_area,
+                                   const xt::pytensor<T, 1>& cell_area,
+                                   const xt::pytensor<index_t, 1>& stack,
+                                   const xt::pytensor<index_t, 1>& receivers)
+{
+    py::gil_scoped_release release;
+    fs::compute_drainage_area(drainage_area, cell_area, stack, receivers);
+}
+
+
+template<class T>
+void compute_drainage_area_grid_py(xt::pytensor<T, 2>& drainage_area,
+                                   const xt::pytensor<index_t, 1>& stack,
+                                   const xt::pytensor<index_t, 1>& receivers,
+                                   double dx,
+                                   double dy)
+{
+    py::gil_scoped_release release;
+    fs::compute_drainage_area(drainage_area, stack, receivers, dx, dy);
+}
+
+
+template<class K, class T>
+index_t erode_stream_power_py(xt::pyarray<T>& erosion,
+                              const xt::pyarray<T>& elevation,
+                              const xt::pytensor<index_t, 1>& stack,
+                              const xt::pytensor<index_t, 1>& receivers,
+                              const xt::pytensor<T, 1>& dist2receivers,
+                              const xt::pyarray<T>& drainage_area,
+                              const K k_coef,
+                              double m_exp,
+                              double n_exp,
+                              double dt,
+                              double tolerance)
+{
+    py::gil_scoped_release release;
+    return fs::erode_stream_power(erosion, elevation,
+                                  stack, receivers,
+                                  dist2receivers, drainage_area,
+                                  k_coef, m_exp, n_exp,
+                                  dt, tolerance);
+}
+
+
+template<class K, class T>
+void erode_linear_diffusion_py(xt::pytensor<T, 2>& erosion,
+                               const xt::pytensor<T, 2>& elevation,
+                               const K k_coef,
+                               double dt,
+                               double dx,
+                               double dy)
+{
+    py::gil_scoped_release release;
+    fs::erode_linear_diffusion(erosion, elevation, k_coef, dt, dx, dy);
+}
+
+void add_modelings_bindings(py::module& m)
+{
+    m.def("compute_receivers_d8_d", &compute_receivers_d8_py<double>,
+          "Compute D8 flow receivers, a single receiver for each grid node.");
+
+    m.def("compute_donors", &compute_donors_py,
+          "Compute flow donors (invert flow receivers).");
+
+    m.def("compute_stack", &compute_stack_py,
+          "Build a stack of grid node ids such that each node in the stack "
+          "is visited before any of its upstream nodes.");
+
+    m.def("compute_basins", &compute_basins_py,
+          "Compute basin ids. Return total number of basins");
+
+    m.def("find_pits", &find_pits_py,
+          "Find pit node ids. Return total number of pit nodes");
+
+    m.def("compute_drainage_area_mesh_d",
+          &compute_drainage_area_mesh_py<double>,
+          "Compute drainage area on a mesh.");
+
+    m.def("compute_drainage_area_grid_d",
+          &compute_drainage_area_grid_py<double>,
+          "Compute drainage area on a 2D grid.");
+
+    m.def("fill_sinks_flat_d", &fill_sinks_flat_py<double>,
+          "Fill depressions in elevation data (flat surfaces).");
+
+    m.def("fill_sinks_sloped_d", &fill_sinks_sloped_py<double>,
+          "Fill depressions in elevation data (slightly sloped surfaces).");
+
+    m.def("erode_stream_power_d", &erode_stream_power_py<double, double>,
+          "Compute bedrock channel erosion during a single time step "
+          "using the Stream Power Law.");
+
+    m.def("erode_stream_power_var_d", &erode_stream_power_py<xt::pyarray<double>&, double>,
+          "Compute bedrock channel erosion during a single time step "
+          "using the Stream Power Law.\n\n"
+          "Version with spatially variable stream power coefficient.");
+
+    m.def("erode_linear_diffusion_d", &erode_linear_diffusion_py<double, double>,
+          "Compute hillslope erosion by linear diffusion on a 2-d regular "
+          "grid using finite differences with an Alternating Direction"
+          "Implicit (ADI) scheme.");
+
+    m.def("erode_linear_diffusion_var_d",
+          &erode_linear_diffusion_py<xt::pytensor<double, 2>&, double>,
+          "Compute hillslope erosion by linear diffusion on a 2-d regular "
+          "grid using finite differences with an Alternating Direction"
+          "Implicit (ADI) scheme.\n\n"
+          "Version with spatially variable diffusion coefficient.");
+}
+ 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,22 +80,30 @@ endif()
 # =====
 
 set(FASTSCAPELIB_TEST_SRC
-    main.cpp
     test_hillslope.cpp
     test_flow_routing.cpp
+    test_profile_grid.cpp
     test_sinks.cpp
     test_bedrock_channel.cpp
 )
 
 set(FASTSCAPELIB_TEST_TARGET test_fastscapelib)
 
-add_executable(${FASTSCAPELIB_TEST_TARGET} ${FASTSCAPELIB_TEST_SRC})
+# -- build a target for each benchmark
+foreach(filename IN LISTS FASTSCAPELIB_TEST_SRC)
+    string(REPLACE ".cpp" "" targetname ${filename})
+    add_executable(${targetname} ${filename} main.cpp)
+    target_link_libraries(${targetname} PRIVATE fastscapelib ${GTEST_BOTH_LIBRARIES})
+endforeach()
+
+# -- build a global target for all benchmarks
+add_executable(${FASTSCAPELIB_TEST_TARGET} ${FASTSCAPELIB_TEST_SRC} main.cpp)
 
 if(DOWNLOAD_GTEST OR GTEST_SRC_DIR)
     add_dependencies(${FASTSCAPELIB_TEST_TARGET} gtest_main)
 endif()
 
-target_link_libraries(${FASTSCAPELIB_TEST_TARGET} PUBLIC
+target_link_libraries(${FASTSCAPELIB_TEST_TARGET} PRIVATE
                       fastscapelib ${GTEST_BOTH_LIBRARIES})
 
 target_compile_features(${FASTSCAPELIB_TEST_TARGET} INTERFACE cxx_std_14)

--- a/test/test_profile_grid.cpp
+++ b/test/test_profile_grid.cpp
@@ -1,0 +1,167 @@
+#include "fastscapelib/profile_grid.hpp"
+
+#include "gtest/gtest.h"
+
+
+namespace fs = fastscapelib;
+
+
+namespace fastscapelib
+{
+    namespace testing
+    {
+
+        class neighbor: public ::testing::Test
+        {
+            protected:
+
+                fs::neighbor n {3, 1.35, fs::node_status::core};
+        };
+
+        TEST_F(neighbor, ctor)
+        {
+            EXPECT_EQ(n.idx, 3);
+            EXPECT_EQ(n.distance, 1.35);
+            EXPECT_EQ(n.status, fs::node_status::core);
+        }
+
+        TEST_F(neighbor, equal)
+        {
+            fs::neighbor other_n {3, 1.35, fs::node_status::core};
+            EXPECT_EQ(n, other_n);
+        }
+
+
+        class profile_boundary_status: public ::testing::Test
+        {
+            protected:
+
+                using node_s = fs::node_status;
+
+                node_s fixed = node_s::fixed_value_boundary;
+                std::array<node_s, 2> loop {node_s::looped_boundary, node_s::looped_boundary};
+                std::array<node_s, 2> hill_formed_loop {node_s::looped_boundary, node_s::fixed_value_boundary};
+
+                fs::profile_boundary_status fixed_value_status {fixed};
+                fs::profile_boundary_status looped_status {loop};
+                
+        };
+
+        TEST_F(profile_boundary_status, ctor)
+        {
+            EXPECT_EQ(fixed_value_status.left, fixed);
+            EXPECT_EQ(fixed_value_status.right, fixed);
+
+            EXPECT_EQ(looped_status.left, node_s::looped_boundary);
+            EXPECT_EQ(looped_status.right, node_s::looped_boundary);
+
+            EXPECT_THROW(fs::profile_boundary_status {hill_formed_loop}, std::invalid_argument);
+        }
+
+        TEST_F(profile_boundary_status, is_horizontal_looped)
+        {
+            EXPECT_FALSE(fixed_value_status.is_horizontal_looped());
+            EXPECT_TRUE(looped_status.is_horizontal_looped());
+        }
+
+
+        class profile_grid: public ::testing::Test
+        {
+            protected:
+
+                using node_s = fs::node_status;
+
+                node_s fixed = node_s::fixed_value_boundary;
+                std::array<node_s, 2> loop {node_s::looped_boundary, node_s::looped_boundary};
+                std::array<node_s, 2> hill_formed_loop {node_s::looped_boundary, node_s::fixed_value_boundary};
+
+                fs::profile_boundary_status fixed_value_status {fixed};
+                fs::profile_boundary_status looped_status {loop};
+
+                using grid_type = fs::profile_grid_xt<fs::xtensor_selector>;
+                using size_type = typename grid_type::size_type;
+
+                size_type shape {5};
+                grid_type fixed_grid = grid_type(shape, 1.3, fs::node_status::fixed_value_boundary);
+                grid_type looped_grid = grid_type(shape, 1.4, fs::node_status::looped_boundary);
+
+                fs::node_status status_fixed(std::size_t idx)
+                { 
+                    return ((idx == 0) || (idx == 4)) ? fs::node_status::fixed_value_boundary : fs::node_status::core; 
+                };
+
+                fs::node_status status_looped(std::size_t idx)
+                { 
+                    return ((idx == 0) || (idx == 4)) ? fs::node_status::looped_boundary : fs::node_status::core; 
+                };
+        };
+
+        TEST_F(profile_grid, boundary_status)
+        {
+            fs::profile_boundary_status looped_status {node_s::looped_boundary, node_s::looped_boundary};
+            ASSERT_THROW(fs::profile_boundary_status status {hill_formed_loop}, std::invalid_argument);
+
+            EXPECT_FALSE(fixed_value_status.is_horizontal_looped());
+            EXPECT_TRUE(looped_status.is_horizontal_looped());
+        }
+
+        TEST_F(profile_grid, ctor)
+        {
+            std::vector<fs::node> nodes_vector1 {fs::node({1, fs::node_status::fixed_value_boundary})};
+            grid_type g1(shape, 1.3, fs::node_status::looped_boundary, nodes_vector1);
+
+            auto expected_status = grid_type::node_status_type {fs::node_status::looped_boundary, 
+                                                                fs::node_status::fixed_value_boundary, 
+                                                                fs::node_status::core, 
+                                                                fs::node_status::core, 
+                                                                fs::node_status::looped_boundary};
+            ASSERT_EQ(g1.status_at_nodes(), expected_status);
+
+            std::vector<fs::node> nodes_vector2 {fs::node({15, fs::node_status::core})};
+            ASSERT_THROW(grid_type(shape, 1.3, fs::node_status::fixed_value_boundary, nodes_vector2), std::out_of_range);
+
+            std::vector<fs::node> nodes_vector3 {fs::node({0, fs::node_status::core})};
+            ASSERT_THROW(grid_type(shape, 1.3, fs::node_status::looped_boundary, nodes_vector3), std::invalid_argument);
+        }
+
+        TEST_F(profile_grid, neighbors__fixed_value_boundary)
+        {
+            EXPECT_EQ(fixed_grid.neighbors(0), (std::vector<fs::neighbor> {{1, 1.3, fs::node_status::core}}));
+
+            for(std::size_t i=1; i<4; ++i)
+            {
+                EXPECT_EQ(fixed_grid.neighbors(i), (std::vector<fs::neighbor> {{i-1, 1.3, status_fixed(i-1)},
+                                                                               {i+1, 1.3, status_fixed(i+1)}}));
+            }
+
+            EXPECT_EQ(fixed_grid.neighbors(4), (std::vector<fs::neighbor> {{3, 1.3, fs::node_status::core}}));
+        }
+
+        TEST_F(profile_grid, neighbors__looped_boundary)
+        {
+            EXPECT_EQ(looped_grid.neighbors(0), (std::vector<fs::neighbor> {{4, 1.4, fs::node_status::looped_boundary},
+                                                                            {1, 1.4, fs::node_status::core}}));
+
+            for(std::size_t i=1; i<4; ++i)
+            {
+                EXPECT_EQ(looped_grid.neighbors(i), (std::vector<fs::neighbor> {{i-1, 1.4, status_looped(i-1)},
+                                                                               {i+1, 1.4, status_looped(i+1)}}));
+            }
+
+            EXPECT_EQ(looped_grid.neighbors(4), (std::vector<fs::neighbor> {{3, 1.4, fs::node_status::core},
+                                                                            {0, 1.4, fs::node_status::looped_boundary}}));
+        }
+
+        TEST_F(profile_grid, spacing)
+        {
+            EXPECT_EQ(fixed_grid.spacing(), 1.3);
+            EXPECT_EQ(looped_grid.spacing(), 1.4);
+        }
+
+        TEST_F(profile_grid, size)
+        {
+            EXPECT_EQ(fixed_grid.size(), 5);
+            EXPECT_EQ(looped_grid.size(), 5);
+        }
+    }
+}


### PR DESCRIPTION
Description
--

Add an interface structured grid and a first implementation named `profile_grid` which is a 1D grid.
This PR is broadly inspired by #42 .

Details:
- add interface for structured grid 
- add profile (1D) grid
- add python bindings using `pybind11`
- add tests (`googletest` and `pytest`) and benchmarks (`google/benchmark`)
- generate cmake targets for each test and benchmark to use development

This PR needs to be rebased after #49 merging.