### PR TITLE
Improve neighbors indices caching

### DIFF
--- a/benchmark/benchmark_flow_routing.cpp
+++ b/benchmark/benchmark_flow_routing.cpp
@@ -18,6 +18,8 @@ namespace bms = benchmark_setup;
 
 namespace fastscapelib
 {
+    using raster_grid_no_cache = fs::raster_grid_xt<fs::xtensor_selector, fs::detail::neighbors_no_cache<8>>;
+    
     namespace bench
     {
 
@@ -35,7 +37,10 @@ namespace fastscapelib
             xt::xtensor<double, 1> dist2receivers = xt::ones<double>({n}) * -1.;
 
             //warm-up cache
-            profile_grid.neighbors_cache().warm_up();
+            for (size_type idx = 0; idx < profile_grid.size(); ++idx)
+            {
+                profile_grid.neighbors(idx);
+            } 
 
             for (auto _ : state)
             {
@@ -91,6 +96,9 @@ namespace fastscapelib
         ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
 
         BENCHMARK_TEMPLATE(flow_routing__compute_receivers__raster, fs::raster_grid)
+        ->Apply(bms::grid_sizes<benchmark::kMillisecond>)->MinTime(2.);
+
+        BENCHMARK_TEMPLATE(flow_routing__compute_receivers__raster, fs::raster_grid_no_cache)
         ->Apply(bms::grid_sizes<benchmark::kMillisecond>)->MinTime(2.);
 
         BENCHMARK(flow_routing__compute_receivers_d8)

--- a/benchmark/benchmark_profile_grid.cpp
+++ b/benchmark/benchmark_profile_grid.cpp
@@ -37,15 +37,24 @@ namespace fastscapelib
         {
             using grid_type = fs::profile_grid_xt<XT>;
             using size_type = typename grid_type::size_type;
+            using neighbors_type = typename grid_type::neighbors_type;
 
             auto size = static_cast<size_type>(state.range(0));
             auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
 
+            //warm-up cache
+            for (size_type idx = 0; idx < grid.size(); ++idx)
+            {
+                auto neighbors = grid.neighbors(idx);
+            } 
+
+            neighbors_type neighbors;
+            
             for (auto _ : state)
             {
-                for (size_type idx = 0; idx < size; ++idx)
+                for (size_type idx = 0; idx < grid.size(); ++idx)
                 {
-                    auto neighbors = grid.neighbors(idx);
+                    grid.neighbors(idx, neighbors);
                 }
             }
         }

--- a/benchmark/benchmark_raster_grid.cpp
+++ b/benchmark/benchmark_raster_grid.cpp
@@ -35,25 +35,6 @@ namespace fastscapelib
         }
 
         template <fs::raster_connect RC>
-        void raster_grid__neighbors_indices_cache_warm_up(benchmark::State& state)
-        {
-            using grid_type = fs::raster_grid;
-            using size_type = typename grid_type::size_type;
-            using neighbors_type = typename grid_type::neighbors_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape {n, n};
-            auto grid = grid_type(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
-            
-            auto cache = grid.neighbors_cache();
-            
-            for (auto _ : state)
-            {
-                cache.warm_up();
-            }
-        }
-
-        template <fs::raster_connect RC>
         void raster_grid__neighbors(benchmark::State& state)
         {
             using grid_type = fs::raster_grid;
@@ -68,14 +49,15 @@ namespace fastscapelib
             for (size_type idx = 0; idx < grid.size(); ++idx)
             {
                 auto neighbors = grid.neighbors(idx);
-            }  
+            } 
+
+            neighbors_type neighbors;
             
             for (auto _ : state)
             {
                 for (size_type idx = 0; idx < grid.size(); ++idx)
                 {
-                    const auto& neighbors = grid.neighbors(idx);
-                    benchmark::DoNotOptimize(neighbors);
+                    grid.neighbors(idx, neighbors);
                 }
             }
         }
@@ -335,9 +317,6 @@ namespace fastscapelib
         ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
 
         BENCHMARK_TEMPLATE(raster_grid__neighbors_distance, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
-
-        BENCHMARK_TEMPLATE(raster_grid__neighbors_indices_cache_warm_up, fs::raster_connect::queen)
         ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
 
         BENCHMARK_TEMPLATE(raster_grid__neighbors, fs::raster_connect::queen)

--- a/include/fastscapelib/flow_routing.hpp
+++ b/include/fastscapelib/flow_routing.hpp
@@ -308,15 +308,18 @@ namespace detail
                                 E&& elevation,
                                 G& grid)
     {
+        using neighbors_type = typename G::neighbors_type;
+        
         double slope, slope_max;
+        neighbors_type neighbors;
 
         for (std::size_t i=0; i<grid.size(); ++i)
         {
             receivers(i) = i;
             dist2receivers(i) = 0;
             slope_max = std::numeric_limits<double>::min();
-
-            const auto& neighbors = grid.neighbors(i);
+            
+            grid.neighbors(i, neighbors);
 
             for (auto n=neighbors.begin(); n != neighbors.end(); ++n)
             {          

--- a/test/test_profile_grid.cpp
+++ b/test/test_profile_grid.cpp
@@ -20,7 +20,7 @@ namespace fastscapelib
 
         TEST_F(neighbor, ctor)
         {
-            EXPECT_EQ(n.idx, 3);
+            EXPECT_EQ(n.idx, 3u);
             EXPECT_EQ(n.distance, 1.35);
             EXPECT_EQ(n.status, fs::node_status::core);
         }
@@ -126,44 +126,44 @@ namespace fastscapelib
 
         TEST_F(profile_grid, neighbors__fixed_value_boundary)
         {
-            EXPECT_EQ(fixed_grid.neighbors_cache().used(), 0);
-            EXPECT_EQ(fixed_grid.neighbors_cache().size(), 5);
+            EXPECT_EQ(fixed_grid.neighbors_indices_cache().cache_used(), 0u);
+            EXPECT_EQ(fixed_grid.neighbors_indices_cache().cache_size(), 5u);
 
             EXPECT_EQ(fixed_grid.neighbors(0), 
                      (xt::xtensor<fs::neighbor, 1> { {1, 1.3, fs::node_status::core} } ));
 
             for(std::size_t i=1; i<4; ++i)
             {
-                EXPECT_EQ(fixed_grid.neighbors_cache().used(), i);
+                EXPECT_EQ(fixed_grid.neighbors_indices_cache().cache_used(), i);
                 EXPECT_EQ(fixed_grid.neighbors(i),
                           (xt::xtensor<fs::neighbor, 1> { {i-1, 1.3, status_fixed(i-1)},
                                                           {i+1, 1.3, status_fixed(i+1)} } ));
             }
-            EXPECT_EQ(fixed_grid.neighbors_cache().used(), 4);
+            EXPECT_EQ(fixed_grid.neighbors_indices_cache().cache_used(), 4u);
 
             EXPECT_EQ(fixed_grid.neighbors(4),
                       (xt::xtensor<fs::neighbor, 1> { {3, 1.3, fs::node_status::core} } ));
-            EXPECT_EQ(fixed_grid.neighbors_cache().used(), 5);
+            EXPECT_EQ(fixed_grid.neighbors_indices_cache().cache_used(), 5u);
         }
 
         TEST_F(profile_grid, neighbors__looped_boundary)
         {
-            EXPECT_EQ(looped_grid.neighbors_cache().used(), 0);
-            EXPECT_EQ(looped_grid.neighbors_cache().size(), 5);
+            EXPECT_EQ(looped_grid.neighbors_indices_cache().cache_used(), 0u);
+            EXPECT_EQ(looped_grid.neighbors_indices_cache().cache_size(), 5u);
 
             EXPECT_EQ(looped_grid.neighbors(0), (xt::xtensor<fs::neighbor, 1> {{4, 1.4, fs::node_status::looped_boundary},
                                                                                {1, 1.4, fs::node_status::core}}));
 
             for(std::size_t i=1; i<4; ++i)
             {
-                EXPECT_EQ(looped_grid.neighbors_cache().used(), i);
+                EXPECT_EQ(looped_grid.neighbors_indices_cache().cache_used(), i);
                 EXPECT_EQ(looped_grid.neighbors(i), (xt::xtensor<fs::neighbor, 1> {{i-1, 1.4, status_looped(i-1)},
                                                                                    {i+1, 1.4, status_looped(i+1)}}));
             }
-            EXPECT_EQ(looped_grid.neighbors_cache().used(), 4);
+            EXPECT_EQ(looped_grid.neighbors_indices_cache().cache_used(), 4u);
             EXPECT_EQ(looped_grid.neighbors(4), (xt::xtensor<fs::neighbor, 1> {{3, 1.4, fs::node_status::core},
                                                                                {0, 1.4, fs::node_status::looped_boundary}}));
-            EXPECT_EQ(looped_grid.neighbors_cache().used(), 5);
+            EXPECT_EQ(looped_grid.neighbors_indices_cache().cache_used(), 5u);
         }
 
         TEST_F(profile_grid, spacing)
@@ -174,8 +174,8 @@ namespace fastscapelib
 
         TEST_F(profile_grid, size)
         {
-            EXPECT_EQ(fixed_grid.size(), 5);
-            EXPECT_EQ(looped_grid.size(), 5);
+            EXPECT_EQ(fixed_grid.size(), 5u);
+            EXPECT_EQ(looped_grid.size(), 5u);
         }
     }
 }

--- a/test/test_raster_grid.cpp
+++ b/test/test_raster_grid.cpp
@@ -375,8 +375,8 @@ namespace fastscapelib
 
         TEST_F(raster_grid, size)
         {
-            EXPECT_EQ(fixed_grid.size(), 50);
-            EXPECT_EQ(looped_grid.size(), 50);
+            EXPECT_EQ(fixed_grid.size(), 50u);
+            EXPECT_EQ(looped_grid.size(), 50u);
         }
 
         TEST_F(raster_grid, gcode)


### PR DESCRIPTION
Improve neighbors indices caching for structured grids.
Clean the code and implement a no-caching policy.

Details:
- add `store` and `get_storage` methods to caches
- add a `neighbors_no_cache` policy
- check that cache width is large enough
- change API of neighbors method for callers to provide a ref to fill
- minor updates of tests and benchs due to API changes

- [x] Need to be rebased after #55 merged