### PR TITLE
Add grid length

### DIFF
--- a/include/fastscapelib/profile_grid.hpp
+++ b/include/fastscapelib/profile_grid.hpp
@@ -223,7 +223,7 @@ namespace fastscapelib
         : base_type(size), m_size(size), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
     {
         m_shape = {static_cast<typename shape_type::value_type>(m_size)};
-        m_length = static_cast<spacing_type>(size) * spacing;
+        m_length = static_cast<spacing_type>(size - 1) * spacing;
         set_status_at_nodes(status_at_nodes);
         build_gcode();
         build_neighbors_distances();
@@ -249,7 +249,7 @@ namespace fastscapelib
                                                                const boundary_status_type& status_at_bounds,
                                                                const std::vector<node>& status_at_nodes)
     {
-        spacing_type spacing = length / static_cast<length_type>(size);
+        spacing_type spacing = length / static_cast<length_type>(size - 1);
         return profile_grid_xt<XT, C>(size, spacing, status_at_bounds, status_at_nodes);
     }
     //@}

--- a/include/fastscapelib/profile_grid.hpp
+++ b/include/fastscapelib/profile_grid.hpp
@@ -107,14 +107,16 @@ namespace fastscapelib
 
         using size_type = typename xt_type::size_type;
         using shape_type = typename xt_type::shape_type;
+        using length_type = double;
+        using spacing_type = length_type;
+
         using code_type = std::uint8_t;
+        using neighbors_count_type = std::uint8_t;
 
         using neighbors_indices_type = typename std::array<std::size_t, 2>;
         using neighbors_distances_type = typename std::array<double, 2>;
-        using neighbors_count_type = std::uint8_t;
 
         using boundary_status_type = profile_boundary_status;
-        using spacing_type = double;
         using node_status_type = xt_container_t<xt_selector, node_status, xt_ndims>;
     };
 
@@ -139,7 +141,9 @@ namespace fastscapelib
 
         using size_type = typename inner_types::size_type;
         using shape_type = typename inner_types::shape_type;
+        using length_type = typename inner_types::length_type;
         using spacing_type = typename inner_types::spacing_type;
+
         using code_type = typename inner_types::code_type;
 
         using neighbors_type = typename base_type::neighbors_type;
@@ -155,6 +159,10 @@ namespace fastscapelib
                         const boundary_status_type& status_at_bounds,
                         const std::vector<node>& status_at_nodes = {});
 
+        static profile_grid_xt from_length(size_type size,
+                                           length_type length,
+                                           const boundary_status_type& status_at_bounds,
+                                           const std::vector<node>& status_at_nodes = {});
     protected:
 
         using coded_neighbors_distances_type = std::array<neighbors_distances_type, 3>;
@@ -162,6 +170,8 @@ namespace fastscapelib
         shape_type m_shape;
         size_type m_size;
         spacing_type m_spacing;
+        length_type m_length;
+
         xt::xtensor<code_type, 1> m_gcode_idx;
 
         node_status_type m_status_at_nodes;
@@ -207,16 +217,40 @@ namespace fastscapelib
      */
     template <class XT, class C>
     profile_grid_xt<XT, C>::profile_grid_xt(size_type size,
-                                        spacing_type spacing,
-                                        const boundary_status_type& status_at_bounds,
-                                        const std::vector<node>& status_at_nodes)
+                                            spacing_type spacing,
+                                            const boundary_status_type& status_at_bounds,
+                                            const std::vector<node>& status_at_nodes)
         : base_type(size), m_size(size), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
     {
         m_shape = {static_cast<typename shape_type::value_type>(m_size)};
+        m_length = static_cast<spacing_type>(size) * spacing;
         set_status_at_nodes(status_at_nodes);
         build_gcode();
         build_neighbors_distances();
         build_neighbors_count();
+    }
+    //@}
+
+    /**
+     * @name Factories
+     */
+    //@{
+   /**
+     * Creates a new profile grid.
+     *
+     * @param size Total number of grid nodes.
+     * @param length Total physical length of the grid.
+     * @param status_at_bounds Status at boundary nodes (left & right grid edges).
+     * @param status_at_nodes Manually define the status at any node on the grid.
+     */
+    template <class XT, class C>
+    profile_grid_xt<XT, C> profile_grid_xt<XT, C>::from_length(size_type size,
+                                                               length_type length,
+                                                               const boundary_status_type& status_at_bounds,
+                                                               const std::vector<node>& status_at_nodes)
+    {
+        spacing_type spacing = length / static_cast<length_type>(size);
+        return profile_grid_xt<XT, C>(size, spacing, status_at_bounds, status_at_nodes);
     }
     //@}
 

