### PR TITLE
Grid caching

### DIFF
--- a/benchmark/benchmark_profile_grid.cpp
+++ b/benchmark/benchmark_profile_grid.cpp
@@ -51,33 +51,6 @@ namespace fastscapelib
         }
 
         template <class XT>
-        void profile_grid__neighbors_iterate(benchmark::State& state)
-        {
-            using grid_type = fs::profile_grid_xt<XT>;
-            using size_type = typename grid_type::size_type;
-
-            auto size = static_cast<size_type>(state.range(0));
-            auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
-
-            for (auto _ : state)
-            {
-                for (size_type idx = 0; idx < size; ++idx)
-                {
-                    for (auto neighbor : grid.neighbors(idx))
-                    {
-                        auto idx = neighbor.idx;
-                        auto distance = neighbor.distance;
-                        auto status = neighbor.status;
-
-                        benchmark::DoNotOptimize(idx);
-                        benchmark::DoNotOptimize(distance);
-                        benchmark::DoNotOptimize(status);
-                    }
-                }
-            }
-        }
-
-        template <class XT>
         void profile_grid__spacing(benchmark::State& state)
         {
             using grid_type = fs::profile_grid_xt<XT>;
@@ -113,9 +86,6 @@ namespace fastscapelib
         ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
 
         BENCHMARK_TEMPLATE(profile_grid__neighbors, fs::xtensor_selector)
-        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
-
-        BENCHMARK_TEMPLATE(profile_grid__neighbors_iterate, fs::xtensor_selector)
         ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
 
         BENCHMARK_TEMPLATE(profile_grid__spacing, fs::xtensor_selector)

--- a/python/fastscapelib/tests/test_profile_grid.py
+++ b/python/fastscapelib/tests/test_profile_grid.py
@@ -94,10 +94,10 @@ class TestProfileGrid():
     def test_status_at_nodes(self):
         npt.assert_equal(self.g.status_at_nodes, np.array([1, 0, 0, 0, 0, 1, 0, 0, 0, 1]))
 
-    def test_neighbors(self):
-        assert self.g.neighbors(0) == [Neighbor(1, 2.2, NodeStatus.CORE)]
-        assert self.g.neighbors(1) == [Neighbor(0, 2.2, NodeStatus.FIXED_VALUE_BOUNDARY), Neighbor(2, 2.2, NodeStatus.CORE)]
-        assert self.g.neighbors(6) == [Neighbor(5, 2.2, NodeStatus.FIXED_VALUE_BOUNDARY), Neighbor(7, 2.2, NodeStatus.CORE)]
-        
-        with pytest.raises(IndexError):
-            self.g.neighbors(11)
+#    def test_neighbors(self):
+#        assert self.g.neighbors(0) == [Neighbor(1, 2.2, NodeStatus.CORE)]
+#        assert self.g.neighbors(1) == [Neighbor(0, 2.2, NodeStatus.FIXED_VALUE_BOUNDARY), Neighbor(2, 2.2, NodeStatus.CORE)]
+#        assert self.g.neighbors(6) == [Neighbor(5, 2.2, NodeStatus.FIXED_VALUE_BOUNDARY), Neighbor(7, 2.2, NodeStatus.CORE)]
+#        
+#        with pytest.raises(IndexError):
+#            self.g.neighbors(11)

--- a/python/src/grid.cpp
+++ b/python/src/grid.cpp
@@ -68,7 +68,7 @@ void add_grid_bindings(py::module& m) {
     pgrid.def_property_readonly("size", [](const profile_grid& g) { return g.size(); })
          .def_property_readonly("spacing", [](const profile_grid& g) { return g.spacing(); })
          .def_property_readonly("status_at_nodes", [](const profile_grid& g) { return g.status_at_nodes(); })
-         .def("neighbors", [](const profile_grid& g, std::size_t idx) { return g.neighbors(idx); });
+         .def("neighbors", [](profile_grid& g, std::size_t idx) { return g.neighbors(idx); });
 
     // ==== Binding of the raster_node structure ==== //
     py::class_<raster_node> (grid_m, "RasterNode")

--- a/test/test_profile_grid.cpp
+++ b/test/test_profile_grid.cpp
@@ -126,30 +126,44 @@ namespace fastscapelib
 
         TEST_F(profile_grid, neighbors__fixed_value_boundary)
         {
-            EXPECT_EQ(fixed_grid.neighbors(0), (std::vector<fs::neighbor> {{1, 1.3, fs::node_status::core}}));
+            EXPECT_EQ(fixed_grid.neighbors_cache().used(), 0);
+            EXPECT_EQ(fixed_grid.neighbors_cache().size(), 5);
+
+            EXPECT_EQ(fixed_grid.neighbors(0), 
+                     (xt::xtensor<fs::neighbor, 1> { {1, 1.3, fs::node_status::core} } ));
 
             for(std::size_t i=1; i<4; ++i)
             {
-                EXPECT_EQ(fixed_grid.neighbors(i), (std::vector<fs::neighbor> {{i-1, 1.3, status_fixed(i-1)},
-                                                                               {i+1, 1.3, status_fixed(i+1)}}));
+                EXPECT_EQ(fixed_grid.neighbors_cache().used(), i);
+                EXPECT_EQ(fixed_grid.neighbors(i),
+                          (xt::xtensor<fs::neighbor, 1> { {i-1, 1.3, status_fixed(i-1)},
+                                                          {i+1, 1.3, status_fixed(i+1)} } ));
             }
+            EXPECT_EQ(fixed_grid.neighbors_cache().used(), 4);
 
-            EXPECT_EQ(fixed_grid.neighbors(4), (std::vector<fs::neighbor> {{3, 1.3, fs::node_status::core}}));
+            EXPECT_EQ(fixed_grid.neighbors(4),
+                      (xt::xtensor<fs::neighbor, 1> { {3, 1.3, fs::node_status::core} } ));
+            EXPECT_EQ(fixed_grid.neighbors_cache().used(), 5);
         }
 
         TEST_F(profile_grid, neighbors__looped_boundary)
         {
-            EXPECT_EQ(looped_grid.neighbors(0), (std::vector<fs::neighbor> {{4, 1.4, fs::node_status::looped_boundary},
-                                                                            {1, 1.4, fs::node_status::core}}));
+            EXPECT_EQ(looped_grid.neighbors_cache().used(), 0);
+            EXPECT_EQ(looped_grid.neighbors_cache().size(), 5);
+
+            EXPECT_EQ(looped_grid.neighbors(0), (xt::xtensor<fs::neighbor, 1> {{4, 1.4, fs::node_status::looped_boundary},
+                                                                               {1, 1.4, fs::node_status::core}}));
 
             for(std::size_t i=1; i<4; ++i)
             {
-                EXPECT_EQ(looped_grid.neighbors(i), (std::vector<fs::neighbor> {{i-1, 1.4, status_looped(i-1)},
-                                                                               {i+1, 1.4, status_looped(i+1)}}));
+                EXPECT_EQ(looped_grid.neighbors_cache().used(), i);
+                EXPECT_EQ(looped_grid.neighbors(i), (xt::xtensor<fs::neighbor, 1> {{i-1, 1.4, status_looped(i-1)},
+                                                                                   {i+1, 1.4, status_looped(i+1)}}));
             }
-
-            EXPECT_EQ(looped_grid.neighbors(4), (std::vector<fs::neighbor> {{3, 1.4, fs::node_status::core},
-                                                                            {0, 1.4, fs::node_status::looped_boundary}}));
+            EXPECT_EQ(looped_grid.neighbors_cache().used(), 4);
+            EXPECT_EQ(looped_grid.neighbors(4), (xt::xtensor<fs::neighbor, 1> {{3, 1.4, fs::node_status::core},
+                                                                               {0, 1.4, fs::node_status::looped_boundary}}));
+            EXPECT_EQ(looped_grid.neighbors_cache().used(), 5);
         }
 
         TEST_F(profile_grid, spacing)

--- a/test/test_raster_grid.cpp
+++ b/test/test_raster_grid.cpp
@@ -13,28 +13,6 @@ namespace fastscapelib
     namespace testing
     {
 
-        class raster_neighbor: public ::testing::Test
-        {
-            protected:
-
-                fs::raster_neighbor n {3, 1, 6, 1.35, fs::node_status::core};
-        };
-
-        TEST_F(raster_neighbor, ctor)
-        {
-            EXPECT_EQ(n.flatten_idx, 3);
-            EXPECT_EQ(n.row, 1);
-            EXPECT_EQ(n.col, 6);
-            EXPECT_EQ(n.distance, 1.35);
-            EXPECT_EQ(n.status, fs::node_status::core);
-        }
-
-        TEST_F(raster_neighbor, equal)
-        {
-            fs::raster_neighbor other_n {3, 1, 6, 1.35, fs::node_status::core};
-            EXPECT_EQ(n, other_n);
-        }
-
        class raster_boundary_status: public ::testing::Test
         {
             protected:
@@ -114,8 +92,10 @@ namespace fastscapelib
                 using size_type = typename grid_type::size_type;
 
                 std::array<size_type, 2> shape {{5, 10}};
-                grid_type fixed_grid = grid_type(shape, {1.3, 1.2}, fs::node_status::fixed_value_boundary);
-                grid_type looped_grid = grid_type(shape, {1.4, 1.8}, fs::node_status::looped_boundary);
+                grid_type fixed_grid = grid_type(shape, {1.3, 1.2}, fixed_value_status);
+                grid_type hlooped_grid = grid_type(shape, {1.3, 1.2}, hlooped_status);
+                grid_type vlooped_grid = grid_type(shape, {1.3, 1.2}, vlooped_status);
+                grid_type looped_grid = grid_type(shape, {1.4, 1.8}, hvlooped_status);
 
                 fs::node_status status_fixed(std::size_t row, std::size_t col)
                 { 
@@ -150,76 +130,94 @@ namespace fastscapelib
         {
             { // First row
                 // Top-left corner
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(0, 0)), (grid_type::neighbor_indices_type { /*(r,c)*/ { 0, 1 }, 
-                                                                                                                              { 1, 0 }, { 1, 1 } }));
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(0, 0)), (grid_type::neighbor_indices_type { /*(r,c)*/ { 0, 1 }, 
-                                                                                                                              { 1, 0 }          }));                                                                                                                              
+                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(0, 0)),
+                          (grid_type::neighbors_indices_raster_type { /*(r,c)*/ { 0, 1 }, 
+                                                                      { 1, 0 }, { 1, 1 } }));
+                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(0, 0)),
+                          (grid_type::neighbors_indices_raster_type { /*(r,c)*/ { 0, 1 }, 
+                                                                      { 1, 0 }           }));                                                                                                                              
                 // Inner cols
                 for(std::size_t c=1; c<9; ++c)
                 {
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(0, c)), (grid_type::neighbor_indices_type { { 0, c-1 }, /*(r,c)*/ { 0, c+1 }, 
-                                                                                                                                  { 1, c-1 }, { 1, c }, { 1, c+1 } }));
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(0, c)), (grid_type::neighbor_indices_type { { 0, c-1 }, /*(r,c)*/ { 0, c+1 }, 
-                                                                                                                                             { 1, c },            }));
+                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(0, c)),
+                              (grid_type::neighbors_indices_raster_type { { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
+                                                                          { 1, c-1 }, { 1, c }, { 1, c+1 } }));
+                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(0, c)),
+                              (grid_type::neighbors_indices_raster_type { { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
+                                                                                      { 1, c },            }));
                 }
 
                 // Top-right corner
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(0, 9)), (grid_type::neighbor_indices_type { { 0, 8 }, /*(r,c)*/
-                                                                                                                              { 1, 8 }, { 1, 9 } }));
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(0, 9)), (grid_type::neighbor_indices_type { { 0, 8 }, /*(r,c)*/
-                                                                                                                                       { 1, 9 } }));
+                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(0, 9)),
+                          (grid_type::neighbors_indices_raster_type { { 0, 8 }, /*(r,c)*/
+                                                                      { 1, 8 }, { 1, 9 } }));
+                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(0, 9)),
+                          (grid_type::neighbors_indices_raster_type { { 0, 8 }, /*(r,c)*/
+                                                                                { 1, 9 } }));
             }
             { // Inners rows
                 for(std::size_t r=1; r<4; ++r)
                 {
                     // First col
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(r, 0)), (grid_type::neighbor_indices_type { { r-1, 0 }, { r-1, 1 },
-                                                                                                                                   /*(r,c)*/  { r,   1 },
-                                                                                                                                  { r+1, 0 }, { r+1, 1 } }));
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(r, 0)), (grid_type::neighbor_indices_type { { r-1, 0 },
-                                                                                                                                  /*(r,c)*/  { r,   1 },
-                                                                                                                                 { r+1, 0 }             }));                                                                                                                                  
+                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(r, 0)),
+                              (grid_type::neighbors_indices_raster_type { { r-1, 0 }, { r-1, 1 },
+                                                                           /*(r,c)*/  { r,   1 },
+                                                                          { r+1, 0 }, { r+1, 1 } }));
+                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(r, 0)),
+                              (grid_type::neighbors_indices_raster_type { { r-1, 0 },
+                                                                           /*(r,c)*/  { r, 1 },
+                                                                          { r+1, 0 }           }));                                                                                                                                  
                     // Inners cols
                     for(std::size_t c=1; c<9; ++c)
                     {
-                        EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(r, c)), (grid_type::neighbor_indices_type { { r-1, c-1 }, { r-1, c }, { r-1, c+1 },
-                                                                                                                                      { r,   c-1 },  /*(r,c)*/  { r,   c+1 },
-                                                                                                                                      { r+1, c-1 }, { r+1, c }, { r+1, c+1 } }));
-                        EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(r, c)), (grid_type::neighbor_indices_type {               { r-1, c },
-                                                                                                                                     { r,   c-1 },  /*(r,c)*/  { r,   c+1 },
-                                                                                                                                                   { r+1, c },              }));
+                        EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(r, c)),
+                                  (grid_type::neighbors_indices_raster_type { { r-1, c-1 }, { r-1, c }, { r-1, c+1 },
+                                                                              { r,   c-1 },  /*(r,c)*/  { r,   c+1 },
+                                                                              { r+1, c-1 }, { r+1, c }, { r+1, c+1 } }));
+                        EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(r, c)),
+                                  (grid_type::neighbors_indices_raster_type {            { r-1, c },
+                                                                             { r, c-1 },  /*(r,c)*/  { r, c+1 },
+                                                                                         { r+1, c },            }));
                     }
 
                     // last col
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(r, 9)), (grid_type::neighbor_indices_type { { r-1, 8 }, { r-1, 9 },
-                                                                                                                                  { r,   8 },  /*(r,c)*/
-                                                                                                                                  { r+1, 8 }, { r+1, 9 } }));
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(r, 9)), (grid_type::neighbor_indices_type {             { r-1, 9 }, 
-                                                                                                                                 { r,   8 },  /*(r,c)*/
-                                                                                                                                             { r+1, 9 } }));
+                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(r, 9)),
+                              (grid_type::neighbors_indices_raster_type { { r-1, 8 }, { r-1, 9 },
+                                                                          { r,   8 },  /*(r,c)*/
+                                                                          { r+1, 8 }, { r+1, 9 } }));
+                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(r, 9)),
+                              (grid_type::neighbors_indices_raster_type {             { r-1, 9 }, 
+                                                                          { r,   8 },  /*(r,c)*/
+                                                                                      { r+1, 9 } }));
                 }
             }
 
             { // Last row
                 // Bottom-left corner
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(4, 0)), (grid_type::neighbor_indices_type { { 3, 0 }, { 3, 1 },
-                                                                                                                              /*(r,c)*/ { 4, 1 } }));
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(4, 0)), (grid_type::neighbor_indices_type { { 3, 0 },
-                                                                                                                             /*(r,c)*/ { 4, 1 } }));
+                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(4, 0)),
+                          (grid_type::neighbors_indices_raster_type { { 3, 0 }, { 3, 1 },
+                                                                      /*(r,c)*/ { 4, 1 } }));
+                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(4, 0)),
+                          (grid_type::neighbors_indices_raster_type { { 3, 0 },
+                                                                      /*(r,c)*/ { 4, 1 } }));
                 // Inner cols
                 for(std::size_t c=1; c<9; ++c)
                 {
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(4, c)), (grid_type::neighbor_indices_type { { 3, c-1 }, { 3, c }, { 3, c+1 },
-                                                                                                                                  { 4, c-1 }, /*(r,c)*/ { 4, c+1 } }));
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(4, c)), (grid_type::neighbor_indices_type {             { 3, c },
-                                                                                                                                 { 4, c-1 }, /*(r,c)*/ { 4, c+1 } }));                                                                                                                                  
+                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(4, c)),
+                              (grid_type::neighbors_indices_raster_type { { 3, c-1 }, { 3, c }, { 3, c+1 },
+                                                                          { 4, c-1 }, /*(r,c)*/ { 4, c+1 } }));
+                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(4, c)),
+                              (grid_type::neighbors_indices_raster_type {             { 3, c },
+                                                                          { 4, c-1 }, /*(r,c)*/ { 4, c+1 } }));                                                                                                                                  
                 }
 
                 // Bottom-right corner
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(4, 9)), (grid_type::neighbor_indices_type { { 3, 8 }, { 3, 9 },
-                                                                                                                              { 4, 8 }  /*(r,c)*/ }));
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(4, 9)), (grid_type::neighbor_indices_type {          { 3, 9 },
-                                                                                                                             { 4, 8 } /*(r,c)*/ }));
+                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(4, 9)),
+                          (grid_type::neighbors_indices_raster_type { { 3, 8 }, { 3, 9 },
+                                                                      { 4, 8 }  /*(r,c)*/ }));
+                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(4, 9)),
+                          (grid_type::neighbors_indices_raster_type {          { 3, 9 },
+                                                                      { 4, 8 } /*(r,c)*/ }));
             }
         }
 
