### PR TITLE
Generic `compute_receivers` flow routing algo

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -124,6 +124,7 @@ set(FASTSCAPELIB_BENCHMARK_SRC
   benchmark_bedrock_channel.cpp
   benchmark_profile_grid.cpp
   benchmark_raster_grid.cpp
+  benchmark_flow_routing.cpp
   benchmark_hillslope.cpp
   benchmark_sinks.cpp
 )

--- a/benchmark/benchmark_flow_routing.cpp
+++ b/benchmark/benchmark_flow_routing.cpp
@@ -1,0 +1,100 @@
+#include "benchmark_setup.hpp"
+
+#include "fastscapelib/consts.hpp"
+#include "fastscapelib/profile_grid.hpp"
+#include "fastscapelib/raster_grid.hpp"
+#include "fastscapelib/flow_routing.hpp"
+
+#include "xtensor/xfixed.hpp"
+#include "xtensor/xtensor.hpp"
+#include "xtensor/xrandom.hpp"
+
+#include <benchmark/benchmark.h>
+
+
+namespace fs = fastscapelib;
+namespace bms = benchmark_setup;
+
+
+namespace fastscapelib
+{
+    namespace bench
+    {
+
+        template <class G>
+        void flow_routing__compute_receivers__profile(benchmark::State& state)
+        {
+            using grid = G;
+            using size_type = typename grid::size_type;
+
+            auto n = static_cast<size_type>(state.range(0));
+            auto profile_grid = grid(n, 1., fs::node_status::fixed_value_boundary);
+
+            xt::xtensor<double, 1> elevation = xt::random::rand<double>({n});
+            xt::xtensor<index_t, 1> receivers = xt::ones<index_t>({n}) * -1;
+            xt::xtensor<double, 1> dist2receivers = xt::ones<double>({n}) * -1.;
+
+            //warm-up cache
+            profile_grid.neighbors_cache().warm_up();
+
+            for (auto _ : state)
+            {
+                fs::compute_receivers(receivers, dist2receivers,
+                                      elevation, profile_grid); 
+            }
+        }
+
+        template <class G>
+        void flow_routing__compute_receivers__raster(benchmark::State& state)
+        {
+            using grid = G;
+            using size_type = typename grid::size_type;
+
+            auto n = static_cast<size_type>(state.range(0));
+            std::array<size_type, 2> shape {n, n};
+            auto raster_grid = grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
+
+            xt::xtensor<double, 2> elevation = xt::random::rand<double>({n,n});
+            xt::xtensor<index_t, 1> receivers = xt::ones<index_t>({n*n}) * -1;
+            xt::xtensor<double, 1> dist2receivers = xt::ones<double>({n*n}) * -1.;
+
+            //warm-up cache
+            for (size_type idx = 0; idx < raster_grid.size(); ++idx)
+            {
+                raster_grid.neighbors(idx);
+            }  
+
+            for (auto _ : state)
+            {
+                fs::compute_receivers(receivers, dist2receivers,
+                                      elevation, raster_grid); 
+            }
+        }
+
+        void flow_routing__compute_receivers_d8(benchmark::State& state)
+        {
+            auto n = static_cast<std::size_t>(state.range(0));
+
+            xt::xtensor<double, 2> elevation = xt::random::rand<double>({n,n});
+            xt::xtensor<index_t, 1> receivers = xt::ones<index_t>({n*n}) * -1;
+            xt::xtensor<double, 1> dist2receivers = xt::ones<double>({n*n}) * -1.;
+            xt::xtensor<bool, 2> active_nodes = xt::full_like(elevation, true);           
+
+            for (auto _ : state)
+            {
+                fs::compute_receivers_d8(receivers, dist2receivers,
+                                         elevation, active_nodes, 1., 1.); 
+            }
+        }
+
+        BENCHMARK_TEMPLATE(flow_routing__compute_receivers__profile, fs::profile_grid)
+        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+
+        BENCHMARK_TEMPLATE(flow_routing__compute_receivers__raster, fs::raster_grid)
+        ->Apply(bms::grid_sizes<benchmark::kMillisecond>)->MinTime(2.);
+
+        BENCHMARK(flow_routing__compute_receivers_d8)
+        ->Apply(bms::grid_sizes<benchmark::kMillisecond>)->MinTime(2.);
+
+    } // namespace bench
+} // namespace fastscapelib

--- a/include/fastscapelib/utils.hpp
+++ b/include/fastscapelib/utils.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <type_traits>
 
+#include "xtensor.hpp"
 #include "xtensor/xcontainer.hpp"
 
 


### PR DESCRIPTION
First implementation of a generic flow routing algorithm `compute_receivers` using the `structured_grid` API, the `profile_grid` and `raster_grid` and the caching of neighbors (PRs #51 #53 #54).

The `compute_receivers` can now handle any grid conforming to the `structured_grid` interface.
The caching of neighbors allows better performances than the current `compute_receivers_d8` when the cache is warmed-up (~15% faster), and only slightly slower when the cache is not computed yet (~5% slower).


```
Run on (8 X 2304.01 MHz CPU s)
2020-12-31 14:55:24
--------------------------------------------------------------------------------------------------------------------
Benchmark                                                                             Time           CPU Iterations
--------------------------------------------------------------------------------------------------------------------
flow_routing__compute_receivers__profile<fs::profile_grid>/256                        2 us          2 us     388090
flow_routing__compute_receivers__profile<fs::profile_grid>/512                        4 us          4 us     179656
flow_routing__compute_receivers__profile<fs::profile_grid>/1024                       9 us          9 us      72550
flow_routing__compute_receivers__profile<fs::profile_grid>/2048                      23 us         23 us      30516
flow_routing__compute_receivers__profile<fs::profile_grid>/4096                      52 us         52 us      12755
flow_routing__compute_receivers__raster<fs::raster_grid>/256/min_time:2.000           2 ms          2 ms       1199
flow_routing__compute_receivers__raster<fs::raster_grid>/512/min_time:2.000          10 ms         10 ms        294
flow_routing__compute_receivers__raster<fs::raster_grid>/1024/min_time:2.000         38 ms         38 ms         73
flow_routing__compute_receivers__raster<fs::raster_grid>/2048/min_time:2.000        167 ms        167 ms         17
flow_routing__compute_receivers__raster<fs::raster_grid>/4096/min_time:2.000        664 ms        664 ms          4
flow_routing__compute_receivers_d8/256/min_time:2.000                                 3 ms          3 ms        938
flow_routing__compute_receivers_d8/512/min_time:2.000                                12 ms         12 ms        241
flow_routing__compute_receivers_d8/1024/min_time:2.000                               46 ms         46 ms         60
flow_routing__compute_receivers_d8/2048/min_time:2.000                              205 ms        204 ms         10
flow_routing__compute_receivers_d8/4096/min_time:2.000                              812 ms        809 ms          4
```

Details:
- `compute_receivers` impl
- add tests and benchmarks

This PR need to be rebased after #51 #53 #54 merged.