--- a/include/fastscapelib/raster_grid.hpp
+++ b/include/fastscapelib/raster_grid.hpp
@@ -296,7 +296,7 @@ namespace fastscapelib
         : base_type(shape[0] * shape[1]), m_shape(shape), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
     {
         m_size = shape[0] * shape[1];
-        m_length = xt::adapt(shape) * spacing;
+        m_length = (xt::adapt(shape) - 1) * spacing;
 
         build_gcode();
         build_neighbors_count();        
@@ -329,7 +329,7 @@ namespace fastscapelib
                                                              const boundary_status_type& status_at_bounds,
                                                              const std::vector<raster_node>& status_at_nodes)
     {
-        spacing_type spacing = length / xt::adapt(shape);
+        spacing_type spacing = length / (xt::adapt(shape) - 1);
         return raster_grid_xt<XT, C>(shape, spacing, status_at_bounds, status_at_nodes);
     }
     //@}

--- a/include/fastscapelib/raster_grid.hpp
+++ b/include/fastscapelib/raster_grid.hpp
@@ -130,7 +130,8 @@ namespace fastscapelib
 
         using size_type = typename xt_type::size_type;
         using shape_type = typename xt_type::shape_type;
-        using spacing_type = std::array<double, 2>;
+        using length_type = xt::xtensor_fixed<double, xt::xshape<2>>;
+        using spacing_type = length_type;
 
         using code_type = std::uint8_t;
         using neighbors_count_type = std::uint8_t;
@@ -161,7 +162,9 @@ namespace fastscapelib
 
         using size_type = typename inner_types::size_type;
         using shape_type = typename inner_types::shape_type;
+        using length_type = typename inner_types::length_type;
         using spacing_type = typename inner_types::spacing_type;
+
         using code_type = typename inner_types::code_type;
 
         using neighbors_type = typename base_type::neighbors_type;
@@ -175,11 +178,15 @@ namespace fastscapelib
         using node_status_type = typename inner_types::node_status_type;
         using offset_list = xt::xtensor<xt::xtensor_fixed<std::ptrdiff_t, xt::xshape<2>>, 1>;
 
-        template <class S>
-        raster_grid_xt(S&& shape,
-                    const spacing_type& spacing,
-                    const boundary_status_type& status_at_bounds,
-                    const std::vector<raster_node>& status_at_nodes = {});
+        raster_grid_xt(const shape_type& shape,
+                       const spacing_type& spacing,
+                       const boundary_status_type& status_at_bounds,
+                       const std::vector<raster_node>& status_at_nodes = {});
+
+        static raster_grid_xt from_length(const shape_type& shape,
+                                          const length_type& length,
+                                          const boundary_status_type& status_at_bounds,
+                                          const std::vector<raster_node>& status_at_nodes = {});
 
         template <raster_connect RC = raster_connect::queen>
         inline neighbors_indices_type neighbor_indices(const size_type& idx) const noexcept;
@@ -214,6 +221,7 @@ namespace fastscapelib
         shape_type m_shape;
         size_type m_size;
         spacing_type m_spacing;
+        length_type m_length;
 
         node_status_type m_status_at_nodes;
         boundary_status_type m_status_at_bounds;
@@ -281,14 +289,14 @@ namespace fastscapelib
      * @param status_at_nodes Manually define the status at any node on the grid.
      */
     template <class XT, class C>