@@ -227,85 +225,145 @@ namespace fastscapelib
         {
             { // First row
                 // Top-left corner
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(0, 0)), (grid_type::neighbor_indices_type { { 4, 9 }, { 4, 0 }, { 4, 1 },
-                                                                                                                               { 0, 9 }, /*(r,c)*/ { 0, 1 },
-                                                                                                                               { 1, 9 }, { 1, 0 }, { 1, 1 } }));
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(0, 0)), (grid_type::neighbor_indices_type {           { 4, 0 },
-                                                                                                                              { 0, 9 }, /*(r,c)*/ { 0, 1 },
-                                                                                                                                        { 1, 0 }            }));
+                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(0, 0)),
+                          (grid_type::neighbors_indices_raster_type { { 4, 9 }, { 4, 0 }, { 4, 1 },
+                                                                      { 0, 9 }, /*(r,c)*/ { 0, 1 },
+                                                                      { 1, 9 }, { 1, 0 }, { 1, 1 } }));
+                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(0, 0)),
+                          (grid_type::neighbors_indices_raster_type {           { 4, 0 },
+                                                                      { 0, 9 }, /*(r,c)*/ { 0, 1 },
+                                                                                { 1, 0 }           }));
                 // Inner cols
                 for(std::size_t c=1; c<9; ++c)
                 {
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(0, c)), (grid_type::neighbor_indices_type { { 4, c-1 }, { 4, c }, { 4, c+1 },
-                                                                                                                                   { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
-                                                                                                                                   { 1, c-1 }, { 1, c }, { 1, c+1 } }));
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(0, c)), (grid_type::neighbor_indices_type {             { 4, c },
-                                                                                                                                  { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
-                                                                                                                                              { 1, c }              }));
+                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(0, c)),
+                              (grid_type::neighbors_indices_raster_type { { 4, c-1 }, { 4, c }, { 4, c+1 },
+                                                                          { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
+                                                                          { 1, c-1 }, { 1, c }, { 1, c+1 } }));
+                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(0, c)),
+                              (grid_type::neighbors_indices_raster_type {             { 4, c },
+                                                                          { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
+                                                                                      { 1, c }             }));
                 }
                 // Top-right corner
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(0, 9)), (grid_type::neighbor_indices_type { { 4, 8 }, { 4, 9 }, { 4, 0 },
-                                                                                                                               { 0, 8 }, /*(r,c)*/ { 0, 0 },
-                                                                                                                               { 1, 8 }, { 1, 9 }, { 1, 0 } }));
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(0, 9)), (grid_type::neighbor_indices_type {            { 4, 9 },
-                                                                                                                               { 0, 8 }, /*(r,c)*/ { 0, 0 },
-                                                                                                                                         { 1, 9 }            }));
+                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(0, 9)),
+                          (grid_type::neighbors_indices_raster_type { { 4, 8 }, { 4, 9 }, { 4, 0 },
+                                                                      { 0, 8 }, /*(r,c)*/ { 0, 0 },
+                                                                      { 1, 8 }, { 1, 9 }, { 1, 0 } }));
+                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(0, 9)),
+                          (grid_type::neighbors_indices_raster_type {            { 4, 9 },
+                                                                      { 0, 8 }, /*(r,c)*/ { 0, 0 },
+                                                                                 { 1, 9 }          }));
             }
             { // Inners rows
                 for(std::size_t r=1; r<4; ++r)
                 {
                     // First col
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(r, 0)), (grid_type::neighbor_indices_type { { r-1, 9 }, { r-1, 0 }, { r-1, 1 },
-                                                                                                                                   { r,   9 },  /*(r,c)*/  { r,   1 },
-                                                                                                                                   { r+1, 9 }, { r+1, 0 }, { r+1, 1 } }));
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(r, 0)), (grid_type::neighbor_indices_type {             { r-1, 0 },
-                                                                                                                                  { r,   9 },  /*(r,c)*/  { r,   1 },
-                                                                                                                                              { r+1, 0 }             }));
+                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(r, 0)),
+                              (grid_type::neighbors_indices_raster_type { { r-1, 9 }, { r-1, 0 }, { r-1, 1 },
+                                                                          { r,   9 },  /*(r,c)*/  { r,   1 },
+                                                                          { r+1, 9 }, { r+1, 0 }, { r+1, 1 } }));
+                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(r, 0)),
+                              (grid_type::neighbors_indices_raster_type {           { r-1, 0 },
+                                                                          { r, 9 },  /*(r,c)*/  { r, 1 },
+                                                                                    { r+1, 0 }           }));
                     // Inners cols
                     for(std::size_t c=1; c<9; ++c)
                     {
-                        EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(r, c)), (grid_type::neighbor_indices_type { { r-1, c-1 }, { r-1, c }, { r-1, c+1 },
-                                                                                                                                       { r,   c-1 },  /*(r,c)*/  { r,   c+1 },
-                                                                                                                                       { r+1, c-1 }, { r+1, c }, { r+1, c+1 } }));
-                        EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(r, c)), (grid_type::neighbor_indices_type {               { r-1, c },
-                                                                                                                                      { r,   c-1 },  /*(r,c)*/ { r,   c+1 },
-                                                                                                                                                    { r+1, c }               }));
+                        EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(r, c)),
+                                  (grid_type::neighbors_indices_raster_type { { r-1, c-1 }, { r-1, c }, { r-1, c+1 },
+                                                                              { r,   c-1 },  /*(r,c)*/  { r,   c+1 },
+                                                                              { r+1, c-1 }, { r+1, c }, { r+1, c+1 } }));
+                        EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(r, c)),
+                                  (grid_type::neighbors_indices_raster_type {               { r-1, c },
+                                                                              { r,   c-1 },  /*(r,c)*/ { r,   c+1 },
+                                                                                            { r+1, c }              }));
                     }
                     // last col
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(r, 9)), (grid_type::neighbor_indices_type { { r-1, 8 }, { r-1, 9 }, { r-1, 0 },
-                                                                                                                                   { r,   8 },  /*(r,c)*/ { r,   0 },
-                                                                                                                                   { r+1, 8 }, { r+1, 9 }, { r+1, 0 } }));
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(r, 9)), (grid_type::neighbor_indices_type {             { r-1, 9 },
-                                                                                                                                  { r,   8 },  /*(r,c)*/  { r,   0 },
-                                                                                                                                              { r+1, 9 }              }));
+                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(r, 9)),
+                              (grid_type::neighbors_indices_raster_type { { r-1, 8 }, { r-1, 9 }, { r-1, 0 },
+                                                                          { r,   8 },  /*(r,c)*/  { r,   0 },
+                                                                          { r+1, 8 }, { r+1, 9 }, { r+1, 0 } }));
+                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(r, 9)),
+                              (grid_type::neighbors_indices_raster_type {             { r-1, 9 },
+                                                                          { r,   8 },  /*(r,c)*/  { r,   0 },
+                                                                                      { r+1, 9 }             }));
                 }
             }
 
             { // Last row 
                 // Bottom-left corner
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(4, 0)), (grid_type::neighbor_indices_type { { 3, 9 }, { 3, 0 }, { 3, 1 },
-                                                                                                                               { 4, 9 }, /*(r,c)*/ { 4, 1 },
-                                                                                                                               { 0, 9 }, { 0, 0 }, { 0, 1 } }));
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(4, 0)), (grid_type::neighbor_indices_type {           { 3, 0 },
-                                                                                                                              { 4, 9 }, /*(r,c)*/ { 4, 1 },
-                                                                                                                                        { 0, 0 }            }));
+                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(4, 0)),
+                (grid_type::neighbors_indices_raster_type { { 3, 9 }, { 3, 0 }, { 3, 1 },
+                                                            { 4, 9 }, /*(r,c)*/ { 4, 1 },
+                                                            { 0, 9 }, { 0, 0 }, { 0, 1 } }));
+                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(4, 0)),
+                (grid_type::neighbors_indices_raster_type {           { 3, 0 },
+                                                            { 4, 9 }, /*(r,c)*/ { 4, 1 },
+                                                                      { 0, 0 }           }));
                 // Inner cols
                 for(std::size_t c=1; c<9; ++c)
                 {
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(4, c)), (grid_type::neighbor_indices_type { { 3, c-1 }, { 3, c }, { 3, c+1 },
-                                                                                                                                   { 4, c-1 }, /*(r,c)*/ { 4, c+1 },
-                                                                                                                                   { 0, c-1 }, { 0, c }, { 0, c+1 } }));
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(4, c)), (grid_type::neighbor_indices_type {             { 3, c },
-                                                                                                                                  { 4, c-1 }, /*(r,c)*/ { 4, c+1 },
-                                                                                                                                              { 0, c }              }));
+                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(4, c)),
+                              (grid_type::neighbors_indices_raster_type { { 3, c-1 }, { 3, c }, { 3, c+1 },
+                                                                          { 4, c-1 }, /*(r,c)*/ { 4, c+1 },
+                                                                          { 0, c-1 }, { 0, c }, { 0, c+1 } }));
+                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(4, c)),
+                              (grid_type::neighbors_indices_raster_type {             { 3, c },
+                                                                          { 4, c-1 }, /*(r,c)*/ { 4, c+1 },
+                                                                                      { 0, c }             }));
                 }
                 // Bottom-right corner
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(4, 9)), (grid_type::neighbor_indices_type { { 3, 8 }, { 3, 9 }, { 3, 0 },
-                                                                                                                               { 4, 8 }, /*(r,c)*/ { 4, 0 },
-                                                                                                                               { 0, 8 }, { 0, 9 }, { 0, 0 } }));
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(4, 9)), (grid_type::neighbor_indices_type {           { 3, 9 },
-                                                                                                                              { 4, 8 }, /*(r,c)*/ { 4, 0 },
-                                                                                                                                        { 0, 9 }            }));
+                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(4, 9)),
+                          (grid_type::neighbors_indices_raster_type { { 3, 8 }, { 3, 9 }, { 3, 0 },
+                                                                      { 4, 8 }, /*(r,c)*/ { 4, 0 },
+                                                                      { 0, 8 }, { 0, 9 }, { 0, 0 } }));
+                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(4, 9)),
+                          (grid_type::neighbors_indices_raster_type {           { 3, 9 },
+                                                                      { 4, 8 }, /*(r,c)*/ { 4, 0 },
+                                                                                { 0, 9 }           }));
+            }
+        }
+
+        TEST_F(raster_grid, neighbors__looped_boundary)
+        {
+            using neighbors_type = xt::xtensor<fs::neighbor, 1>;
+
+            double d1 = std::sqrt(1.3*1.3 + 1.2*1.2);
+            double d2 = std::sqrt(1.4*1.4 + 1.8*1.8);
+
+            constexpr node_status fb = node_status::fixed_value_boundary;
+            constexpr node_status lb = node_status::looped_boundary;
+            constexpr node_status co = node_status::core;
+
+            { // First row
+                // Top-left corner
+                EXPECT_EQ(fixed_grid.neighbors(0),
+                          (neighbors_type {   /* Node */   {1, 1.2, fb},
+                                            {10, 1.3, fb}, {11, d1, co} } ));
+
+                EXPECT_EQ(looped_grid.neighbors(0), 
+                          (neighbors_type { {49, d2, lb}, {40, 1.4, lb}, {41, d2, lb},
+                                            {9, 1.8, lb},  /* Node */    {1, 1.8, lb},
+                                            {19, d2, lb}, {10, 1.4, lb}, {11, d2, co} } ));
+
+                // Inner cols
+                for(std::size_t c=2; c<8; ++c)
+                {
+                    EXPECT_EQ(fixed_grid.neighbors(c), 
+                              (neighbors_type { {c-1, 1.2, fb},   /* Node */     {c+1, 1.2, fb},
+                                                {c+9,  d1, co}, {c+10, 1.3, co}, {c+11, d1, co} } ));
+
+                    EXPECT_EQ(looped_grid.neighbors(c), 
+                              (neighbors_type { {c+39, d2, lb}, {c+40, 1.4, lb}, {c+41, d2, lb},
+                                                {c-1, 1.8, lb},    /* Node */    {c+1, 1.8, lb},
+                                                {c+9,  d2, co}, {c+10, 1.4, co}, {c+11, d2, co} } ));
+                }
+
+                EXPECT_EQ(looped_grid.neighbors(22), 
+                          (neighbors_type { {11,  d2, co}, {12, 1.4, co}, {13,  d2, co},
+                                            {21, 1.8, co},   /* Node */   {23, 1.8, co},
+                                            {31,  d2, co}, {32, 1.4, co}, {33,  d2, co} } ));
             }
         }
 
@@ -321,5 +379,124 @@ namespace fastscapelib
             EXPECT_EQ(looped_grid.size(), 50);
         }
 
+        TEST_F(raster_grid, gcode)
+        {
+            // Top-left corner nodes
+            EXPECT_EQ(fixed_grid.gcode(0), 0);
+            EXPECT_EQ(looped_grid.gcode(0), 0);
+            
+            // Top-right corner nodes
+            EXPECT_EQ(fixed_grid.gcode(shape[1]-1), 2);
+            EXPECT_EQ(looped_grid.gcode(shape[1]-1), 2);
+
+            // Bottom-left corner nodes
+            EXPECT_EQ(fixed_grid.gcode((shape[0]-1)*shape[1]), 6);
+            EXPECT_EQ(looped_grid.gcode((shape[0]-1)*shape[1]), 6);
+
+            // Bottom-right corner nodes
+            EXPECT_EQ(fixed_grid.gcode(shape[0]*shape[1]-1), 8);
+            EXPECT_EQ(looped_grid.gcode(shape[0]*shape[1]-1), 8);
+
+            for (std::size_t c=1; c<shape[1]-1; ++c)
+            {   
+                // Top edge nodes (without corners)
+                EXPECT_EQ(fixed_grid.gcode(c), 1);
+                EXPECT_EQ(looped_grid.gcode(c), 1);
+
+                // Bottom edge nodes (without corners)
+                EXPECT_EQ(fixed_grid.gcode((shape[0]-1)*shape[1]+c), 7);
+                EXPECT_EQ(looped_grid.gcode((shape[0]-1)*shape[1]+c), 7);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                // Left edge nodes (without corners)
+                EXPECT_EQ(fixed_grid.gcode(r*shape[1]), 3);
+                EXPECT_EQ(looped_grid.gcode(r*shape[1]), 3);
+
+                // Right edge nodes (without corners)
+                EXPECT_EQ(fixed_grid.gcode((r+1)*shape[1]-1), 5);
+                EXPECT_EQ(looped_grid.gcode((r+1)*shape[1]-1), 5);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                for (std::size_t c=1; c<shape[1]-1; ++c)
+                {
+                    // Inner nodes
+                    EXPECT_EQ(fixed_grid.gcode(r*10+c), 4);
+                    EXPECT_EQ(looped_grid.gcode(r*10+c), 4);
+                }
+            }
+        }
+
+        TEST_F(raster_grid, neighbors_count)
+        {
+            // Top-left corner nodes
+            EXPECT_EQ(fixed_grid.neighbors_count(static_cast<std::size_t>(0)), 3);
+            EXPECT_EQ(hlooped_grid.neighbors_count(static_cast<std::size_t>(0)), 5);
+            EXPECT_EQ(vlooped_grid.neighbors_count(static_cast<std::size_t>(0)), 5);
+            EXPECT_EQ(looped_grid.neighbors_count(static_cast<std::size_t>(0)), 8);
+            
+            // Top-right corner nodes
+            EXPECT_EQ(fixed_grid.neighbors_count(shape[1]-1), 3);
+            EXPECT_EQ(hlooped_grid.neighbors_count(shape[1]-1), 5);
+            EXPECT_EQ(vlooped_grid.neighbors_count(shape[1]-1), 5);
+            EXPECT_EQ(looped_grid.neighbors_count(shape[1]-1), 8);
+
+            // Bottom-left corner nodes
+            EXPECT_EQ(fixed_grid.neighbors_count((shape[0]-1)*shape[1]), 3);
+            EXPECT_EQ(hlooped_grid.neighbors_count((shape[0]-1)*shape[1]), 5);
+            EXPECT_EQ(vlooped_grid.neighbors_count((shape[0]-1)*shape[1]), 5);
+            EXPECT_EQ(looped_grid.neighbors_count((shape[0]-1)*shape[1]), 8);
+
+            // Bottom-right corner nodes
+            EXPECT_EQ(fixed_grid.neighbors_count(shape[0]*shape[1]-1), 3);
+            EXPECT_EQ(hlooped_grid.neighbors_count(shape[0]*shape[1]-1), 5);
+            EXPECT_EQ(vlooped_grid.neighbors_count(shape[0]*shape[1]-1), 5);
+            EXPECT_EQ(looped_grid.neighbors_count(shape[0]*shape[1]-1), 8);
+
+            for (std::size_t c=1; c<shape[1]-1; ++c)
+            {   
+                // Top edge nodes (without corners)
+                EXPECT_EQ(fixed_grid.neighbors_count(c), 5);
+                EXPECT_EQ(hlooped_grid.neighbors_count(c), 5);
+                EXPECT_EQ(vlooped_grid.neighbors_count(c), 8);
+                EXPECT_EQ(looped_grid.neighbors_count(c), 8);
+
+                // Bottom edge nodes (without corners)
+                EXPECT_EQ(fixed_grid.neighbors_count((shape[0]-1)*shape[1]+c), 5);
+                EXPECT_EQ(hlooped_grid.neighbors_count((shape[0]-1)*shape[1]+c), 5);
+                EXPECT_EQ(vlooped_grid.neighbors_count((shape[0]-1)*shape[1]+c), 8);
+                EXPECT_EQ(looped_grid.neighbors_count((shape[0]-1)*shape[1]+c), 8);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                // Left edge nodes (without corners)
+                EXPECT_EQ(fixed_grid.neighbors_count(r*shape[1]), 5);
+                EXPECT_EQ(hlooped_grid.neighbors_count(r*shape[1]), 8);
+                EXPECT_EQ(vlooped_grid.neighbors_count(r*shape[1]), 5);
+                EXPECT_EQ(looped_grid.neighbors_count(r*shape[1]), 8);
+
+                // Right edge nodes (without corners)
+                EXPECT_EQ(fixed_grid.neighbors_count((r+1)*shape[1]-1), 5);
+                EXPECT_EQ(hlooped_grid.neighbors_count((r+1)*shape[1]-1), 8);
+                EXPECT_EQ(vlooped_grid.neighbors_count((r+1)*shape[1]-1), 5);
+                EXPECT_EQ(looped_grid.neighbors_count((r+1)*shape[1]-1), 8);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                for (std::size_t c=1; c<shape[1]-1; ++c)
+                {
+                    // Inner nodes
+                    EXPECT_EQ(fixed_grid.neighbors_count(r*shape[1]+c), 8);
+                    EXPECT_EQ(hlooped_grid.neighbors_count(r*shape[1]+c), 8);
+                    EXPECT_EQ(vlooped_grid.neighbors_count(r*shape[1]+c), 8);
+                    EXPECT_EQ(looped_grid.neighbors_count(r*shape[1]+c), 8);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Add caching of nodes neighbors indices for structured grids.
At this time, the neighbors computation uses caching from both:
- derived classes/grids for the distances and node status (specific implementations)
- base class/grid for indices (generic implementation)

This will allow to iterate efficiently over nodes and their neighbors.
Extract from the benchmarks:
```
Run on (8 X 2304.01 MHz CPU s)
2020-12-28 17:11:57
--------------------------------------------------------------------------------------------------------------------
Benchmark                                                                             Time           CPU Iterations
--------------------------------------------------------------------------------------------------------------------
raster_grid__ctor<fs::xtensor_selector>/256                                           0 ms          0 ms       3387
raster_grid__ctor<fs::xtensor_selector>/512                                           1 ms          1 ms        457
raster_grid__ctor<fs::xtensor_selector>/1024                                          7 ms          7 ms         90
raster_grid__ctor<fs::xtensor_selector>/2048                                         32 ms         30 ms         19
raster_grid__ctor<fs::xtensor_selector>/4096                                        269 ms        265 ms          6
raster_grid__neighbors_cache_warm_up<fs::raster_connect::queen>/256                   1 ms          1 ms       1008
raster_grid__neighbors_cache_warm_up<fs::raster_connect::queen>/512                   3 ms          3 ms        264
raster_grid__neighbors_cache_warm_up<fs::raster_connect::queen>/1024                 10 ms         10 ms         70
raster_grid__neighbors_cache_warm_up<fs::raster_connect::queen>/2048                 40 ms         40 ms         18
raster_grid__neighbors_cache_warm_up<fs::raster_connect::queen>/4096                159 ms        159 ms          4
raster_grid__neighbors<fs::raster_connect::queen>/256                                 1 ms          1 ms        816
raster_grid__neighbors<fs::raster_connect::queen>/512                                 4 ms          3 ms        203
raster_grid__neighbors<fs::raster_connect::queen>/1024                               14 ms         14 ms         50
raster_grid__neighbors<fs::raster_connect::queen>/2048                               52 ms         52 ms         13
raster_grid__neighbors<fs::raster_connect::queen>/4096                              202 ms        202 ms          3
raster_grid__neighbor_classic<fs::raster_connect::queen>/256                          2 ms          2 ms        422
raster_grid__neighbor_classic<fs::raster_connect::queen>/512                          7 ms          7 ms         96
raster_grid__neighbor_classic<fs::raster_connect::queen>/1024                        25 ms         25 ms         27
raster_grid__neighbor_classic<fs::raster_connect::queen>/2048                       101 ms        101 ms          7
raster_grid__neighbor_classic<fs::raster_connect::queen>/4096                       406 ms        406 ms          2
```

At this time, some methods of the raster grid only work with the `queen` raster code.
This implementation will be improved in coming PRs.

Details:
- use fixed size types for efficiency
- add template parameter for cache sizing with max neighbors
- use indices to iterate over nodes
- also use indices to iterate over neighbors (faster than unravel)
- add tests and benchmarks

This PR needs to be rebased after #53 merging.