-    template <class S>
-    raster_grid_xt<XT, C>::raster_grid_xt(S&& shape,
-                                       const spacing_type& spacing,
-                                       const boundary_status_type& status_at_bounds,
-                                       const std::vector<raster_node>& status_at_nodes)
+    raster_grid_xt<XT, C>::raster_grid_xt(const shape_type& shape,
+                                          const spacing_type& spacing,
+                                          const boundary_status_type& status_at_bounds,
+                                          const std::vector<raster_node>& status_at_nodes)
         : base_type(shape[0] * shape[1]), m_shape(shape), m_spacing(spacing), m_status_at_bounds(status_at_bounds)
     {
         m_size = shape[0] * shape[1];
+        m_length = xt::adapt(shape) * spacing;
 
         build_gcode();
         build_neighbors_count();        
@@ -300,6 +308,29 @@ namespace fastscapelib
 
         m_neighbor_distances_queen = build_neighbor_distances<raster_connect::queen>();
         m_neighbor_distances_rook = build_neighbor_distances<raster_connect::rook>();
+    }
+    //@}
+
+    /**
+     * @name Factories
+     */
+    //@{
+   /**
+     * Creates a new raster grid.
+     *
+     * @param shape Shape of the grid (number of rows and cols).
+     * @param length Total physical lengths of the grid.
+     * @param status_at_bounds Status at boundary nodes (left & right grid edges).
+     * @param status_at_nodes Manually define the status at any node on the grid.
+     */
+    template <class XT, class C>
+    raster_grid_xt<XT, C> raster_grid_xt<XT, C>::from_length(const shape_type& shape,
+                                                             const length_type& length,
+                                                             const boundary_status_type& status_at_bounds,
+                                                             const std::vector<raster_node>& status_at_nodes)
+    {
+        spacing_type spacing = length / xt::adapt(shape);
+        return raster_grid_xt<XT, C>(shape, spacing, status_at_bounds, status_at_nodes);
     }
     //@}
 

--- a/include/fastscapelib/structured_grid.hpp
+++ b/include/fastscapelib/structured_grid.hpp
@@ -270,6 +270,7 @@ namespace fastscapelib
 
         using size_type = typename inner_types::size_type;
         using shape_type = typename inner_types::shape_type;
+        using length_type = typename inner_types::length_type;
         using spacing_type = typename inner_types::spacing_type;
         
         using neighbors_type = typename xt::xtensor<neighbor, 1>;
@@ -290,7 +291,11 @@ namespace fastscapelib
         using node_status_type = typename inner_types::node_status_type;
         
         size_type size() const noexcept;
+
         spacing_t spacing() const noexcept;
+
+        length_type length() const noexcept;
+
         const node_status_type& status_at_nodes() const;
 
         const neighbors_count_type& neighbors_count(const size_type& idx) const;
@@ -356,6 +361,16 @@ namespace fastscapelib
         -> spacing_t
     {
         return derived_grid().m_spacing;
+    }
+
+    /**
+     * Returns the length of the grid for all its dimensions.
+     */
+    template <class G, class C>
+    inline auto structured_grid<G, C>::length() const noexcept
+        -> length_type
+    {
+        return derived_grid().m_length;
     }
 
     /**

--- a/python/fastscapelib/tests/test_profile_grid.py
+++ b/python/fastscapelib/tests/test_profile_grid.py
@@ -69,27 +69,37 @@ class TestNeighbor():
 class TestProfileGrid():
 
     def setup_method(self, method):
-        bs = [NodeStatus.FIXED_VALUE_BOUNDARY]*2
-        self.g = ProfileGrid(10, 2.2, bs, [(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+        self.bs = [NodeStatus.FIXED_VALUE_BOUNDARY]*2
+        self.g = ProfileGrid(10, 2.2, self.bs, [(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
 
     def test___init__(self):
-        bs = [NodeStatus.FIXED_VALUE_BOUNDARY]*2
-        g = ProfileGrid(10, 2, bs, [(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+        g = ProfileGrid(10, 2, self.bs, [(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
         assert g.size == 10
         assert g.spacing == 2.
+        assert g.length == 20.
 
-        g = ProfileGrid(15, 3., ProfileBoundaryStatus(bs), [Node(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+        g = ProfileGrid(15, 3., ProfileBoundaryStatus(self.bs), [Node(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
         assert g.size == 15
         assert g.spacing == 3.
+        assert g.length == 45.
 
         with pytest.raises(IndexError):
-            ProfileGrid(10, 2, bs, [(15, NodeStatus.FIXED_VALUE_BOUNDARY)])
+            ProfileGrid(10, 2, self.bs, [(15, NodeStatus.FIXED_VALUE_BOUNDARY)])
+
+    def test_from_length(self):
+        g = ProfileGrid.from_length(10, 20., ProfileBoundaryStatus(self.bs), [Node(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+        assert g.size == 10
+        assert g.spacing == 2.
+        assert g.length == 20.
 
     def test_size(self):
         assert self.g.size == 10
 
     def test_spacing(self):
         assert self.g.spacing == 2.2
+
+    def test_length(self):
+        assert self.g.length == 22.
 
     def test_status_at_nodes(self):
         npt.assert_equal(self.g.status_at_nodes, np.array([1, 0, 0, 0, 0, 1, 0, 0, 0, 1]))

--- a/python/fastscapelib/tests/test_profile_grid.py
+++ b/python/fastscapelib/tests/test_profile_grid.py
@@ -76,19 +76,19 @@ class TestProfileGrid():
         g = ProfileGrid(10, 2, self.bs, [(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
         assert g.size == 10
         assert g.spacing == 2.
-        assert g.length == 20.
+        assert g.length == 18.
 
         g = ProfileGrid(15, 3., ProfileBoundaryStatus(self.bs), [Node(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
         assert g.size == 15
         assert g.spacing == 3.
-        assert g.length == 45.
+        assert g.length == 42.
 
         with pytest.raises(IndexError):
             ProfileGrid(10, 2, self.bs, [(15, NodeStatus.FIXED_VALUE_BOUNDARY)])
 
     def test_from_length(self):
-        g = ProfileGrid.from_length(10, 20., ProfileBoundaryStatus(self.bs), [Node(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
-        assert g.size == 10
+        g = ProfileGrid.from_length(11, 20., ProfileBoundaryStatus(self.bs), [Node(5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+        assert g.size == 11
         assert g.spacing == 2.
         assert g.length == 20.
 
@@ -99,7 +99,7 @@ class TestProfileGrid():
         assert self.g.spacing == 2.2
 
     def test_length(self):
-        assert self.g.length == 22.
+        assert self.g.length == 19.8
 
     def test_status_at_nodes(self):
         npt.assert_equal(self.g.status_at_nodes, np.array([1, 0, 0, 0, 0, 1, 0, 0, 0, 1]))

--- a/python/fastscapelib/tests/test_raster_grid.py
+++ b/python/fastscapelib/tests/test_raster_grid.py
@@ -98,14 +98,20 @@ class TestRasterGrid():
     def test___init__(self):
         g1 = RasterGrid([10, 10], [2.3, 2.1], self.bs, [RasterNode(0, 5, NodeStatus.FIXED_VALUE_BOUNDARY)])
         assert g1.size == 100
-        assert g1.spacing == [2.3, 2.1]
+        npt.assert_almost_equal(g1.spacing, [2.3, 2.1])
+        npt.assert_almost_equal(g1.length, [23., 21.])
 
         with pytest.raises(IndexError):
             RasterGrid([5, 10], [2.2, 2.4], self.bs, [RasterNode(20, 255, NodeStatus.FIXED_VALUE_BOUNDARY)])
+
+    def test_from_length(self):
+        g = RasterGrid.from_length([10, 10], np.r_[23, 21], self.bs, [RasterNode(0, 5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+        assert g.size == 100
+        npt.assert_almost_equal(g.spacing, [2.3, 2.1])
+        npt.assert_almost_equal(g.length, [23., 21.])
 
     def test_size(self):
         assert self.g.size == 50
 
     def test_spacing(self):
-        assert self.g.spacing == [2.2, 2.4]
-
+        npt.assert_almost_equal(self.g.spacing, [2.2, 2.4])

--- a/python/fastscapelib/tests/test_raster_grid.py
+++ b/python/fastscapelib/tests/test_raster_grid.py
@@ -99,14 +99,14 @@ class TestRasterGrid():
         g1 = RasterGrid([10, 10], [2.3, 2.1], self.bs, [RasterNode(0, 5, NodeStatus.FIXED_VALUE_BOUNDARY)])
         assert g1.size == 100
         npt.assert_almost_equal(g1.spacing, [2.3, 2.1])
-        npt.assert_almost_equal(g1.length, [23., 21.])
+        npt.assert_almost_equal(g1.length, [20.7, 18.9])
 
         with pytest.raises(IndexError):
             RasterGrid([5, 10], [2.2, 2.4], self.bs, [RasterNode(20, 255, NodeStatus.FIXED_VALUE_BOUNDARY)])
 
     def test_from_length(self):
-        g = RasterGrid.from_length([10, 10], np.r_[23, 21], self.bs, [RasterNode(0, 5, NodeStatus.FIXED_VALUE_BOUNDARY)])
-        assert g.size == 100
+        g = RasterGrid.from_length([11, 11], np.r_[23, 21], self.bs, [RasterNode(0, 5, NodeStatus.FIXED_VALUE_BOUNDARY)])
+        assert g.size == 121
         npt.assert_almost_equal(g.spacing, [2.3, 2.1])
         npt.assert_almost_equal(g.length, [23., 21.])
 

--- a/test/test_profile_grid.cpp
+++ b/test/test_profile_grid.cpp
@@ -180,15 +180,15 @@ namespace fastscapelib
 
         TEST_F(profile_grid, length)
         {
-            EXPECT_EQ(fixed_grid.length(), 6.5);
-            EXPECT_EQ(looped_grid.length(), 7.);
+            EXPECT_EQ(fixed_grid.length(), 5.2);
+            EXPECT_EQ(looped_grid.length(), 5.6);
         }
 
         TEST_F(profile_grid, from_length)
         {
-            auto grid_from_length = grid_type::from_length(150, 1500., fs::node_status::fixed_value_boundary);
+            auto grid_from_length = grid_type::from_length(151, 1500., fs::node_status::fixed_value_boundary);
             EXPECT_EQ(grid_from_length.length(), 1500.);
-            EXPECT_EQ(grid_from_length.size(), 150u);
+            EXPECT_EQ(grid_from_length.size(), 151u);
             EXPECT_EQ(grid_from_length.spacing(), 10.);
         }
     }

--- a/test/test_profile_grid.cpp
+++ b/test/test_profile_grid.cpp
@@ -177,5 +177,19 @@ namespace fastscapelib
             EXPECT_EQ(fixed_grid.size(), 5u);
             EXPECT_EQ(looped_grid.size(), 5u);
         }
+
+        TEST_F(profile_grid, length)
+        {
+            EXPECT_EQ(fixed_grid.length(), 6.5);
+            EXPECT_EQ(looped_grid.length(), 7.);
+        }
+
+        TEST_F(profile_grid, from_length)
+        {
+            auto grid_from_length = grid_type::from_length(150, 1500., fs::node_status::fixed_value_boundary);
+            EXPECT_EQ(grid_from_length.length(), 1500.);
+            EXPECT_EQ(grid_from_length.size(), 150u);
+            EXPECT_EQ(grid_from_length.spacing(), 10.);
+        }
     }
 }

--- a/test/test_raster_grid.cpp
+++ b/test/test_raster_grid.cpp
@@ -385,15 +385,15 @@ namespace fastscapelib
 
         TEST_F(raster_grid, length)
         {
-            EXPECT_TRUE(xt::all(xt::equal(fixed_grid.length(), length_type({6.5, 12.}))));
-            EXPECT_TRUE(xt::all(xt::equal(looped_grid.length(), length_type({7., 18.}))));
+            EXPECT_TRUE(xt::all(xt::isclose(fixed_grid.length(), length_type({5.2, 10.8}))));
+            EXPECT_TRUE(xt::all(xt::equal(looped_grid.length(), length_type({5.6, 16.2}))));
         }
 
         TEST_F(raster_grid, from_length)
         {
-            auto grid_from_length = grid_type::from_length(shape_type({{150, 100}}), length_type({1500., 2000.}), fixed_value_status);
+            auto grid_from_length = grid_type::from_length(shape_type({{151, 101}}), length_type({1500., 2000.}), fixed_value_status);
             EXPECT_TRUE(xt::all(xt::equal(grid_from_length.length(), length_type({1500., 2000.}))));
-            EXPECT_EQ(grid_from_length.size(), 15000u);
+            EXPECT_EQ(grid_from_length.size(), 15251u);
             EXPECT_TRUE(xt::all(xt::equal(grid_from_length.spacing(), spacing_type({10., 20.}))));
         }
 

--- a/test/test_raster_grid.cpp
+++ b/test/test_raster_grid.cpp
@@ -89,9 +89,13 @@ namespace fastscapelib
                 fs::raster_boundary_status hvlooped_status {hvloop};
 
                 using grid_type = fs::raster_grid_xt<fs::xtensor_selector>;
-                using size_type = typename grid_type::size_type;
 
-                std::array<size_type, 2> shape {{5, 10}};
+                using size_type = typename grid_type::size_type;
+                using length_type = typename grid_type::length_type;
+                using spacing_type = typename grid_type::spacing_type;
+                using shape_type = typename grid_type::shape_type;
+
+                shape_type shape {{5, 10}};
                 grid_type fixed_grid = grid_type(shape, {1.3, 1.2}, fixed_value_status);
                 grid_type hlooped_grid = grid_type(shape, {1.3, 1.2}, hlooped_status);
                 grid_type vlooped_grid = grid_type(shape, {1.3, 1.2}, vlooped_status);
@@ -369,14 +373,28 @@ namespace fastscapelib
 
         TEST_F(raster_grid, spacing)
         {
-            EXPECT_EQ(fixed_grid.spacing(), (std::array<double, 2> {{1.3, 1.2}}));
-            EXPECT_EQ(looped_grid.spacing(), (std::array<double, 2> {{1.4, 1.8}}));
+            EXPECT_TRUE(xt::all(xt::equal(fixed_grid.spacing(), spacing_type({1.3, 1.2}))));
+            EXPECT_TRUE(xt::all(xt::equal(looped_grid.spacing(), spacing_type({1.4, 1.8}))));
         }
 
         TEST_F(raster_grid, size)
         {
             EXPECT_EQ(fixed_grid.size(), 50u);
             EXPECT_EQ(looped_grid.size(), 50u);
+        }
+
+        TEST_F(raster_grid, length)
+        {
+            EXPECT_TRUE(xt::all(xt::equal(fixed_grid.length(), length_type({6.5, 12.}))));
+            EXPECT_TRUE(xt::all(xt::equal(looped_grid.length(), length_type({7., 18.}))));
+        }
+
+        TEST_F(raster_grid, from_length)
+        {
+            auto grid_from_length = grid_type::from_length(shape_type({{150, 100}}), length_type({1500., 2000.}), fixed_value_status);
+            EXPECT_TRUE(xt::all(xt::equal(grid_from_length.length(), length_type({1500., 2000.}))));
+            EXPECT_EQ(grid_from_length.size(), 15000u);
+            EXPECT_TRUE(xt::all(xt::equal(grid_from_length.spacing(), spacing_type({10., 20.}))));
         }
 
         TEST_F(raster_grid, gcode)


### PR DESCRIPTION
Add a `length` method to get the physical length of the grid in all its dimensions.

Related to #59.

Details:
- add factory method `from_length`
- add tests for profile and raster grids
- fix ICE (internal compiler error) on MSVC14.0 (VS2015)

- [x] Rebase after #57 merged