### PR TITLE
Improved raster grids

### DIFF
--- a/benchmark/benchmark_flow_routing.cpp
+++ b/benchmark/benchmark_flow_routing.cpp
@@ -18,8 +18,6 @@ namespace bms = benchmark_setup;
 
 namespace fastscapelib
 {
-    using raster_grid_no_cache = fs::raster_grid_xt<fs::xtensor_selector, fs::detail::neighbors_no_cache<8>>;
-    
     namespace bench
     {
 
@@ -92,17 +90,41 @@ namespace fastscapelib
             }
         }
 
-        BENCHMARK_TEMPLATE(flow_routing__compute_receivers__profile, fs::profile_grid)
-        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+        using profile_nocache = fs::profile_grid_xt<xtensor_selector, detail::neighbors_no_cache<2>>;
+        using profile_cacheall = fs::profile_grid;
 
-        BENCHMARK_TEMPLATE(flow_routing__compute_receivers__raster, fs::raster_grid)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>)->MinTime(2.);
+        using queen_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, detail::neighbors_no_cache<8>>;
+        using queen_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, detail::neighbors_cache<8>>;
 
-        BENCHMARK_TEMPLATE(flow_routing__compute_receivers__raster, fs::raster_grid_no_cache)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>)->MinTime(2.);
+        using rook_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, detail::neighbors_no_cache<4>>;
+        using rook_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, detail::neighbors_cache<4>>;
+
+        using bishop_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, detail::neighbors_no_cache<4>>;
+        using bishop_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, detail::neighbors_cache<4>>;
+
+
+#define BENCH_GRID(NAME, GRID)                         \
+    BENCHMARK_TEMPLATE(NAME, GRID)                     \
+    ->Apply(bms::grid_sizes<benchmark::kMillisecond>);  
+
+#define BENCH_RASTER(NAME)             \
+    BENCH_GRID(NAME, queen_nocache)    \
+    BENCH_GRID(NAME, queen_cacheall)   \
+    BENCH_GRID(NAME, rook_nocache)     \
+    BENCH_GRID(NAME, rook_cacheall)    \
+    BENCH_GRID(NAME, bishop_nocache)   \
+    BENCH_GRID(NAME, bishop_cacheall)
+
+
+        BENCHMARK_TEMPLATE(flow_routing__compute_receivers__profile, profile_nocache)
+        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);  
+        BENCHMARK_TEMPLATE(flow_routing__compute_receivers__profile, profile_cacheall)
+        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);  
+        
+        BENCH_RASTER(flow_routing__compute_receivers__raster)
 
         BENCHMARK(flow_routing__compute_receivers_d8)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>)->MinTime(2.);
+        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
 
     } // namespace bench
 } // namespace fastscapelib

--- a/benchmark/benchmark_profile_grid.cpp
+++ b/benchmark/benchmark_profile_grid.cpp
@@ -18,10 +18,10 @@ namespace fastscapelib
     namespace bench
     {
 
-        template <class XT>
+        template <class G>
         void profile_grid__ctor(benchmark::State& state)
         {
-            using grid_type = fs::profile_grid_xt<XT>;
+            using grid_type = G;
             using size_type = typename grid_type::size_type;
 
             auto shape = static_cast<size_type>(state.range(0));
@@ -32,10 +32,10 @@ namespace fastscapelib
             }
         }
 
-        template <class XT>
+        template <class G>
         void profile_grid__neighbors(benchmark::State& state)
         {
-            using grid_type = fs::profile_grid_xt<XT>;
+            using grid_type = G;
             using size_type = typename grid_type::size_type;
             using neighbors_type = typename grid_type::neighbors_type;
 
@@ -59,49 +59,19 @@ namespace fastscapelib
             }
         }
 
-        template <class XT>
-        void profile_grid__spacing(benchmark::State& state)
-        {
-            using grid_type = fs::profile_grid_xt<XT>;
-            using size_type = typename grid_type::size_type;
+        using profile_nocache = fs::profile_grid_xt<xtensor_selector, detail::neighbors_no_cache<2>>;
+        using profile_cacheall = fs::profile_grid;
 
-            auto size = static_cast<size_type>(state.range(0));
-            auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
+#define BENCH_GRID(NAME, GRID)                             \
+    BENCHMARK_TEMPLATE(NAME, GRID)                         \
+    ->Apply(bms::small_grid_sizes<benchmark::kNanosecond>);  
 
-            for (auto _ : state)
-            {
-                auto spacing = grid.spacing();
-                benchmark::DoNotOptimize(spacing);
-            }
-        }
+#define BENCH_RASTER(NAME)             \
+    BENCH_GRID(NAME, profile_nocache)  \
+    BENCH_GRID(NAME, profile_cacheall)
 
-        template <class XT>
-        void profile_grid__size(benchmark::State& state)
-        {
-            using grid_type = fs::profile_grid_xt<XT>;
-            using size_type = typename grid_type::size_type;
-
-            auto size = static_cast<size_type>(state.range(0));
-            auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
-
-            for (auto _ : state)
-            {
-                auto s = grid.size();
-                benchmark::DoNotOptimize(s);
-            }
-        }
-
-        BENCHMARK_TEMPLATE(profile_grid__ctor, fs::xtensor_selector)
-        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
-
-        BENCHMARK_TEMPLATE(profile_grid__neighbors, fs::xtensor_selector)
-        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
-
-        BENCHMARK_TEMPLATE(profile_grid__spacing, fs::xtensor_selector)
-        ->Apply(bms::grid_sizes<benchmark::kNanosecond>);
-
-        BENCHMARK_TEMPLATE(profile_grid__size, fs::xtensor_selector)
-        ->Apply(bms::grid_sizes<benchmark::kNanosecond>);
+        BENCH_RASTER(profile_grid__ctor);
+        BENCH_RASTER(profile_grid__neighbors);
  
     } // namespace bench
 } // namespace fastscapelib

--- a/benchmark/benchmark_raster_grid.cpp
+++ b/benchmark/benchmark_raster_grid.cpp
@@ -19,10 +19,10 @@ namespace fastscapelib
     namespace bench
     {
 
-        template <class XT>
+        template <class G>
         void raster_grid__ctor(benchmark::State& state)
         {
-            using grid = fs::raster_grid_xt<XT>;
+            using grid = G;
             using size_type = typename grid::size_type;
 
             auto n = static_cast<size_type>(state.range(0));
@@ -34,10 +34,10 @@ namespace fastscapelib
             }
         }
 
-        template <fs::raster_connect RC>
+        template <class G>
         void raster_grid__neighbors(benchmark::State& state)
         {
-            using grid_type = fs::raster_grid;
+            using grid_type = G;
             using size_type = typename grid_type::size_type;
             using neighbors_type = typename grid_type::neighbors_type;
 
@@ -45,7 +45,7 @@ namespace fastscapelib
             std::array<size_type, 2> shape {n, n};
             auto grid = grid_type(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
 
-            //warm-up cache
+            // warm-up cache
             for (size_type idx = 0; idx < grid.size(); ++idx)
             {
                 auto neighbors = grid.neighbors(idx);
@@ -62,170 +62,16 @@ namespace fastscapelib
             }
         }
 
-        template <fs::raster_connect RC>
-        void raster_grid__neighbors_count(benchmark::State& state)
-        {
-            using grid_type = fs::raster_grid;
-            using size_type = typename grid_type::size_type;
-            using neighbors_type = typename grid_type::neighbors_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape {n, n};
-            auto grid = grid_type(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
-            
-            for (auto _ : state)
-            {
-                for (size_type idx = 0; idx < grid.size(); ++idx)
-                {
-                    auto count = grid.neighbors_count(idx);
-                    benchmark::DoNotOptimize(count);
-                }
-            }
-        }
-
-        template <fs::raster_connect RC>
-        void raster_grid__neighbors_distance(benchmark::State& state)
-        {
-            using grid_type = fs::raster_grid;
-            using size_type = typename grid_type::size_type;
-            using neighbors_type = typename grid_type::neighbors_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape {n, n};
-            auto grid = grid_type(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
-            
-            for (auto _ : state)
-            {
-                for (size_type idx = 0; idx < grid.size(); ++idx)
-                {
-                    auto distance = grid.neighbors_distance_impl(idx);
-                    benchmark::DoNotOptimize(distance);
-                }
-            }
-        }
-
-        template <fs::raster_connect RC>
-        void raster_grid__ref_neighbors(benchmark::State& state)
-        {
-            using grid_type = fs::raster_grid;
-            using size_type = typename grid_type::size_type;
-            using neighbors_type = typename grid_type::neighbors_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape {n, n};
-            auto grid = grid_type(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
-
-            for (auto _ : state)
-            {
-                for (size_type idx = 0; idx < grid.size(); ++idx)
-                {
-                    for (auto n = 0; n < 8; ++n)
-                    {
-                        fs::neighbor neighbor {0, 1., node_status::core};
-                        benchmark::DoNotOptimize(neighbor);
-                    }
-                }
-            }
-        }
-
-        template <fs::raster_connect RC>
-        void raster_grid__neighbor_indices(benchmark::State& state)
-        {
-            using size_type = typename fs::raster_grid::size_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape {n, n};
-
-            auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
-
-            for (auto _ : state)
-            {
-                for (size_type r = 0; r < shape[0]; ++r)
-                {
-                    for (size_type c = 0; c < shape[1]; ++c)
-                    {
-                        auto nb_indices = rg.neighbor_indices<RC>(r, c);
-                    }
-                }
-            }
-        }
-
-        template <class XT>
-        void raster_grid__gcode_rowcol(benchmark::State& state)
-        {
-            using size_type = typename fs::raster_grid::size_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape {n, n};
-
-            auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
-
-            for (auto _ : state)
-            {
-                for (size_type r = 0; r < shape[0]; ++r)
-                {
-                    for (size_type c = 0; c < shape[1]; ++c)
-                    {
-                        auto code = rg.gcode(r, c);
-                        benchmark::DoNotOptimize(code);
-                    }
-                }
-            }
-        }
-
-        template <class XT>
-        void raster_grid__gcode_index(benchmark::State& state)
-        {
-            using size_type = typename fs::raster_grid::size_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape {n, n};
-
-            auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
-
-            for (auto _ : state)
-            {
-                for (size_type idx = 0; idx < rg.size(); ++idx)
-                {
-                    auto code = rg.gcode(idx);
-                    benchmark::DoNotOptimize(code);
-                }
-            }
-        }
-
-        template <fs::raster_connect RC>
-        void raster_grid__neighbor_offsets(benchmark::State& state)
-        {
-            using size_type = typename fs::raster_grid::size_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape {n, n};
-
-            auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
-
-            for (auto _ : state)
-            {
-                for (size_type r = 0; r < shape[0]; ++r)
-                {
-                    for (size_type c = 0; c < shape[1]; ++c)
-                    {
-                        auto offset = rg.neighbor_offsets<RC>(0);
-
-                        benchmark::DoNotOptimize(offset);
-                    }
-                }
-            }
-        }
-
-        template <fs::raster_connect RC>
+        template <class G>
         void raster_grid__neighbor_view(benchmark::State& state)
         {
-            using size_type = typename fs::raster_grid::size_type;
+            using grid_type = G;
+            using size_type = typename grid_type::size_type;
 
             auto n = static_cast<size_type>(state.range(0));
             std::array<size_type, 2> shape {n, n};
 
-            auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
+            auto rg = grid_type(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
             xt::xtensor<double, 2> field(shape, 1.);
 
             for (auto _ : state)
@@ -234,50 +80,28 @@ namespace fastscapelib
                 {
                     for (size_type c = 0; c < shape[1]; ++c)
                     {
-                        auto nb_field_view = rg.neighbor_view<RC>(field, r * shape[1] + c);
+                        auto nb_field_view = rg.neighbor_view(field, r * shape[1] + c);
                     }
                 }
             }
         }
 
-        template <fs::raster_connect RC>
-        void raster_grid__neighbor_distances(benchmark::State& state)
-        {
-            using size_type = typename fs::raster_grid::size_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape {n, n};
-
-            auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
-
-            for (auto _ : state)
-            {
-                for (size_type r = 0; r < shape[0]; ++r)
-                {
-                    for (size_type c = 0; c < shape[1]; ++c)
-                    {
-                        auto nb_distances = rg.neighbor_distances<RC>(r * shape[1] + c);
-                    }
-                }
-            }
-        }
-
-        template <fs::raster_connect RC>
+        template <class G>
         void raster_grid__neighbor_classic(benchmark::State& state)
         {
-            using size_type = typename fs::raster_grid::size_type;
+            using grid_type = G;
+            using size_type = typename grid_type::size_type;
+            using neighbors_offsets_type = typename raster_neighbors<raster_connect::queen>::neighbors_offsets_type;
 
             auto n = static_cast<size_type>(state.range(0));
             std::array<size_type, 2> shape {n, n};
 
-            auto rg = fs::raster_grid(shape, {1., 1.}, fs::node_status::fixed_value_boundary);
+            neighbors_offsets_type::shape_type sh0 = {grid_type::max_neighbors()};
+            neighbors_offsets_type offsets = xt::empty<xt::xtensor_fixed<std::ptrdiff_t, xt::xshape<2>>>(sh0);
 
-            auto get_neighbors_indices = [&shape](auto& r, auto& c) -> fs::raster_grid::offset_list {
+            auto get_neighbors_indices = [&shape, &offsets](auto& r, auto& c) -> neighbors_offsets_type {
 
-                fs::raster_grid::offset_list::shape_type sh0 = {8};
-                fs::raster_grid::offset_list offsets = xt::empty<xt::xtensor_fixed<std::ptrdiff_t, xt::xshape<2>>>(sh0);
-
-                for(std::size_t k=1; k<=8; ++k)
+                    for(std::size_t k=1; k<=grid_type::max_neighbors(); ++k)
                     {
                         const index_t kr = r + fs::consts::d8_row_offsets[k];
                         const index_t kc = c + fs::consts::d8_col_offsets[k];
@@ -289,7 +113,7 @@ namespace fastscapelib
                             continue;
                         }
                     }
-                return offsets;
+                    return offsets;
                 };
 
             for (auto _ : state)
@@ -304,50 +128,38 @@ namespace fastscapelib
             }
         }
 
-        BENCHMARK_TEMPLATE(raster_grid__ctor, fs::xtensor_selector)
-        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+        using queen_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, detail::neighbors_no_cache<8>>;
+        using queen_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, detail::neighbors_cache<8>>;
 
-        BENCHMARK_TEMPLATE(raster_grid__gcode_index, fs::xtensor_selector)
-        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+        using rook_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, detail::neighbors_no_cache<4>>;
+        using rook_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, detail::neighbors_cache<4>>;
 
-        BENCHMARK_TEMPLATE(raster_grid__gcode_rowcol, fs::xtensor_selector)
-        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+        using bishop_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, detail::neighbors_no_cache<4>>;
+        using bishop_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, detail::neighbors_cache<4>>;
 
-        BENCHMARK_TEMPLATE(raster_grid__neighbors_count, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
 
-        BENCHMARK_TEMPLATE(raster_grid__neighbors_distance, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+#define BENCH_GRID(NAME, GRID)                              \
+    BENCHMARK_TEMPLATE(NAME, GRID)                          \
+    ->Apply(bms::small_grid_sizes<benchmark::kMillisecond>);  
 
-        BENCHMARK_TEMPLATE(raster_grid__neighbors, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+#define BENCH_RC(NAME)                \
+    BENCH_GRID(NAME, queen_nocache)   \
+    BENCH_GRID(NAME, rook_nocache)    \
+    BENCH_GRID(NAME, bishop_nocache)
 
-        BENCHMARK_TEMPLATE(raster_grid__neighbor_classic, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+#define BENCH_ALL(NAME)               \
+    BENCH_GRID(NAME, queen_nocache)   \
+    BENCH_GRID(NAME, queen_cacheall)  \
+    BENCH_GRID(NAME, rook_nocache)    \
+    BENCH_GRID(NAME, rook_cacheall)   \
+    BENCH_GRID(NAME, bishop_nocache)  \
+    BENCH_GRID(NAME, bishop_cacheall)
 
-        BENCHMARK_TEMPLATE(raster_grid__ref_neighbors, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
 
-        BENCHMARK_TEMPLATE(raster_grid__neighbor_offsets, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
-
-        BENCHMARK_TEMPLATE(raster_grid__neighbor_indices, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
-
-        BENCHMARK_TEMPLATE(raster_grid__neighbor_indices, fs::raster_connect::rook)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
-
-        BENCHMARK_TEMPLATE(raster_grid__neighbor_view, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
-
-        BENCHMARK_TEMPLATE(raster_grid__neighbor_view, fs::raster_connect::rook)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
-
-        BENCHMARK_TEMPLATE(raster_grid__neighbor_distances, fs::raster_connect::queen)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
-
-        BENCHMARK_TEMPLATE(raster_grid__neighbor_distances, fs::raster_connect::rook)
-        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+        BENCH_ALL(raster_grid__ctor);
+        BENCH_ALL(raster_grid__neighbors);
+        BENCH_RC(raster_grid__neighbor_classic);
+        BENCH_ALL(raster_grid__neighbor_view);
 
     } // namespace bench
 } // namespace fastscapelib

--- a/benchmark/benchmark_setup.hpp
+++ b/benchmark/benchmark_setup.hpp
@@ -36,6 +36,20 @@ static void grid_sizes(benchmark::internal::Benchmark* bench) {
     }
 }
 
+/*
+ * Run benchmarks for different grid sizes.
+ * 
+ * Only use 2 different sizes to keep it simple and readable.
+ */
+template<benchmark::TimeUnit time_unit>
+static void small_grid_sizes(benchmark::internal::Benchmark* bench) {
+    std::array<int, 2> sizes {512, 2048};
+
+    for (int s : sizes)
+    {
+        bench->Args({s})->Unit(time_unit);
+    }
+}
 
 enum class SurfaceType {cone, cone_inv, cone_noise, flat_noise, gauss, custom};
 

--- a/include/fastscapelib/flow_routing.hpp
+++ b/include/fastscapelib/flow_routing.hpp
@@ -3,7 +3,8 @@
  * surface and compute flow path-related features or structures.
  *
  */
-#pragma once
+#ifndef FASTSCAPELIB_FLOW_ROUTING_H
+#define FASTSCAPELIB_FLOW_ROUTING_H
 
 #include <algorithm>
 #include <array>
@@ -526,3 +527,5 @@ void compute_drainage_area(xtensor_t<D>& drainage_area,
 }
 
 }  // namespace fastscapelib
+
+#endif

--- a/include/fastscapelib/hillslope.hpp
+++ b/include/fastscapelib/hillslope.hpp
@@ -1,7 +1,8 @@
 /**
  * Functions to compute hillslope erosion.
  */
-#pragma once
+#ifndef FASTSCAPELIB_HILLSLOPE_H
+#define FASTSCAPELIB_HILLSLOPE_H
 
 #include <array>
 #include <cstddef>
@@ -323,3 +324,5 @@ void erode_linear_diffusion(xtensor_t<Er>& erosion,
 }
 
 }  // namespace fastscapelib
+
+#endif

--- a/include/fastscapelib/profile_grid.hpp
+++ b/include/fastscapelib/profile_grid.hpp
@@ -1,7 +1,8 @@
 /**
  * A profile grid is a one dimensional grid.
  */
-#pragma once
+#ifndef FASTSCAPELIB_PROFILE_GRID_H
+#define FASTSCAPELIB_PROFILE_GRID_H
 
 #include "fastscapelib/structured_grid.hpp"
 
@@ -108,13 +109,13 @@ namespace fastscapelib
         using size_type = typename xt_type::size_type;
         using shape_type = typename xt_type::shape_type;
         using length_type = double;
+        using distance_type = double;
         using spacing_type = length_type;
 
         using code_type = std::uint8_t;
-        using neighbors_count_type = std::uint8_t;
 
-        using neighbors_indices_type = typename std::array<std::size_t, 2>;
-        using neighbors_distances_type = typename std::array<double, 2>;
+        using neighbors_count_type = std::uint8_t;
+        using neighbors_distances_impl_type = typename std::array<distance_type, max_neighbors>;
 
         using boundary_status_type = profile_boundary_status;
         using node_status_type = xt_container_t<xt_selector, node_status, xt_ndims>;
@@ -143,13 +144,14 @@ namespace fastscapelib
         using shape_type = typename inner_types::shape_type;
         using length_type = typename inner_types::length_type;
         using spacing_type = typename inner_types::spacing_type;
+        using distance_type = typename inner_types::distance_type;
 
         using code_type = typename inner_types::code_type;
 
         using neighbors_type = typename base_type::neighbors_type;
-        using neighbors_indices_type = typename inner_types::neighbors_indices_type;
-        using neighbors_distances_type = typename inner_types::neighbors_distances_type;
         using neighbors_count_type = typename inner_types::neighbors_count_type;
+        using neighbors_indices_type = typename base_type::neighbors_indices_type;
+        using neighbors_distances_type = typename base_type::neighbors_distances_type;
 
         using boundary_status_type = typename inner_types::boundary_status_type;
         using node_status_type = typename inner_types::node_status_type;
@@ -165,7 +167,10 @@ namespace fastscapelib
                                            const std::vector<node>& status_at_nodes = {});
     protected:
 
-        using coded_neighbors_distances_type = std::array<neighbors_distances_type, 3>;
+        using neighbors_distances_impl_type = typename inner_types::neighbors_distances_impl_type;
+        using neighbors_indices_impl_type = typename base_type::neighbors_indices_impl_type;
+
+        using coded_ndistances_type = std::array<neighbors_distances_impl_type, 3>;
 
         shape_type m_shape;
         size_type m_size;
@@ -182,7 +187,7 @@ namespace fastscapelib
         static constexpr std::array<std::ptrdiff_t, 3> offsets { {0, -1, 1} };
         std::vector<neighbors_type> m_all_neighbors;
 
-        coded_neighbors_distances_type m_neighbors_distances;
+        coded_ndistances_type m_neighbors_distances;
         void build_neighbors_distances();
 
         void build_gcode();
@@ -193,9 +198,9 @@ namespace fastscapelib
         inline const neighbors_count_type& neighbors_count(const size_type& idx) const noexcept;
         inline const neighbors_count_type& neighbors_count(const code_type& code) const noexcept;
 
-        void neighbors_indices_impl(neighbors_indices_type& neighbors, const size_type& idx) const;
+        void neighbors_indices_impl(neighbors_indices_impl_type& neighbors, const size_type& idx) const;
 
-        const neighbors_distances_type& neighbors_distance_impl(const size_type& idx) const;
+        const neighbors_distances_impl_type& neighbors_distances_impl(const size_type& idx) const;
 
         friend class structured_grid<self_type, C>;
     };
@@ -332,14 +337,14 @@ namespace fastscapelib
     }
 
     template <class XT, class C>
-    auto profile_grid_xt<XT, C>::neighbors_distance_impl(const size_type& /*idx*/) const
-    -> const neighbors_distances_type&
+    auto profile_grid_xt<XT, C>::neighbors_distances_impl(const size_type& /*idx*/) const
+    -> const neighbors_distances_impl_type&
     {
         return m_neighbors_distances[0];
     }
 
     template <class XT, class C>
-    inline auto profile_grid_xt<XT, C>::neighbors_indices_impl(neighbors_indices_type& neighbors, const size_type& idx) const
+    inline auto profile_grid_xt<XT, C>::neighbors_indices_impl(neighbors_indices_impl_type& neighbors, const size_type& idx) const
         -> void
     {
         if (idx==0)
@@ -378,3 +383,5 @@ namespace fastscapelib
      */
     using profile_grid = profile_grid_xt<xtensor_selector>;
 }
+
+#endif

--- a/include/fastscapelib/sinks.hpp
+++ b/include/fastscapelib/sinks.hpp
@@ -2,7 +2,8 @@
  * Provides implementation of various efficient algorithms for
  * depression filling or pit resolving.
  */
-#pragma once
+#ifndef FASTSCAPELIB_SINKS_H
+#define FASTSCAPELIB_SINKS_H
 
 #include <cmath>
 #include <functional>
@@ -19,220 +20,220 @@
 
 namespace fastscapelib
 {
-
-namespace detail
-{
-
-
-/**
- * A simple grid node container.
- *
- * Stores both a position (r, c) and a value at that position.
- * Also defines  operator '>' that compares only on `value`.
- *
- * The main purpose of this container is for using with
- * (priority) queues.
- */
-template<class T>
-struct node_container
-{
-    index_t r;
-    index_t c;
-    T value;
-    node_container() { }
-    node_container(index_t row, index_t col, T val) :
-        r(row), c(col), value(val) { }
-    bool operator > (const node_container<T>& other) const
+    namespace detail
     {
-        return value > other.value;
-    }
-};
 
 
-template<class T>
-using node_pr_queue = std::priority_queue<node_container<T>,
-                                          std::vector<node_container<T>>,
-                                          std::greater<node_container<T>>>;
-
-
-template<class T>
-using node_queue = std::queue<node_container<T>>;
-
-
-/**
- * Initialize priority flood algorithms.
- *
- * Add border grid nodes to the priority queue and mark them as
- * resolved.
- */
-template<class E, class elev_t = typename std::decay_t<E>::value_type>
-void init_pflood(E&& elevation,
-                 xt::xtensor<bool, 2>& closed,
-                 node_pr_queue<elev_t>& open)
-{
-    auto elev_shape = elevation.shape();
-
-    index_t nrows = static_cast<index_t>(elev_shape[0]);
-    index_t ncols = static_cast<index_t>(elev_shape[1]);
-
-    auto place_node = [&](index_t row, index_t col)
-    {
-        open.emplace(node_container<elev_t>(row, col, elevation(row, col)));
-        closed(row, col) = true;
-    };
-
-    for(index_t c=0; c<ncols; ++c)
-    {
-        place_node(0, c);
-        place_node(nrows-1, c);
-    }
-
-    for(index_t r=1; r<nrows-1; ++r)
-    {
-        place_node(r, 0);
-        place_node(r, ncols-1);
-    }
-}
-
-
-/**
- * fill_sinks_flat implementation.
- */
-template<class E>
-void fill_sinks_flat_impl(E&& elevation)
-{
-    using elev_t = typename std::decay_t<E>::value_type;
-    auto elev_shape = elevation.shape();
-
-    node_pr_queue<elev_t> open;
-    xt::xtensor<bool, 2> closed = xt::zeros<bool>(elev_shape);
-
-    init_pflood(elevation, closed, open);
-
-    while(open.size()>0)
-    {
-        node_container<elev_t> inode = open.top();
-        open.pop();
-
-        for(unsigned short k=1; k<=8; ++k)
+        /**
+         * A simple grid node container.
+         *
+         * Stores both a position (r, c) and a value at that position.
+         * Also defines  operator '>' that compares only on `value`.
+         *
+         * The main purpose of this container is for using with
+         * (priority) queues.
+         */
+        template<class T>
+        struct node_container
         {
-            index_t kr = inode.r + fastscapelib::consts::d8_row_offsets[k];
-            index_t kc = inode.c + fastscapelib::consts::d8_col_offsets[k];
-
-            if(!fastscapelib::detail::in_bounds(elev_shape, kr, kc)) { continue; }
-            if(closed(kr, kc)) { continue; }
-
-            elevation(kr, kc) = std::max(elevation(kr, kc), inode.value);
-            open.emplace(node_container<elev_t>(kr, kc, elevation(kr, kc)));
-            closed(kr, kc) = true;
-        }
-    }
-}
-
-
-/**
- * fill_sinks_sloped implementation.
- */
-template<class E>
-void fill_sinks_sloped_impl(E&& elevation)
-{
-    using elev_t = typename std::decay_t<E>::value_type;
-    auto elev_shape = elevation.shape();
-
-    node_pr_queue<elev_t> open;
-    node_queue<elev_t> pit;
-    xt::xtensor<bool, 2> closed = xt::zeros<bool>(elev_shape);
-
-    init_pflood(elevation, closed, open);
-
-    while(!open.empty() || !pit.empty())
-    {
-        node_container<elev_t> inode, knode;
-
-        if(!pit.empty() &&
-           (open.empty() || open.top().value == pit.front().value))
-        {
-            inode = pit.front();
-            pit.pop();
-        }
-        else
-        {
-            inode = open.top();
-            open.pop();
-        }
-
-        elev_t elev_tiny_step = std::nextafter(
-            inode.value, std::numeric_limits<elev_t>::infinity());
-
-        for(unsigned short k=1; k<=8; ++k)
-        {
-            index_t kr = inode.r + fastscapelib::consts::d8_row_offsets[k];
-            index_t kc = inode.c + fastscapelib::consts::d8_col_offsets[k];
-
-            if(!fastscapelib::detail::in_bounds(elev_shape, kr, kc)) { continue; }
-            if(closed(kr, kc)) { continue; }
-
-            if(elevation(kr, kc) <= elev_tiny_step)
+            index_t r;
+            index_t c;
+            T value;
+            node_container() { }
+            node_container(index_t row, index_t col, T val) :
+                r(row), c(col), value(val) { }
+            bool operator > (const node_container<T>& other) const
             {
-                elevation(kr, kc) = elev_tiny_step;
-                knode = node_container<elev_t>(kr, kc, elevation(kr, kc));
-                pit.emplace(knode);
+                return value > other.value;
             }
-            else
+        };
+
+
+        template<class T>
+        using node_pr_queue = std::priority_queue<node_container<T>,
+                                                std::vector<node_container<T>>,
+                                                std::greater<node_container<T>>>;
+
+
+        template<class T>
+        using node_queue = std::queue<node_container<T>>;
+
+
+        /**
+         * Initialize priority flood algorithms.
+         *
+         * Add border grid nodes to the priority queue and mark them as
+         * resolved.
+         */
+        template<class E, class elev_t = typename std::decay_t<E>::value_type>
+        void init_pflood(E&& elevation,
+                        xt::xtensor<bool, 2>& closed,
+                        node_pr_queue<elev_t>& open)
+        {
+            auto elev_shape = elevation.shape();
+
+            index_t nrows = static_cast<index_t>(elev_shape[0]);
+            index_t ncols = static_cast<index_t>(elev_shape[1]);
+
+            auto place_node = [&](index_t row, index_t col)
             {
-                knode = node_container<elev_t>(kr, kc, elevation(kr, kc));
-                open.emplace(knode);
+                open.emplace(node_container<elev_t>(row, col, elevation(row, col)));
+                closed(row, col) = true;
+            };
+
+            for(index_t c=0; c<ncols; ++c)
+            {
+                place_node(0, c);
+                place_node(nrows-1, c);
             }
 
-            closed(kr, kc) = true;
+            for(index_t r=1; r<nrows-1; ++r)
+            {
+                place_node(r, 0);
+                place_node(r, ncols-1);
+            }
         }
+
+
+        /**
+         * fill_sinks_flat implementation.
+         */
+        template<class E>
+        void fill_sinks_flat_impl(E&& elevation)
+        {
+            using elev_t = typename std::decay_t<E>::value_type;
+            auto elev_shape = elevation.shape();
+
+            node_pr_queue<elev_t> open;
+            xt::xtensor<bool, 2> closed = xt::zeros<bool>(elev_shape);
+
+            init_pflood(elevation, closed, open);
+
+            while(open.size()>0)
+            {
+                node_container<elev_t> inode = open.top();
+                open.pop();
+
+                for(unsigned short k=1; k<=8; ++k)
+                {
+                    index_t kr = inode.r + fastscapelib::consts::d8_row_offsets[k];
+                    index_t kc = inode.c + fastscapelib::consts::d8_col_offsets[k];
+
+                    if(!fastscapelib::detail::in_bounds(elev_shape, kr, kc)) { continue; }
+                    if(closed(kr, kc)) { continue; }
+
+                    elevation(kr, kc) = std::max(elevation(kr, kc), inode.value);
+                    open.emplace(node_container<elev_t>(kr, kc, elevation(kr, kc)));
+                    closed(kr, kc) = true;
+                }
+            }
+        }
+
+
+        /**
+         * fill_sinks_sloped implementation.
+         */
+        template<class E>
+        void fill_sinks_sloped_impl(E&& elevation)
+        {
+            using elev_t = typename std::decay_t<E>::value_type;
+            auto elev_shape = elevation.shape();
+
+            node_pr_queue<elev_t> open;
+            node_queue<elev_t> pit;
+            xt::xtensor<bool, 2> closed = xt::zeros<bool>(elev_shape);
+
+            init_pflood(elevation, closed, open);
+
+            while(!open.empty() || !pit.empty())
+            {
+                node_container<elev_t> inode, knode;
+
+                if(!pit.empty() &&
+                (open.empty() || open.top().value == pit.front().value))
+                {
+                    inode = pit.front();
+                    pit.pop();
+                }
+                else
+                {
+                    inode = open.top();
+                    open.pop();
+                }
+
+                elev_t elev_tiny_step = std::nextafter(
+                    inode.value, std::numeric_limits<elev_t>::infinity());
+
+                for(unsigned short k=1; k<=8; ++k)
+                {
+                    index_t kr = inode.r + fastscapelib::consts::d8_row_offsets[k];
+                    index_t kc = inode.c + fastscapelib::consts::d8_col_offsets[k];
+
+                    if(!fastscapelib::detail::in_bounds(elev_shape, kr, kc)) { continue; }
+                    if(closed(kr, kc)) { continue; }
+
+                    if(elevation(kr, kc) <= elev_tiny_step)
+                    {
+                        elevation(kr, kc) = elev_tiny_step;
+                        knode = node_container<elev_t>(kr, kc, elevation(kr, kc));
+                        pit.emplace(knode);
+                    }
+                    else
+                    {
+                        knode = node_container<elev_t>(kr, kc, elevation(kr, kc));
+                        open.emplace(knode);
+                    }
+
+                    closed(kr, kc) = true;
+                }
+            }
+        }
+
+    }  // namespace detail
+
+
+    /**
+     * Fill all pits and remove all digital dams from a digital
+     * elevation model (rectangular grid).
+     *
+     * Elevation values may be updated so that no depression (sinks or
+     * local minima) remains.
+     *
+     * The algorithm is based on priority queues and is detailed
+     * in Barnes (2014). It fills sinks with flat areas.
+     *
+     * @param elevation : ``[intent=inout, shape=(nrows, ncols)]``
+     *     Elevation at grid node.
+     */
+    template<class E>
+    void fill_sinks_flat(xtensor_t<E>& elevation)
+    {
+        detail::fill_sinks_flat_impl(elevation.derived_cast());
     }
-}
-
-}  // namespace detail
 
 
-/**
- * Fill all pits and remove all digital dams from a digital
- * elevation model (rectangular grid).
- *
- * Elevation values may be updated so that no depression (sinks or
- * local minima) remains.
- *
- * The algorithm is based on priority queues and is detailed
- * in Barnes (2014). It fills sinks with flat areas.
- *
- * @param elevation : ``[intent=inout, shape=(nrows, ncols)]``
- *     Elevation at grid node.
- */
-template<class E>
-void fill_sinks_flat(xtensor_t<E>& elevation)
-{
-    detail::fill_sinks_flat_impl(elevation.derived_cast());
-}
-
-
-/**
- * Fill all pits and remove all digital dams from a digital
- * elevation model (rectangular grid).
- *
- * Elevation values may be updated so that no depression (sinks or
- * local minima) remains.
- *
- * The algorithm is based on priority queues and is detailed in Barnes
- * (2014). This variant fills sinks with nearly flat areas
- * (i.e. elevation is increased by small amount) so that there is no
- * drainage singularities.
- *
- * @param elevation : ``[intent=inout, shape=(nrows, ncols)]``
- *     Elevation at grid node.
- *
- * @sa fill_sinks_flat
- */
-template<class E>
-void fill_sinks_sloped(xtensor_t<E>& elevation)
-{
-    detail::fill_sinks_sloped_impl(elevation.derived_cast());
-}
-
+    /**
+     * Fill all pits and remove all digital dams from a digital
+     * elevation model (rectangular grid).
+     *
+     * Elevation values may be updated so that no depression (sinks or
+     * local minima) remains.
+     *
+     * The algorithm is based on priority queues and is detailed in Barnes
+     * (2014). This variant fills sinks with nearly flat areas
+     * (i.e. elevation is increased by small amount) so that there is no
+     * drainage singularities.
+     *
+     * @param elevation : ``[intent=inout, shape=(nrows, ncols)]``
+     *     Elevation at grid node.
+     *
+     * @sa fill_sinks_flat
+     */
+    template<class E>
+    void fill_sinks_sloped(xtensor_t<E>& elevation)
+    {
+        detail::fill_sinks_sloped_impl(elevation.derived_cast());
+    }
 }  // namespace fastscapelib
+
+#endif

--- a/include/fastscapelib/utils.hpp
+++ b/include/fastscapelib/utils.hpp
@@ -2,7 +2,9 @@
  * @file
  * @brief Some utilities used internally.
  */
-#pragma once
+#ifndef FASTSCAPELIB_UTILS_H
+#define FASTSCAPELIB_UTILS_H
+
 
 #include <cstddef>
 #include <type_traits>
@@ -25,27 +27,23 @@ using xtensor_t = xt::xexpression<E>;
 
 namespace fastscapelib
 {
-
-namespace detail
-{
-
-
-/**
- * @brief Return true if a given (row, col) index is in bounds (false
- *        otherwise).
- */
-template<class S>
-bool in_bounds(const S& shape, index_t row, index_t col)
-{
-    if(row >= 0 && row < static_cast<index_t>(shape[0])
-       && col >= 0 && col < static_cast<index_t>(shape[1]))
+    namespace detail
     {
-        return true;
+        /**
+         * @brief Return true if a given (row, col) index is in bounds (false
+         *        otherwise).
+         */
+        template<class S>
+        bool in_bounds(const S& shape, index_t row, index_t col)
+        {
+            if(row >= 0 && row < static_cast<index_t>(shape[0])
+            && col >= 0 && col < static_cast<index_t>(shape[1]))
+            {
+                return true;
+            }
+            return false;
+        }
     }
-    return false;
 }
 
-
-}  // namespace detail
-
-}  // namespace fastscapelib
+#endif

--- a/include/fastscapelib/xtensor_utils.hpp
+++ b/include/fastscapelib/xtensor_utils.hpp
@@ -1,7 +1,9 @@
 /**
  * xtensor utils (container tags, etc.)
  */
-#pragma once
+#ifndef FASTSCAPELIB_XTENSOR_UTILS_H
+#define FASTSCAPELIB_XTENSOR_UTILS_H
+
 
 #include <cstddef>
 
@@ -38,3 +40,5 @@ namespace fastscapelib
     using xt_container_t = typename xt_container<X, T, N>::type;
 
 } // namespace fastscapelib
+
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,9 @@ set(FASTSCAPELIB_TEST_SRC
     test_flow_routing.cpp
     test_profile_grid.cpp
     test_raster_grid.cpp
+    test_raster_rook_grid.cpp
+    test_raster_queen_grid.cpp
+    test_raster_bishop_grid.cpp    
     test_sinks.cpp
     test_bedrock_channel.cpp
 )

--- a/test/test_raster_bishop_grid.cpp
+++ b/test/test_raster_bishop_grid.cpp
@@ -1,0 +1,336 @@
+#include "test_raster_grid.hpp"
+
+
+namespace fs = fastscapelib;
+
+namespace fastscapelib
+{
+    namespace testing
+    {
+
+        TEST_F(bishop_raster_grid, max_neighbors)
+        {
+            EXPECT_EQ(grid_type::max_neighbors(), 4u);
+        }
+
+#define EXPECT_INDICES(ROW, COL, INDICES, RC_INDICES)                  \
+    EXPECT_EQ(bishop_fixed.neighbors_indices(ROW*shape[1]+COL),        \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
+    EXPECT_EQ((bishop_fixed.neighbors_indices(ROW, COL)),              \
+              (grid_type::neighbors_indices_raster_type RC_INDICES));    
+
+        TEST_F(bishop_raster_grid_fixed, neighbors_indices)
+        {
+            { // First row
+                // Top-left corner
+                EXPECT_INDICES(0, 0,
+                               ({ 11}),
+                               ({ /*(r,c)*/
+                                            { 1, 1 } }));
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(0, c, 
+                                   ({shape[1]+c-1, shape[1]+c+1}),
+                                   ({             /*(r,c)*/
+                                      { 1, c-1 },           { 1, c+1 } }));
+                }
+                // Top-right corner
+                EXPECT_INDICES(0, 9,
+                               ({18}),
+                               ({           /*(r,c)*/
+                                  { 1, 8 },          }));
+            }
+            { // Inners rows
+                for(std::size_t r=1; r<4; ++r)
+                {
+                    // First col
+                    EXPECT_INDICES(r, 0,
+                                   ({(r-1)*shape[1]+1, (r+1)*shape[1]+1}),
+                                   ({            { r-1, 1 },
+                                       /*(r,c)*/
+                                                 { r+1, 1 }}));
+                    // Inners cols
+                    for(std::size_t c=1; c<9; ++c)
+                    {
+                        EXPECT_INDICES(r, c, 
+                                   ({(r-1)*shape[1]+c-1, (r-1)*shape[1]+c+1,
+                                     (r+1)*shape[1]+c-1, (r+1)*shape[1]+c+1}),
+                                   ({ { r-1, c-1 },           { r-1, c+1 },
+                                                    /*(r,c)*/
+                                      { r+1, c-1 },           { r+1, c+1 } }));
+                    }
+                    // last col
+                    EXPECT_INDICES(r, shape[1]-1,
+                            ({(r-1)*shape[1]+8, (r+1)*shape[1]+8}),
+                            ({ { r-1, 8 },
+                                           /*(r,c)*/
+                               { r+1, 8 },           }));
+                }
+            }
+
+            { // Last row
+                // Bottom-left corner
+                EXPECT_INDICES(4, 0,
+                               ({31}),
+                               ({           { 3, 1 },
+                                  /*(r,c)*/          }));
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(4, c, 
+                                   ({30+c-1, 30+c+1}),
+                                   ({ { 3, c-1 },           { 3, c+1 },
+                                                  /*(r,c)*/            }));
+                }
+                // Bottom-right corner
+                EXPECT_INDICES(4, 9,
+                               ({38}),
+                               ({ { 3, 8 }
+                                           /*(r,c)*/ }));
+            }
+        }
+#undef EXPECT_INDICES
+
+#define EXPECT_INDICES(ROW, COL, INDICES, RC_INDICES)                  \
+    EXPECT_EQ(bishop_looped.neighbors_indices(ROW*shape[1]+COL),       \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
+    EXPECT_EQ((bishop_looped.neighbors_indices(ROW, COL)),             \
+              (grid_type::neighbors_indices_raster_type RC_INDICES));  
+
+        TEST_F(bishop_raster_grid_looped, neighbors_indices)
+        {
+            { // First row
+                // Top-left corner
+                EXPECT_INDICES(0, 0,
+                               ({49, 41, 19, 11}), 
+                               ({ { 4, 9 },          { 4, 1 },
+                                           /*(r,c)*/
+                                  { 1, 9 },          { 1, 1 } }));
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(0, c, 
+                                   ({40+c-1, 40+c+1,
+                                     10+c-1, 10+c+1}),
+                                   ({ { 4, c-1 },           { 4, c+1 },
+                                                  /*(r,c)*/
+                                      { 1, c-1 },           { 1, c+1 } }));
+                }
+                // Top-right corner
+                EXPECT_INDICES(0, 9,
+                               ({48, 40, 18, 10}),
+                               ({ { 4, 8 },           { 4, 0 },
+                                            /*(r,c)*/
+                                  { 1, 8 },           { 1, 0 } }));
+            }
+            { // Inners rows
+                for(std::size_t r=1; r<4; ++r)
+                {
+                    // First col
+                    EXPECT_INDICES(r, 0,
+                                   ({(r-1)*shape[1]+9, (r-1)*shape[1]+1,
+                                     (r+1)*shape[1]+9, (r+1)*shape[1]+1}),
+                                   ({ { r-1, 9 },           { r-1, 1 },
+                                                  /*(r,c)*/
+                                      { r+1, 9 },           { r+1, 1 }}));
+                    // Inners cols
+                    for(std::size_t c=1; c<9; ++c)
+                    {
+                        EXPECT_INDICES(r, c,
+                                       ({(r-1)*shape[1]+c-1, (r-1)*shape[1]+c+1,
+                                         (r+1)*shape[1]+c-1, (r+1)*shape[1]+c+1}),
+                                       ({ { r-1, c-1 },           { r-1, c+1 },
+                                                        /*(r,c)*/
+                                          { r+1, c-1 },           { r+1, c+1 }}));
+                    }
+                    // last col
+                    EXPECT_INDICES(r, shape[1]-1,
+                                    ({(r-1)*shape[1]+8, (r-1)*shape[1],
+                                      (r+1)*shape[1]+8, (r+1)*shape[1]}),
+                                    ({ { r-1, 8 },           { r-1, 0 },
+                                                   /*(r,c)*/
+                                       { r+1, 8 },           { r+1, 0 } }));
+                }
+            }
+            { // Last row 
+                // Bottom-left corner
+                EXPECT_INDICES(4, 0,
+                               ({39, 31, 9, 1}),
+                               ({ { 3, 9 },           { 3, 1 },
+                                            /*(r,c)*/
+                                  { 0, 9 },           { 0, 1 } }));
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(4, c,
+                                   ({3*shape[1]+c-1, 3*shape[1]+c+1,
+                                     c-1, c+1}),
+                                   ({ { 3, c-1 },           { 3, c+1 },
+                                                  /*(r,c)*/
+                                      { 0, c-1 },           { 0, c+1 }}));
+                }
+                // Bottom-right corner
+                EXPECT_INDICES(4, 9,
+                               ({38, 30, 8, 0}),
+                                ({ { 3, 8 },           { 3, 0 },
+                                             /*(r,c)*/
+                                   { 0, 8 },           { 0, 0 } }));
+            }
+        }
+#undef EXPECT_INDICES
+
+
+        TEST_F(bishop_raster_grid_fixed, neighbors_distances)
+        {
+            using distance_type = grid_type::distance_type;
+            using neighbors_distances_type = grid_type::neighbors_distances_type;
+
+            distance_type dia = std::sqrt(1.2*1.2 + 1.3*1.3);
+
+            // Top-left corner
+            EXPECT_EQ(bishop_fixed.neighbors_distances(0),
+                      (neighbors_distances_type {dia}));
+
+            // Bottom-right corner
+            EXPECT_EQ(bishop_fixed.neighbors_distances(49),
+                      (neighbors_distances_type {dia}));
+
+            // Inners rows/cols    
+            for(std::size_t r=1; r<4; ++r)
+            {
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_EQ(bishop_fixed.neighbors_distances(r*shape[1]+c),
+                            (neighbors_distances_type {dia, dia, dia, dia}));
+                }
+            }
+        }
+
+        TEST_F(bishop_raster_grid_looped, neighbors_distances)
+        {
+            using distance_type = grid_type::distance_type;
+            using neighbors_distances_type = grid_type::neighbors_distances_type;
+
+            distance_type dia = std::sqrt(1.4*1.4 + 1.8*1.8);
+   
+            for(std::size_t r=0; r<5; ++r)
+            {
+                for(std::size_t c=0; c<10; ++c)
+                {
+                    EXPECT_EQ(bishop_looped.neighbors_distances(r*shape[1]+c),
+                              (neighbors_distances_type {dia, dia, dia, dia}));
+                }
+            }
+        }
+
+        TEST_F(bishop_raster_grid_fixed, neighbors)
+        {
+            using neighbors_type = xt::xtensor<fs::neighbor, 1>;
+
+            double d1 = std::sqrt(1.3*1.3 + 1.2*1.2);
+            double d2 = std::sqrt(1.4*1.4 + 1.8*1.8);
+
+            { // First row
+                // Top-left corner
+                EXPECT_EQ(bishop_fixed.neighbors(0),
+                          (neighbors_type {   /* Node */
+                                                         {11, d1, co} } ));
+
+                EXPECT_EQ(bishop_looped.neighbors(0), 
+                          (neighbors_type { {49, d2, lb},            {41, d2, lb},
+                                                          /* Node */
+                                            {19, d2, lb},            {11, d2, co} } ));
+
+                // Inner cols
+                for(std::size_t c=2; c<8; ++c)
+                {
+                    EXPECT_EQ(bishop_fixed.neighbors(c), 
+                              (neighbors_type {                 /* Node */
+                                                {c+9,  d1, co},            {c+11, d1, co} } ));
+
+                    EXPECT_EQ(bishop_looped.neighbors(c), 
+                              (neighbors_type { {c+39, d2, lb},            {c+41, d2, lb},
+                                                                /* Node */
+                                                {c+9,  d2, co},            {c+11, d2, co} } ));
+                }
+
+                EXPECT_EQ(bishop_looped.neighbors(22), 
+                          (neighbors_type { {11,  d2, co},            {13,  d2, co},
+                                                           /* Node */
+                                            {31,  d2, co},            {33,  d2, co} } ));
+            }
+        }
+
+        TEST_F(bishop_raster_grid, neighbors_count)
+        {
+            // Top-left corner nodes
+            EXPECT_EQ(bishop_fixed.neighbors_count(static_cast<std::size_t>(0)), 1);
+            EXPECT_EQ(bishop_hlooped.neighbors_count(static_cast<std::size_t>(0)), 2);
+            EXPECT_EQ(bishop_vlooped.neighbors_count(static_cast<std::size_t>(0)), 2);
+            EXPECT_EQ(bishop_looped.neighbors_count(static_cast<std::size_t>(0)), 4);
+            
+            // Top-right corner nodes
+            EXPECT_EQ(bishop_fixed.neighbors_count(shape[1]-1), 1);
+            EXPECT_EQ(bishop_hlooped.neighbors_count(shape[1]-1), 2);
+            EXPECT_EQ(bishop_vlooped.neighbors_count(shape[1]-1), 2);
+            EXPECT_EQ(bishop_looped.neighbors_count(shape[1]-1), 4);
+
+            // Bottom-left corner nodes
+            EXPECT_EQ(bishop_fixed.neighbors_count((shape[0]-1)*shape[1]), 1);
+            EXPECT_EQ(bishop_hlooped.neighbors_count((shape[0]-1)*shape[1]), 2);
+            EXPECT_EQ(bishop_vlooped.neighbors_count((shape[0]-1)*shape[1]), 2);
+            EXPECT_EQ(bishop_looped.neighbors_count((shape[0]-1)*shape[1]), 4);
+
+            // Bottom-right corner nodes
+            EXPECT_EQ(bishop_fixed.neighbors_count(shape[0]*shape[1]-1), 1);
+            EXPECT_EQ(bishop_hlooped.neighbors_count(shape[0]*shape[1]-1), 2);
+            EXPECT_EQ(bishop_vlooped.neighbors_count(shape[0]*shape[1]-1), 2);
+            EXPECT_EQ(bishop_looped.neighbors_count(shape[0]*shape[1]-1), 4);
+
+            for (std::size_t c=1; c<shape[1]-1; ++c)
+            {   
+                // Top edge nodes (without corners)
+                EXPECT_EQ(bishop_fixed.neighbors_count(c), 2);
+                EXPECT_EQ(bishop_hlooped.neighbors_count(c), 2);
+                EXPECT_EQ(bishop_vlooped.neighbors_count(c), 4);
+                EXPECT_EQ(bishop_looped.neighbors_count(c), 4);
+
+                // Bottom edge nodes (without corners)
+                EXPECT_EQ(bishop_fixed.neighbors_count((shape[0]-1)*shape[1]+c), 2);
+                EXPECT_EQ(bishop_hlooped.neighbors_count((shape[0]-1)*shape[1]+c), 2);
+                EXPECT_EQ(bishop_vlooped.neighbors_count((shape[0]-1)*shape[1]+c), 4);
+                EXPECT_EQ(bishop_looped.neighbors_count((shape[0]-1)*shape[1]+c), 4);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                // Left edge nodes (without corners)
+                EXPECT_EQ(bishop_fixed.neighbors_count(r*shape[1]), 2);
+                EXPECT_EQ(bishop_hlooped.neighbors_count(r*shape[1]), 4);
+                EXPECT_EQ(bishop_vlooped.neighbors_count(r*shape[1]), 2);
+                EXPECT_EQ(bishop_looped.neighbors_count(r*shape[1]), 4);
+
+                // Right edge nodes (without corners)
+                EXPECT_EQ(bishop_fixed.neighbors_count((r+1)*shape[1]-1), 2);
+                EXPECT_EQ(bishop_hlooped.neighbors_count((r+1)*shape[1]-1), 4);
+                EXPECT_EQ(bishop_vlooped.neighbors_count((r+1)*shape[1]-1), 2);
+                EXPECT_EQ(bishop_looped.neighbors_count((r+1)*shape[1]-1), 4);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                for (std::size_t c=1; c<shape[1]-1; ++c)
+                {
+                    // Inner nodes
+                    EXPECT_EQ(bishop_fixed.neighbors_count(r*shape[1]+c), 4);
+                    EXPECT_EQ(bishop_hlooped.neighbors_count(r*shape[1]+c), 4);
+                    EXPECT_EQ(bishop_vlooped.neighbors_count(r*shape[1]+c), 4);
+                    EXPECT_EQ(bishop_looped.neighbors_count(r*shape[1]+c), 4);
+                }
+            }
+        }
+    }
+}

--- a/test/test_raster_grid.cpp
+++ b/test/test_raster_grid.cpp
@@ -1,8 +1,4 @@
-#include "fastscapelib/raster_grid.hpp"
-
-#include "gtest/gtest.h"
-
-#include <array>
+#include "test_raster_grid.hpp"
 
 
 namespace fs = fastscapelib;
@@ -13,45 +9,27 @@ namespace fastscapelib
     namespace testing
     {
 
-       class raster_boundary_status: public ::testing::Test
-        {
-            protected:
-
-                using node_s = fs::node_status;
-
-                node_s fixed = node_s::fixed_value_boundary;
-                std::array<node_s, 4> hloop {{node_s::looped_boundary, node_s::looped_boundary, node_s::fixed_value_boundary, node_s::fixed_value_boundary}};
-                std::array<node_s, 4> vloop {{node_s::fixed_value_boundary, node_s::fixed_value_boundary, node_s::looped_boundary, node_s::looped_boundary}};
-                std::array<node_s, 4> hvloop {{node_s::looped_boundary, node_s::looped_boundary, node_s::looped_boundary, node_s::looped_boundary}};
-                std::array<node_s, 4> hill_formed_loop {{node_s::looped_boundary, node_s::fixed_value_boundary, node_s::looped_boundary, node_s::looped_boundary}};
-
-                fs::raster_boundary_status fixed_value_status {fixed};
-                fs::raster_boundary_status hlooped_status {hloop};
-                fs::raster_boundary_status vlooped_status {vloop};
-                fs::raster_boundary_status hvlooped_status {hvloop};
-        };
-
         TEST_F(raster_boundary_status, ctor)
         {
-            EXPECT_EQ(fixed_value_status.left, fixed);
-            EXPECT_EQ(fixed_value_status.right, fixed);
-            EXPECT_EQ(fixed_value_status.bottom, fixed);
-            EXPECT_EQ(fixed_value_status.top, fixed);
+            EXPECT_EQ(fixed_value_status.left, fb);
+            EXPECT_EQ(fixed_value_status.right, fb);
+            EXPECT_EQ(fixed_value_status.bottom, fb);
+            EXPECT_EQ(fixed_value_status.top, fb);
 
-            EXPECT_EQ(hlooped_status.left, node_s::looped_boundary);
-            EXPECT_EQ(hlooped_status.right, node_s::looped_boundary);
-            EXPECT_EQ(hlooped_status.bottom, node_s::fixed_value_boundary);
-            EXPECT_EQ(hlooped_status.top, node_s::fixed_value_boundary);
+            EXPECT_EQ(hlooped_status.left, lb);
+            EXPECT_EQ(hlooped_status.right, lb);
+            EXPECT_EQ(hlooped_status.bottom, fb);
+            EXPECT_EQ(hlooped_status.top, fb);
 
-            EXPECT_EQ(vlooped_status.left, node_s::fixed_value_boundary);
-            EXPECT_EQ(vlooped_status.right, node_s::fixed_value_boundary);
-            EXPECT_EQ(vlooped_status.bottom, node_s::looped_boundary);
-            EXPECT_EQ(vlooped_status.top, node_s::looped_boundary);
+            EXPECT_EQ(vlooped_status.left, fb);
+            EXPECT_EQ(vlooped_status.right, fb);
+            EXPECT_EQ(vlooped_status.bottom, lb);
+            EXPECT_EQ(vlooped_status.top, lb);
 
-            EXPECT_EQ(hvlooped_status.left, node_s::looped_boundary);
-            EXPECT_EQ(hvlooped_status.right, node_s::looped_boundary);
-            EXPECT_EQ(hvlooped_status.bottom, node_s::looped_boundary);
-            EXPECT_EQ(hvlooped_status.top, node_s::looped_boundary);
+            EXPECT_EQ(hvlooped_status.left, lb);
+            EXPECT_EQ(hvlooped_status.right, lb);
+            EXPECT_EQ(hvlooped_status.bottom, lb);
+            EXPECT_EQ(hvlooped_status.top, lb);
 
             EXPECT_THROW(fs::raster_boundary_status {hill_formed_loop}, std::invalid_argument);
         }
@@ -72,303 +50,24 @@ namespace fastscapelib
             EXPECT_TRUE(hvlooped_status.is_vertical_looped());
         }
 
-        class raster_grid: public ::testing::Test
-        {
-            protected:
-                using node_s = fs::node_status;
-
-                node_s fixed = node_s::fixed_value_boundary;
-                std::array<node_s, 4> hloop {{ node_s::looped_boundary, node_s::looped_boundary, node_s::fixed_value_boundary, node_s::fixed_value_boundary }};
-                std::array<node_s, 4> vloop {{ node_s::fixed_value_boundary, node_s::fixed_value_boundary, node_s::looped_boundary, node_s::looped_boundary }};
-                std::array<node_s, 4> hvloop {{ node_s::looped_boundary, node_s::looped_boundary, node_s::looped_boundary, node_s::looped_boundary }};
-                std::array<node_s, 4> hill_formed_loop {{ node_s::looped_boundary, node_s::fixed_value_boundary, node_s::looped_boundary, node_s::looped_boundary }};
-
-                fs::raster_boundary_status fixed_value_status {fixed};
-                fs::raster_boundary_status hlooped_status {hloop};
-                fs::raster_boundary_status vlooped_status {vloop};
-                fs::raster_boundary_status hvlooped_status {hvloop};
-
-                using grid_type = fs::raster_grid_xt<fs::xtensor_selector>;
-
-                using size_type = typename grid_type::size_type;
-                using length_type = typename grid_type::length_type;
-                using spacing_type = typename grid_type::spacing_type;
-                using shape_type = typename grid_type::shape_type;
-
-                shape_type shape {{5, 10}};
-                grid_type fixed_grid = grid_type(shape, {1.3, 1.2}, fixed_value_status);
-                grid_type hlooped_grid = grid_type(shape, {1.3, 1.2}, hlooped_status);
-                grid_type vlooped_grid = grid_type(shape, {1.3, 1.2}, vlooped_status);
-                grid_type looped_grid = grid_type(shape, {1.4, 1.8}, hvlooped_status);
-
-                fs::node_status status_fixed(std::size_t row, std::size_t col)
-                { 
-                    return ((row == 0) || (row == 4) || (col == 0) || (col == 9)) ? fs::node_status::fixed_value_boundary : fs::node_status::core; 
-                };
-
-                fs::node_status status_looped(std::size_t row, std::size_t col)
-                { 
-                    return ((row == 0) || (row == 4) || (col == 0) || (col == 9)) ? fs::node_status::looped_boundary : fs::node_status::core; 
-                };
-        };
-
         TEST_F(raster_grid, ctor)
         {
+            node_status lg = node_status::fixed_gradient_boundary;
+
             std::array<size_type, 2> shape {{ 3, 3 }};
             std::vector<fs::raster_node> nodes_vector1 {fs::raster_node({1, 1, fs::node_status::fixed_gradient_boundary})};
-            grid_type g1 = grid_type(shape, {1.4, 1.8}, hloop, nodes_vector1);
+            auto g1 = grid_type(shape, {1.4, 1.8}, hloop, nodes_vector1);
 
-            auto expected_status = grid_type::node_status_type {{fs::node_status::fixed_value_boundary, fs::node_status::fixed_value_boundary, fs::node_status::fixed_value_boundary},
-                                                                {fs::node_status::looped_boundary, fs::node_status::fixed_gradient_boundary, fs::node_status::looped_boundary},
-                                                                {fs::node_status::fixed_value_boundary, fs::node_status::fixed_value_boundary, fs::node_status::fixed_value_boundary}};
+            auto expected_status = grid_type::node_status_type { {fb, fb, fb},
+                                                                 {lb, lg, lb},
+                                                                 {fb, fb, fb} };
             ASSERT_EQ(g1.status_at_nodes(), expected_status);
 
-            std::vector<fs::raster_node> nodes_vector2 {fs::raster_node({15, 15, fs::node_status::core})};
-            ASSERT_THROW(grid_type(shape, {1.4, 1.8}, fixed, nodes_vector2), std::out_of_range);
+            std::vector<fs::raster_node> nodes_vector2 {fs::raster_node({15, 15, co})};
+            ASSERT_THROW(grid_type(shape, {1.4, 1.8}, fb, nodes_vector2), std::out_of_range);
 
-            std::vector<fs::raster_node> nodes_vector3 {fs::raster_node({0, 0, fs::node_status::core})};
+            std::vector<fs::raster_node> nodes_vector3 {fs::raster_node({0, 0, co})};
             ASSERT_THROW(grid_type(shape, {1.4, 1.8}, hvloop, nodes_vector3), std::invalid_argument);
-        }
-
-        TEST_F(raster_grid, neighbor_indices__fixed_value_boundary)
-        {
-            { // First row
-                // Top-left corner
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(0, 0)),
-                          (grid_type::neighbors_indices_raster_type { /*(r,c)*/ { 0, 1 }, 
-                                                                      { 1, 0 }, { 1, 1 } }));
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(0, 0)),
-                          (grid_type::neighbors_indices_raster_type { /*(r,c)*/ { 0, 1 }, 
-                                                                      { 1, 0 }           }));                                                                                                                              
-                // Inner cols
-                for(std::size_t c=1; c<9; ++c)
-                {
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(0, c)),
-                              (grid_type::neighbors_indices_raster_type { { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
-                                                                          { 1, c-1 }, { 1, c }, { 1, c+1 } }));
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(0, c)),
-                              (grid_type::neighbors_indices_raster_type { { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
-                                                                                      { 1, c },            }));
-                }
-
-                // Top-right corner
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(0, 9)),
-                          (grid_type::neighbors_indices_raster_type { { 0, 8 }, /*(r,c)*/
-                                                                      { 1, 8 }, { 1, 9 } }));
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(0, 9)),
-                          (grid_type::neighbors_indices_raster_type { { 0, 8 }, /*(r,c)*/
-                                                                                { 1, 9 } }));
-            }
-            { // Inners rows
-                for(std::size_t r=1; r<4; ++r)
-                {
-                    // First col
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(r, 0)),
-                              (grid_type::neighbors_indices_raster_type { { r-1, 0 }, { r-1, 1 },
-                                                                           /*(r,c)*/  { r,   1 },
-                                                                          { r+1, 0 }, { r+1, 1 } }));
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(r, 0)),
-                              (grid_type::neighbors_indices_raster_type { { r-1, 0 },
-                                                                           /*(r,c)*/  { r, 1 },
-                                                                          { r+1, 0 }           }));                                                                                                                                  
-                    // Inners cols
-                    for(std::size_t c=1; c<9; ++c)
-                    {
-                        EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(r, c)),
-                                  (grid_type::neighbors_indices_raster_type { { r-1, c-1 }, { r-1, c }, { r-1, c+1 },
-                                                                              { r,   c-1 },  /*(r,c)*/  { r,   c+1 },
-                                                                              { r+1, c-1 }, { r+1, c }, { r+1, c+1 } }));
-                        EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(r, c)),
-                                  (grid_type::neighbors_indices_raster_type {            { r-1, c },
-                                                                             { r, c-1 },  /*(r,c)*/  { r, c+1 },
-                                                                                         { r+1, c },            }));
-                    }
-
-                    // last col
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(r, 9)),
-                              (grid_type::neighbors_indices_raster_type { { r-1, 8 }, { r-1, 9 },
-                                                                          { r,   8 },  /*(r,c)*/
-                                                                          { r+1, 8 }, { r+1, 9 } }));
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(r, 9)),
-                              (grid_type::neighbors_indices_raster_type {             { r-1, 9 }, 
-                                                                          { r,   8 },  /*(r,c)*/
-                                                                                      { r+1, 9 } }));
-                }
-            }
-
-            { // Last row
-                // Bottom-left corner
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(4, 0)),
-                          (grid_type::neighbors_indices_raster_type { { 3, 0 }, { 3, 1 },
-                                                                      /*(r,c)*/ { 4, 1 } }));
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(4, 0)),
-                          (grid_type::neighbors_indices_raster_type { { 3, 0 },
-                                                                      /*(r,c)*/ { 4, 1 } }));
-                // Inner cols
-                for(std::size_t c=1; c<9; ++c)
-                {
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(4, c)),
-                              (grid_type::neighbors_indices_raster_type { { 3, c-1 }, { 3, c }, { 3, c+1 },
-                                                                          { 4, c-1 }, /*(r,c)*/ { 4, c+1 } }));
-                    EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(4, c)),
-                              (grid_type::neighbors_indices_raster_type {             { 3, c },
-                                                                          { 4, c-1 }, /*(r,c)*/ { 4, c+1 } }));                                                                                                                                  
-                }
-
-                // Bottom-right corner
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::queen>(4, 9)),
-                          (grid_type::neighbors_indices_raster_type { { 3, 8 }, { 3, 9 },
-                                                                      { 4, 8 }  /*(r,c)*/ }));
-                EXPECT_EQ((fixed_grid.neighbor_indices<fs::raster_connect::rook>(4, 9)),
-                          (grid_type::neighbors_indices_raster_type {          { 3, 9 },
-                                                                      { 4, 8 } /*(r,c)*/ }));
-            }
-        }
-
-        TEST_F(raster_grid, neighbor_indices__looped_boundary)
-        {
-            { // First row
-                // Top-left corner
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(0, 0)),
-                          (grid_type::neighbors_indices_raster_type { { 4, 9 }, { 4, 0 }, { 4, 1 },
-                                                                      { 0, 9 }, /*(r,c)*/ { 0, 1 },
-                                                                      { 1, 9 }, { 1, 0 }, { 1, 1 } }));
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(0, 0)),
-                          (grid_type::neighbors_indices_raster_type {           { 4, 0 },
-                                                                      { 0, 9 }, /*(r,c)*/ { 0, 1 },
-                                                                                { 1, 0 }           }));
-                // Inner cols
-                for(std::size_t c=1; c<9; ++c)
-                {
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(0, c)),
-                              (grid_type::neighbors_indices_raster_type { { 4, c-1 }, { 4, c }, { 4, c+1 },
-                                                                          { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
-                                                                          { 1, c-1 }, { 1, c }, { 1, c+1 } }));
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(0, c)),
-                              (grid_type::neighbors_indices_raster_type {             { 4, c },
-                                                                          { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
-                                                                                      { 1, c }             }));
-                }
-                // Top-right corner
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(0, 9)),
-                          (grid_type::neighbors_indices_raster_type { { 4, 8 }, { 4, 9 }, { 4, 0 },
-                                                                      { 0, 8 }, /*(r,c)*/ { 0, 0 },
-                                                                      { 1, 8 }, { 1, 9 }, { 1, 0 } }));
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(0, 9)),
-                          (grid_type::neighbors_indices_raster_type {            { 4, 9 },
-                                                                      { 0, 8 }, /*(r,c)*/ { 0, 0 },
-                                                                                 { 1, 9 }          }));
-            }
-            { // Inners rows
-                for(std::size_t r=1; r<4; ++r)
-                {
-                    // First col
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(r, 0)),
-                              (grid_type::neighbors_indices_raster_type { { r-1, 9 }, { r-1, 0 }, { r-1, 1 },
-                                                                          { r,   9 },  /*(r,c)*/  { r,   1 },
-                                                                          { r+1, 9 }, { r+1, 0 }, { r+1, 1 } }));
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(r, 0)),
-                              (grid_type::neighbors_indices_raster_type {           { r-1, 0 },
-                                                                          { r, 9 },  /*(r,c)*/  { r, 1 },
-                                                                                    { r+1, 0 }           }));
-                    // Inners cols
-                    for(std::size_t c=1; c<9; ++c)
-                    {
-                        EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(r, c)),
-                                  (grid_type::neighbors_indices_raster_type { { r-1, c-1 }, { r-1, c }, { r-1, c+1 },
-                                                                              { r,   c-1 },  /*(r,c)*/  { r,   c+1 },
-                                                                              { r+1, c-1 }, { r+1, c }, { r+1, c+1 } }));
-                        EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(r, c)),
-                                  (grid_type::neighbors_indices_raster_type {               { r-1, c },
-                                                                              { r,   c-1 },  /*(r,c)*/ { r,   c+1 },
-                                                                                            { r+1, c }              }));
-                    }
-                    // last col
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(r, 9)),
-                              (grid_type::neighbors_indices_raster_type { { r-1, 8 }, { r-1, 9 }, { r-1, 0 },
-                                                                          { r,   8 },  /*(r,c)*/  { r,   0 },
-                                                                          { r+1, 8 }, { r+1, 9 }, { r+1, 0 } }));
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(r, 9)),
-                              (grid_type::neighbors_indices_raster_type {             { r-1, 9 },
-                                                                          { r,   8 },  /*(r,c)*/  { r,   0 },
-                                                                                      { r+1, 9 }             }));
-                }
-            }
-
-            { // Last row 
-                // Bottom-left corner
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(4, 0)),
-                (grid_type::neighbors_indices_raster_type { { 3, 9 }, { 3, 0 }, { 3, 1 },
-                                                            { 4, 9 }, /*(r,c)*/ { 4, 1 },
-                                                            { 0, 9 }, { 0, 0 }, { 0, 1 } }));
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(4, 0)),
-                (grid_type::neighbors_indices_raster_type {           { 3, 0 },
-                                                            { 4, 9 }, /*(r,c)*/ { 4, 1 },
-                                                                      { 0, 0 }           }));
-                // Inner cols
-                for(std::size_t c=1; c<9; ++c)
-                {
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(4, c)),
-                              (grid_type::neighbors_indices_raster_type { { 3, c-1 }, { 3, c }, { 3, c+1 },
-                                                                          { 4, c-1 }, /*(r,c)*/ { 4, c+1 },
-                                                                          { 0, c-1 }, { 0, c }, { 0, c+1 } }));
-                    EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(4, c)),
-                              (grid_type::neighbors_indices_raster_type {             { 3, c },
-                                                                          { 4, c-1 }, /*(r,c)*/ { 4, c+1 },
-                                                                                      { 0, c }             }));
-                }
-                // Bottom-right corner
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::queen>(4, 9)),
-                          (grid_type::neighbors_indices_raster_type { { 3, 8 }, { 3, 9 }, { 3, 0 },
-                                                                      { 4, 8 }, /*(r,c)*/ { 4, 0 },
-                                                                      { 0, 8 }, { 0, 9 }, { 0, 0 } }));
-                EXPECT_EQ((looped_grid.neighbor_indices<fs::raster_connect::rook>(4, 9)),
-                          (grid_type::neighbors_indices_raster_type {           { 3, 9 },
-                                                                      { 4, 8 }, /*(r,c)*/ { 4, 0 },
-                                                                                { 0, 9 }           }));
-            }
-        }
-
-        TEST_F(raster_grid, neighbors__looped_boundary)
-        {
-            using neighbors_type = xt::xtensor<fs::neighbor, 1>;
-
-            double d1 = std::sqrt(1.3*1.3 + 1.2*1.2);
-            double d2 = std::sqrt(1.4*1.4 + 1.8*1.8);
-
-            constexpr node_status fb = node_status::fixed_value_boundary;
-            constexpr node_status lb = node_status::looped_boundary;
-            constexpr node_status co = node_status::core;
-
-            { // First row
-                // Top-left corner
-                EXPECT_EQ(fixed_grid.neighbors(0),
-                          (neighbors_type {   /* Node */   {1, 1.2, fb},
-                                            {10, 1.3, fb}, {11, d1, co} } ));
-
-                EXPECT_EQ(looped_grid.neighbors(0), 
-                          (neighbors_type { {49, d2, lb}, {40, 1.4, lb}, {41, d2, lb},
-                                            {9, 1.8, lb},  /* Node */    {1, 1.8, lb},
-                                            {19, d2, lb}, {10, 1.4, lb}, {11, d2, co} } ));
-
-                // Inner cols
-                for(std::size_t c=2; c<8; ++c)
-                {
-                    EXPECT_EQ(fixed_grid.neighbors(c), 
-                              (neighbors_type { {c-1, 1.2, fb},   /* Node */     {c+1, 1.2, fb},
-                                                {c+9,  d1, co}, {c+10, 1.3, co}, {c+11, d1, co} } ));
-
-                    EXPECT_EQ(looped_grid.neighbors(c), 
-                              (neighbors_type { {c+39, d2, lb}, {c+40, 1.4, lb}, {c+41, d2, lb},
-                                                {c-1, 1.8, lb},    /* Node */    {c+1, 1.8, lb},
-                                                {c+9,  d2, co}, {c+10, 1.4, co}, {c+11, d2, co} } ));
-                }
-
-                EXPECT_EQ(looped_grid.neighbors(22), 
-                          (neighbors_type { {11,  d2, co}, {12, 1.4, co}, {13,  d2, co},
-                                            {21, 1.8, co},   /* Node */   {23, 1.8, co},
-                                            {31,  d2, co}, {32, 1.4, co}, {33,  d2, co} } ));
-            }
         }
 
         TEST_F(raster_grid, spacing)
@@ -397,111 +96,67 @@ namespace fastscapelib
             EXPECT_TRUE(xt::all(xt::equal(grid_from_length.spacing(), spacing_type({10., 20.}))));
         }
 
-        TEST_F(raster_grid, gcode)
+        TEST_F(raster_grid, clone)
         {
-            // Top-left corner nodes
-            EXPECT_EQ(fixed_grid.gcode(0), 0);
-            EXPECT_EQ(looped_grid.gcode(0), 0);
-            
-            // Top-right corner nodes
-            EXPECT_EQ(fixed_grid.gcode(shape[1]-1), 2);
-            EXPECT_EQ(looped_grid.gcode(shape[1]-1), 2);
+            using queen_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::queen>;
+            using neighbors_type = xt::xtensor<fs::neighbor, 1>;
 
-            // Bottom-left corner nodes
-            EXPECT_EQ(fixed_grid.gcode((shape[0]-1)*shape[1]), 6);
-            EXPECT_EQ(looped_grid.gcode((shape[0]-1)*shape[1]), 6);
+            double d1 = std::sqrt(1.3*1.3 + 1.2*1.2);
 
-            // Bottom-right corner nodes
-            EXPECT_EQ(fixed_grid.gcode(shape[0]*shape[1]-1), 8);
-            EXPECT_EQ(looped_grid.gcode(shape[0]*shape[1]-1), 8);
+            auto queen_fixed = queen_type(shape, {1.3, 1.2}, fixed_value_status);
+            EXPECT_EQ(queen_fixed.neighbors(9),  // Top-right corner
+                      (neighbors_type { {8, 1.2, fb},   /* Node */ 
+                                        {18, d1, co}, {19, 1.3, fb} } ));
+                                                                    
+            auto rook_like = fs::raster_grid::clone<raster_connect::rook>(queen_fixed);
+            EXPECT_EQ(rook_like.neighbors(9),  // Top-right corner
+                    (neighbors_type { {8, 1.2, fb},   /* Node */ 
+                                                    {19, 1.3, fb} } ));
 
-            for (std::size_t c=1; c<shape[1]-1; ++c)
-            {   
-                // Top edge nodes (without corners)
-                EXPECT_EQ(fixed_grid.gcode(c), 1);
-                EXPECT_EQ(looped_grid.gcode(c), 1);
-
-                // Bottom edge nodes (without corners)
-                EXPECT_EQ(fixed_grid.gcode((shape[0]-1)*shape[1]+c), 7);
-                EXPECT_EQ(looped_grid.gcode((shape[0]-1)*shape[1]+c), 7);
-            }
-
-            for (std::size_t r=1; r<shape[0]-1; ++r)
-            {
-                // Left edge nodes (without corners)
-                EXPECT_EQ(fixed_grid.gcode(r*shape[1]), 3);
-                EXPECT_EQ(looped_grid.gcode(r*shape[1]), 3);
-
-                // Right edge nodes (without corners)
-                EXPECT_EQ(fixed_grid.gcode((r+1)*shape[1]-1), 5);
-                EXPECT_EQ(looped_grid.gcode((r+1)*shape[1]-1), 5);
-            }
-
-            for (std::size_t r=1; r<shape[0]-1; ++r)
-            {
-                for (std::size_t c=1; c<shape[1]-1; ++c)
-                {
-                    // Inner nodes
-                    EXPECT_EQ(fixed_grid.gcode(r*10+c), 4);
-                    EXPECT_EQ(looped_grid.gcode(r*10+c), 4);
-                }
-            }
+            auto bishop_like = fs::raster_grid::clone<raster_connect::bishop>(queen_fixed);
+            EXPECT_EQ(bishop_like.neighbors(9),  // Top-right corner
+                    (neighbors_type {               /* Node */ 
+                                      {18, d1, co}             } ));
         }
 
-        TEST_F(raster_grid, neighbors_count)
+        TEST_F(raster_grid, node_code)
         {
             // Top-left corner nodes
-            EXPECT_EQ(fixed_grid.neighbors_count(static_cast<std::size_t>(0)), 3);
-            EXPECT_EQ(hlooped_grid.neighbors_count(static_cast<std::size_t>(0)), 5);
-            EXPECT_EQ(vlooped_grid.neighbors_count(static_cast<std::size_t>(0)), 5);
-            EXPECT_EQ(looped_grid.neighbors_count(static_cast<std::size_t>(0)), 8);
+            EXPECT_EQ(fixed_grid.node_code(0), 0);
+            EXPECT_EQ(looped_grid.node_code(0), 0);
             
             // Top-right corner nodes
-            EXPECT_EQ(fixed_grid.neighbors_count(shape[1]-1), 3);
-            EXPECT_EQ(hlooped_grid.neighbors_count(shape[1]-1), 5);
-            EXPECT_EQ(vlooped_grid.neighbors_count(shape[1]-1), 5);
-            EXPECT_EQ(looped_grid.neighbors_count(shape[1]-1), 8);
+            EXPECT_EQ(fixed_grid.node_code(shape[1]-1), 2);
+            EXPECT_EQ(looped_grid.node_code(shape[1]-1), 2);
 
             // Bottom-left corner nodes
-            EXPECT_EQ(fixed_grid.neighbors_count((shape[0]-1)*shape[1]), 3);
-            EXPECT_EQ(hlooped_grid.neighbors_count((shape[0]-1)*shape[1]), 5);
-            EXPECT_EQ(vlooped_grid.neighbors_count((shape[0]-1)*shape[1]), 5);
-            EXPECT_EQ(looped_grid.neighbors_count((shape[0]-1)*shape[1]), 8);
+            EXPECT_EQ(fixed_grid.node_code((shape[0]-1)*shape[1]), 6);
+            EXPECT_EQ(looped_grid.node_code((shape[0]-1)*shape[1]), 6);
 
             // Bottom-right corner nodes
-            EXPECT_EQ(fixed_grid.neighbors_count(shape[0]*shape[1]-1), 3);
-            EXPECT_EQ(hlooped_grid.neighbors_count(shape[0]*shape[1]-1), 5);
-            EXPECT_EQ(vlooped_grid.neighbors_count(shape[0]*shape[1]-1), 5);
-            EXPECT_EQ(looped_grid.neighbors_count(shape[0]*shape[1]-1), 8);
+            EXPECT_EQ(fixed_grid.node_code(shape[0]*shape[1]-1), 8);
+            EXPECT_EQ(looped_grid.node_code(shape[0]*shape[1]-1), 8);
 
             for (std::size_t c=1; c<shape[1]-1; ++c)
             {   
                 // Top edge nodes (without corners)
-                EXPECT_EQ(fixed_grid.neighbors_count(c), 5);
-                EXPECT_EQ(hlooped_grid.neighbors_count(c), 5);
-                EXPECT_EQ(vlooped_grid.neighbors_count(c), 8);
-                EXPECT_EQ(looped_grid.neighbors_count(c), 8);
+                EXPECT_EQ(fixed_grid.node_code(c), 1);
+                EXPECT_EQ(looped_grid.node_code(c), 1);
 
                 // Bottom edge nodes (without corners)
-                EXPECT_EQ(fixed_grid.neighbors_count((shape[0]-1)*shape[1]+c), 5);
-                EXPECT_EQ(hlooped_grid.neighbors_count((shape[0]-1)*shape[1]+c), 5);
-                EXPECT_EQ(vlooped_grid.neighbors_count((shape[0]-1)*shape[1]+c), 8);
-                EXPECT_EQ(looped_grid.neighbors_count((shape[0]-1)*shape[1]+c), 8);
+                EXPECT_EQ(fixed_grid.node_code((shape[0]-1)*shape[1]+c), 7);
+                EXPECT_EQ(looped_grid.node_code((shape[0]-1)*shape[1]+c), 7);
             }
 
             for (std::size_t r=1; r<shape[0]-1; ++r)
             {
                 // Left edge nodes (without corners)
-                EXPECT_EQ(fixed_grid.neighbors_count(r*shape[1]), 5);
-                EXPECT_EQ(hlooped_grid.neighbors_count(r*shape[1]), 8);
-                EXPECT_EQ(vlooped_grid.neighbors_count(r*shape[1]), 5);
-                EXPECT_EQ(looped_grid.neighbors_count(r*shape[1]), 8);
+                EXPECT_EQ(fixed_grid.node_code(r*shape[1]), 3);
+                EXPECT_EQ(looped_grid.node_code(r*shape[1]), 3);
 
                 // Right edge nodes (without corners)
-                EXPECT_EQ(fixed_grid.neighbors_count((r+1)*shape[1]-1), 5);
-                EXPECT_EQ(hlooped_grid.neighbors_count((r+1)*shape[1]-1), 8);
-                EXPECT_EQ(vlooped_grid.neighbors_count((r+1)*shape[1]-1), 5);
-                EXPECT_EQ(looped_grid.neighbors_count((r+1)*shape[1]-1), 8);
+                EXPECT_EQ(fixed_grid.node_code((r+1)*shape[1]-1), 5);
+                EXPECT_EQ(looped_grid.node_code((r+1)*shape[1]-1), 5);
             }
 
             for (std::size_t r=1; r<shape[0]-1; ++r)
@@ -509,10 +164,8 @@ namespace fastscapelib
                 for (std::size_t c=1; c<shape[1]-1; ++c)
                 {
                     // Inner nodes
-                    EXPECT_EQ(fixed_grid.neighbors_count(r*shape[1]+c), 8);
-                    EXPECT_EQ(hlooped_grid.neighbors_count(r*shape[1]+c), 8);
-                    EXPECT_EQ(vlooped_grid.neighbors_count(r*shape[1]+c), 8);
-                    EXPECT_EQ(looped_grid.neighbors_count(r*shape[1]+c), 8);
+                    EXPECT_EQ(fixed_grid.node_code(r*10+c), 4);
+                    EXPECT_EQ(looped_grid.node_code(r*10+c), 4);
                 }
             }
         }

--- a/test/test_raster_grid.hpp
+++ b/test/test_raster_grid.hpp
@@ -1,0 +1,131 @@
+
+#ifndef FASTSCAPELIB_TEST_RASTER_GRID_H
+#define FASTSCAPELIB_TEST_RASTER_GRID_H
+
+#include "fastscapelib/raster_grid.hpp"
+
+#include "gtest/gtest.h"
+
+#include <array>
+
+
+namespace fs = fastscapelib;
+
+
+namespace fastscapelib
+{
+    namespace testing
+    {
+
+       class raster_boundary_status: public ::testing::Test
+        {
+            protected:
+
+                using node_s = fs::node_status;
+                
+                node_status fb = node_status::fixed_value_boundary;
+                node_status lb = node_status::looped_boundary;
+                node_status co = node_status::core;
+
+                std::array<node_s, 4> hloop {{ lb, lb, fb, fb }};
+                std::array<node_s, 4> vloop {{ fb, fb, lb, lb }};
+                std::array<node_s, 4> hvloop {{lb, lb, lb, lb }};
+                std::array<node_s, 4> hill_formed_loop {{ lb, fb, lb, lb}};
+                
+                fs::raster_boundary_status fixed_value_status {fb};
+                fs::raster_boundary_status hlooped_status {hloop};
+                fs::raster_boundary_status vlooped_status {vloop};
+                fs::raster_boundary_status hvlooped_status {hvloop};
+        };
+
+        class raster_grid_base: public raster_boundary_status
+        {
+            protected:
+                
+                using size_type = typename fs::raster_grid::size_type;
+                using length_type = typename fs::raster_grid::length_type;
+                using spacing_type = typename fs::raster_grid::spacing_type;
+                using shape_type = typename fs::raster_grid::shape_type;
+
+                shape_type shape {{5, 10}};
+        };
+
+        class raster_grid: public raster_grid_base
+        {
+            protected:
+
+                using grid_type = fs::raster_grid;
+
+                grid_type fixed_grid = grid_type(shape, {1.3, 1.2}, fixed_value_status);
+                grid_type hlooped_grid = grid_type(shape, {1.3, 1.2}, hlooped_status);
+                grid_type vlooped_grid = grid_type(shape, {1.3, 1.2}, vlooped_status);
+                grid_type looped_grid = grid_type(shape, {1.4, 1.8}, hvlooped_status);
+        };
+
+        class queen_raster_grid: public raster_grid_base
+        {
+            protected:
+
+                using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::queen>;
+
+                grid_type queen_fixed = grid_type(shape, {1.3, 1.2}, fixed_value_status);
+                grid_type queen_hlooped = grid_type(shape, {1.3, 1.2}, hlooped_status);
+                grid_type queen_vlooped = grid_type(shape, {1.3, 1.2}, vlooped_status);
+                grid_type queen_looped = grid_type(shape, {1.4, 1.8}, hvlooped_status);
+        };
+
+       class queen_raster_grid_fixed: public queen_raster_grid
+        {};
+
+       class queen_raster_grid_looped: public queen_raster_grid
+        {};
+
+       class rook_raster_grid: public raster_grid_base
+        {
+            protected:
+
+                using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::rook>;
+
+                grid_type rook_fixed = grid_type(shape, {1.3, 1.2}, fixed_value_status);
+                grid_type rook_hlooped = grid_type(shape, {1.3, 1.2}, hlooped_status);
+                grid_type rook_vlooped = grid_type(shape, {1.3, 1.2}, vlooped_status);
+                grid_type rook_looped = grid_type(shape, {1.4, 1.8}, hvlooped_status);
+        };
+        
+       class rook_raster_grid_fixed: public rook_raster_grid
+        {};
+
+       class rook_raster_grid_looped: public rook_raster_grid
+        {};
+
+        class bishop_raster_grid: public raster_grid_base
+        {
+            protected:
+               
+                using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::bishop>;
+
+                grid_type bishop_fixed = grid_type(shape, {1.3, 1.2}, fixed_value_status);
+                grid_type bishop_hlooped = grid_type(shape, {1.3, 1.2}, hlooped_status);
+                grid_type bishop_vlooped = grid_type(shape, {1.3, 1.2}, vlooped_status);
+                grid_type bishop_looped = grid_type(shape, {1.4, 1.8}, hvlooped_status);
+
+                fs::node_status status_fixed(std::size_t row, std::size_t col)
+                { 
+                    return ((row == 0) || (row == 4) || (col == 0) || (col == 9)) ? fs::node_status::fixed_value_boundary : fs::node_status::core; 
+                };
+
+                fs::node_status status_looped(std::size_t row, std::size_t col)
+                { 
+                    return ((row == 0) || (row == 4) || (col == 0) || (col == 9)) ? fs::node_status::looped_boundary : fs::node_status::core; 
+                };
+        };
+
+       class bishop_raster_grid_fixed: public bishop_raster_grid
+        {};
+
+       class bishop_raster_grid_looped: public bishop_raster_grid
+        {};
+    }
+}
+
+#endif

--- a/test/test_raster_queen_grid.cpp
+++ b/test/test_raster_queen_grid.cpp
@@ -1,0 +1,340 @@
+#include "test_raster_grid.hpp"
+
+
+namespace fs = fastscapelib;
+
+namespace fastscapelib
+{
+    namespace testing
+    {
+
+        TEST_F(queen_raster_grid, max_neighbors)
+        {
+            EXPECT_EQ(grid_type::max_neighbors(), 8u);
+        }
+
+#define EXPECT_INDICES(ROW, COL, INDICES, RC_INDICES)                  \
+    EXPECT_EQ(queen_fixed.neighbors_indices(ROW*shape[1]+COL),         \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
+    EXPECT_EQ((queen_fixed.neighbors_indices(ROW, COL)),               \
+              (grid_type::neighbors_indices_raster_type RC_INDICES));    
+
+        TEST_F(queen_raster_grid_fixed, neighbors_indices)
+        {
+            { // First row
+                // Top-left corner
+                EXPECT_INDICES(0, 0,
+                               ({1, 10, 11}), 
+                               ({ /*(r,c)*/ { 0, 1 }, 
+                                  { 1, 0 }, { 1, 1 } }));
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(0, c, 
+                                   ({c-1, c+1, shape[1]+c-1, shape[1]+c, shape[1]+c+1}),
+                                   ({ { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
+                                      { 1, c-1 }, { 1, c }, { 1, c+1 } }));
+                }
+                // Top-right corner
+                EXPECT_INDICES(0, 9,
+                               ({8, 18, 19}),
+                               ({ { 0, 8 }, /*(r,c)*/
+                                  { 1, 8 }, { 1, 9 } }));
+            }
+            { // Inners rows
+                for(std::size_t r=1; r<4; ++r)
+                {
+                    // First col
+                    EXPECT_INDICES(r, 0,
+                                   ({(r-1)*shape[1], (r-1)*shape[1]+1, r*shape[1]+1, (r+1)*shape[1], (r+1)*shape[1]+1}),
+                                   ({ { r-1, 0 }, { r-1, 1 },
+                                       /*(r,c)*/  { r,   1 },
+                                      { r+1, 0 }, { r+1, 1 }}));                                                                              
+                    // Inners cols
+                    for(std::size_t c=1; c<9; ++c)
+                    {
+                        EXPECT_INDICES(r, c, 
+                                   ({(r-1)*shape[1]+c-1, (r-1)*shape[1]+c, (r-1)*shape[1]+c+1,
+                                     r*shape[1]+c-1, r*shape[1]+c+1,
+                                     (r+1)*shape[1]+c-1, (r+1)*shape[1]+c, (r+1)*shape[1]+c+1}),
+                                   ({ { r-1, c-1 }, { r-1, c }, { r-1, c+1 },
+                                      { r,   c-1 },  /*(r,c)*/  { r,   c+1 },
+                                      { r+1, c-1 }, { r+1, c }, { r+1, c+1 } }));
+                    }
+                    // last col
+                    EXPECT_INDICES(r, shape[1]-1, 
+                            ({(r-1)*shape[1]+8, (r-1)*shape[1]+9, r*shape[1]+8, (r+1)*shape[1]+8, (r+1)*shape[1]+9}),
+                            ({ { r-1, 8 }, { r-1, 9 },
+                               { r,   8 },  /*(r,c)*/
+                               { r+1, 8 }, { r+1, 9 } }));
+                }
+            }
+            { // Last row
+                // Bottom-left corner
+                EXPECT_INDICES(4, 0, 
+                               ({30, 31, 41}),
+                               ({ { 3, 0 }, { 3, 1 },
+                                  /*(r,c)*/ { 4, 1 } })); 
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(4, c, 
+                                   ({30+c-1, 30+c, 30+c+1, 40+c-1, 40+c+1}),
+                                   ({ { 3, c-1 }, { 3, c }, { 3, c+1 },
+                                      { 4, c-1 }, /*(r,c)*/ { 4, c+1 } }));                                                                                                                                 
+                }
+                // Bottom-right corner
+                EXPECT_INDICES(4, 9, 
+                               ({38, 39, 48}),
+                               ({ { 3, 8 }, { 3, 9 },
+                                  { 4, 8 } /*(r,c)*/ })); 
+            }
+        }
+#undef EXPECT_INDICES
+
+#define EXPECT_INDICES(ROW, COL, INDICES, RC_INDICES)                  \
+    EXPECT_EQ(queen_looped.neighbors_indices(ROW*shape[1]+COL),        \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
+    EXPECT_EQ((queen_looped.neighbors_indices(ROW, COL)),              \
+              (grid_type::neighbors_indices_raster_type RC_INDICES));  
+
+        TEST_F(queen_raster_grid_looped, neighbors_indices)
+        {
+            { // First row
+                // Top-left corner
+                EXPECT_INDICES(0, 0,
+                               ({49, 40, 41, 9, 1, 19, 10, 11}), 
+                               ({ { 4, 9 }, { 4, 0 }, { 4, 1 },
+                                  { 0, 9 }, /*(r,c)*/ { 0, 1 },
+                                  { 1, 9 }, { 1, 0 }, { 1, 1 } }));
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(0, c, 
+                                   ({40+c-1, 40+c, 40+c+1,
+                                     c-1, c+1,
+                                     10+c-1, 10+c, 10+c+1}),
+                                   ({ { 4, c-1 }, { 4, c }, { 4, c+1 },
+                                      { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
+                                      { 1, c-1 }, { 1, c }, { 1, c+1 } }));
+                }
+                // Top-right corner
+                EXPECT_INDICES(0, 9,
+                               ({48, 49, 40, 8, 0, 18, 19, 10}),
+                               ({ { 4, 8 }, { 4, 9 }, { 4, 0 },
+                                  { 0, 8 }, /*(r,c)*/ { 0, 0 },
+                                  { 1, 8 }, { 1, 9 }, { 1, 0 } }));
+            }
+            { // Inners rows
+                for(std::size_t r=1; r<4; ++r)
+                {
+                    // First col
+                    EXPECT_INDICES(r, 0,
+                                   ({(r-1)*shape[1]+9, (r-1)*shape[1], (r-1)*shape[1]+1,
+                                     r*shape[1]+9, r*shape[1]+1, 
+                                     (r+1)*shape[1]+9, (r+1)*shape[1], (r+1)*shape[1]+1}),
+                                   ({ { r-1, 9 }, { r-1, 0 }, { r-1, 1 },
+                                      { r,   9 },  /*(r,c)*/  { r,   1 },
+                                      { r+1, 9 }, { r+1, 0 }, { r+1, 1 }}));
+                    // Inners cols
+                    for(std::size_t c=1; c<9; ++c)
+                    {
+                        EXPECT_INDICES(r, c, 
+                                       ({(r-1)*shape[1]+c-1, (r-1)*shape[1]+c, (r-1)*shape[1]+c+1,
+                                         r*shape[1]+c-1, r*shape[1]+c+1, 
+                                         (r+1)*shape[1]+c-1, (r+1)*shape[1]+c, (r+1)*shape[1]+c+1}),
+                                       ({ { r-1, c-1 }, { r-1, c }, { r-1, c+1 },
+                                          { r,   c-1 },  /*(r,c)*/  { r,   c+1 },
+                                          { r+1, c-1 }, { r+1, c }, { r+1, c+1 }}));
+                    }
+                    // last col
+                    EXPECT_INDICES(r, shape[1]-1, 
+                                    ({(r-1)*shape[1]+8, (r-1)*shape[1]+9, (r-1)*shape[1],
+                                      r*shape[1]+8, r*shape[1],
+                                      (r+1)*shape[1]+8, (r+1)*shape[1]+9, (r+1)*shape[1]}),
+                                    ({ { r-1, 8 }, { r-1, 9 }, { r-1, 0 },
+                                       { r,   8 },  /*(r,c)*/  { r,   0 },
+                                       { r+1, 8 }, { r+1, 9 }, { r+1, 0 } }));
+                }
+            }
+            { // Last row 
+                // Bottom-left corner
+                EXPECT_INDICES(4, 0, 
+                               ({39, 30, 31, 49, 41, 9, 0, 1}),
+                               ({ { 3, 9 }, { 3, 0 }, { 3, 1 },
+                                  { 4, 9 }, /*(r,c)*/ { 4, 1 },
+                                  { 0, 9 }, { 0, 0 }, { 0, 1 } }));
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(4, c, 
+                                   ({3*shape[1]+c-1, 3*shape[1]+c, 3*shape[1]+c+1,
+                                     4*shape[1]+c-1, 4*shape[1]+c+1,
+                                     c-1, c, c+1}),
+                                   ({ { 3, c-1 }, { 3, c }, { 3, c+1 },
+                                      { 4, c-1 }, /*(r,c)*/ { 4, c+1 },
+                                      { 0, c-1 }, { 0, c }, { 0, c+1 }}));  
+                }
+                // Bottom-right corner
+                EXPECT_INDICES(4, 9, 
+                               ({38, 39, 30, 48, 40, 8, 9, 0}),
+                                ({ { 3, 8 }, { 3, 9 }, { 3, 0 },
+                                   { 4, 8 }, /*(r,c)*/ { 4, 0 },
+                                   { 0, 8 }, { 0, 9 }, { 0, 0 } })); 
+            }
+        }
+#undef EXPECT_INDICES
+
+        TEST_F(queen_raster_grid_fixed, neighbors_distances)
+        {
+            using distance_type = grid_type::distance_type;
+            using neighbors_distances_type = grid_type::neighbors_distances_type;
+
+            distance_type dia = std::sqrt(1.2*1.2 + 1.3*1.3);
+
+            // Top-left corner
+            EXPECT_EQ(queen_fixed.neighbors_distances(0),
+                      (neighbors_distances_type {1.2, 1.3, dia}));
+
+            // Bottom-right corner
+            EXPECT_EQ(queen_fixed.neighbors_distances(49),
+                      (neighbors_distances_type {dia, 1.3, 1.2}));
+
+            // Inners rows/cols    
+            for(std::size_t r=1; r<4; ++r)
+            {
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_EQ(queen_fixed.neighbors_distances(r*shape[1]+c),
+                            (neighbors_distances_type {dia, 1.3, dia, 1.2, 1.2, dia, 1.3, dia}));
+                }
+            }
+        }
+
+        TEST_F(queen_raster_grid_looped, neighbors_distances)
+        {
+            using distance_type = grid_type::distance_type;
+            using neighbors_distances_type = grid_type::neighbors_distances_type;
+
+            distance_type dia = std::sqrt(1.4*1.4 + 1.8*1.8);
+   
+            for(std::size_t r=0; r<5; ++r)
+            {
+                for(std::size_t c=0; c<10; ++c)
+                {
+                    EXPECT_EQ(queen_looped.neighbors_distances(r*shape[1]+c),
+                              (neighbors_distances_type {dia, 1.4, dia, 1.8, 1.8, dia, 1.4, dia}));
+                }
+            }
+        }
+
+        TEST_F(queen_raster_grid_fixed, neighbors)
+        {  // Do not test extensively, indices and distances are already tested
+            using neighbors_type = xt::xtensor<fs::neighbor, 1>;
+
+            double d1 = std::sqrt(1.3*1.3 + 1.2*1.2);
+            double d2 = std::sqrt(1.4*1.4 + 1.8*1.8);
+
+            { // First row
+                // Top-left corner
+                EXPECT_EQ(queen_fixed.neighbors(0),
+                          (neighbors_type {   /* Node */   {1, 1.2, fb},
+                                            {10, 1.3, fb}, {11, d1, co} } ));
+
+                EXPECT_EQ(queen_looped.neighbors(0), 
+                          (neighbors_type { {49, d2, lb}, {40, 1.4, lb}, {41, d2, lb},
+                                            {9, 1.8, lb},  /* Node */    {1, 1.8, lb},
+                                            {19, d2, lb}, {10, 1.4, lb}, {11, d2, co} } ));
+
+                // Inner cols
+                for(std::size_t c=2; c<8; ++c)
+                {
+                    EXPECT_EQ(queen_fixed.neighbors(c), 
+                              (neighbors_type { {c-1, 1.2, fb},   /* Node */     {c+1, 1.2, fb},
+                                                {c+9,  d1, co}, {c+10, 1.3, co}, {c+11, d1, co} } ));
+
+                    EXPECT_EQ(queen_looped.neighbors(c), 
+                              (neighbors_type { {c+39, d2, lb}, {c+40, 1.4, lb}, {c+41, d2, lb},
+                                                {c-1, 1.8, lb},    /* Node */    {c+1, 1.8, lb},
+                                                {c+9,  d2, co}, {c+10, 1.4, co}, {c+11, d2, co} } ));
+                }
+
+                EXPECT_EQ(queen_looped.neighbors(22), 
+                          (neighbors_type { {11,  d2, co}, {12, 1.4, co}, {13,  d2, co},
+                                            {21, 1.8, co},   /* Node */   {23, 1.8, co},
+                                            {31,  d2, co}, {32, 1.4, co}, {33,  d2, co} } ));
+            }
+        }
+
+        TEST_F(queen_raster_grid, neighbors_count)
+        {
+            // Top-left corner nodes
+            EXPECT_EQ(queen_fixed.neighbors_count(static_cast<std::size_t>(0)), 3);
+            EXPECT_EQ(queen_hlooped.neighbors_count(static_cast<std::size_t>(0)), 5);
+            EXPECT_EQ(queen_vlooped.neighbors_count(static_cast<std::size_t>(0)), 5);
+            EXPECT_EQ(queen_looped.neighbors_count(static_cast<std::size_t>(0)), 8);
+            
+            // Top-right corner nodes
+            EXPECT_EQ(queen_fixed.neighbors_count(shape[1]-1), 3);
+            EXPECT_EQ(queen_hlooped.neighbors_count(shape[1]-1), 5);
+            EXPECT_EQ(queen_vlooped.neighbors_count(shape[1]-1), 5);
+            EXPECT_EQ(queen_looped.neighbors_count(shape[1]-1), 8);
+
+            // Bottom-left corner nodes
+            EXPECT_EQ(queen_fixed.neighbors_count((shape[0]-1)*shape[1]), 3);
+            EXPECT_EQ(queen_hlooped.neighbors_count((shape[0]-1)*shape[1]), 5);
+            EXPECT_EQ(queen_vlooped.neighbors_count((shape[0]-1)*shape[1]), 5);
+            EXPECT_EQ(queen_looped.neighbors_count((shape[0]-1)*shape[1]), 8);
+
+            // Bottom-right corner nodes
+            EXPECT_EQ(queen_fixed.neighbors_count(shape[0]*shape[1]-1), 3);
+            EXPECT_EQ(queen_hlooped.neighbors_count(shape[0]*shape[1]-1), 5);
+            EXPECT_EQ(queen_vlooped.neighbors_count(shape[0]*shape[1]-1), 5);
+            EXPECT_EQ(queen_looped.neighbors_count(shape[0]*shape[1]-1), 8);
+
+            for (std::size_t c=1; c<shape[1]-1; ++c)
+            {   
+                // Top edge nodes (without corners)
+                EXPECT_EQ(queen_fixed.neighbors_count(c), 5);
+                EXPECT_EQ(queen_hlooped.neighbors_count(c), 5);
+                EXPECT_EQ(queen_vlooped.neighbors_count(c), 8);
+                EXPECT_EQ(queen_looped.neighbors_count(c), 8);
+
+                // Bottom edge nodes (without corners)
+                EXPECT_EQ(queen_fixed.neighbors_count((shape[0]-1)*shape[1]+c), 5);
+                EXPECT_EQ(queen_hlooped.neighbors_count((shape[0]-1)*shape[1]+c), 5);
+                EXPECT_EQ(queen_vlooped.neighbors_count((shape[0]-1)*shape[1]+c), 8);
+                EXPECT_EQ(queen_looped.neighbors_count((shape[0]-1)*shape[1]+c), 8);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                // Left edge nodes (without corners)
+                EXPECT_EQ(queen_fixed.neighbors_count(r*shape[1]), 5);
+                EXPECT_EQ(queen_hlooped.neighbors_count(r*shape[1]), 8);
+                EXPECT_EQ(queen_vlooped.neighbors_count(r*shape[1]), 5);
+                EXPECT_EQ(queen_looped.neighbors_count(r*shape[1]), 8);
+
+                // Right edge nodes (without corners)
+                EXPECT_EQ(queen_fixed.neighbors_count((r+1)*shape[1]-1), 5);
+                EXPECT_EQ(queen_hlooped.neighbors_count((r+1)*shape[1]-1), 8);
+                EXPECT_EQ(queen_vlooped.neighbors_count((r+1)*shape[1]-1), 5);
+                EXPECT_EQ(queen_looped.neighbors_count((r+1)*shape[1]-1), 8);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                for (std::size_t c=1; c<shape[1]-1; ++c)
+                {
+                    // Inner nodes
+                    EXPECT_EQ(queen_fixed.neighbors_count(r*shape[1]+c), 8);
+                    EXPECT_EQ(queen_hlooped.neighbors_count(r*shape[1]+c), 8);
+                    EXPECT_EQ(queen_vlooped.neighbors_count(r*shape[1]+c), 8);
+                    EXPECT_EQ(queen_looped.neighbors_count(r*shape[1]+c), 8);
+                }
+            }
+        }
+    }
+}

--- a/test/test_raster_rook_grid.cpp
+++ b/test/test_raster_rook_grid.cpp
@@ -1,0 +1,320 @@
+#include "test_raster_grid.hpp"
+
+
+namespace fs = fastscapelib;
+
+namespace fastscapelib
+{
+    namespace testing
+    {
+
+        TEST_F(rook_raster_grid, max_neighbors)
+        {
+            EXPECT_EQ(grid_type::max_neighbors(), 4u);
+        }
+
+#define EXPECT_INDICES(ROW, COL, INDICES, RC_INDICES)                  \
+    EXPECT_EQ(rook_fixed.neighbors_indices(ROW*shape[1]+COL),          \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
+    EXPECT_EQ((rook_fixed.neighbors_indices(ROW, COL)),                \
+              (grid_type::neighbors_indices_raster_type RC_INDICES));    
+
+        TEST_F(rook_raster_grid_fixed, neighbors_indices)
+        {
+            { // First row
+                // Top-left corner
+                EXPECT_INDICES(0, 0,
+                               ({1, 10}), 
+                               ({ /*(r,c)*/ { 0, 1 }, 
+                                  { 1, 0 }           }));
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(0, c, 
+                                   ({c-1, c+1, shape[1]+c}),
+                                   ({ { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
+                                                 { 1, c },            }));
+                }
+                // Top-right corner
+                EXPECT_INDICES(0, 9,
+                               ({8, 19}),
+                               ({ { 0, 8 }, /*(r,c)*/
+                                            { 1, 9 } }));
+            }
+            { // Inners rows
+                for(std::size_t r=1; r<4; ++r)
+                {
+                    // First col
+                    EXPECT_INDICES(r, 0,
+                                   ({(r-1)*shape[1], r*shape[1]+1, (r+1)*shape[1]}),
+                                   ({ { r-1, 0 },
+                                       /*(r,c)*/  { r, 1 },
+                                      { r+1, 0 }           })); 
+                    // Inners cols
+                    for(std::size_t c=1; c<9; ++c)
+                    {
+                        EXPECT_INDICES(r, c, 
+                                   ({(r-1)*shape[1]+c, r*shape[1]+c-1, r*shape[1]+c+1, (r+1)*shape[1]+c}),
+                                   ({             { r-1, c },
+                                      { r, c-1 },  /*(r,c)*/  { r, c+1 },
+                                                  { r+1, c },            })); 
+                    }
+                    // last col
+                    EXPECT_INDICES(r, shape[1]-1, 
+                            ({(r-1)*shape[1]+9, r*shape[1]+8, (r+1)*shape[1]+9}),
+                            ({             { r-1, 9 }, 
+                               { r,   8 },  /*(r,c)*/
+                                           { r+1, 9 } })); 
+                }
+            }
+            { // Last row
+                // Bottom-left corner
+                EXPECT_INDICES(4, 0, 
+                               ({30, 41}),
+                               ({ { 3, 0 },
+                                  /*(r,c)*/ { 4, 1 } })); 
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(4, c, 
+                                   ({30+c, 40+c-1, 40+c+1}),
+                                   ({             { 3, c },
+                                      { 4, c-1 }, /*(r,c)*/ { 4, c+1 } }));                                                                                                                             
+                }
+                // Bottom-right corner
+                EXPECT_INDICES(4, 9, 
+                               ({39, 48}),
+                               ({          { 3, 9 },
+                                  { 4, 8 } /*(r,c)*/ })); 
+            }
+        }
+#undef EXPECT_INDICES
+
+#define EXPECT_INDICES(ROW, COL, INDICES, RC_INDICES)                  \
+    EXPECT_EQ(rook_looped.neighbors_indices(ROW*shape[1]+COL),         \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
+    EXPECT_EQ((rook_looped.neighbors_indices(ROW, COL)),               \
+              (grid_type::neighbors_indices_raster_type RC_INDICES));  
+
+        TEST_F(rook_raster_grid_looped, neighbors_indices)
+        {
+            { // First row
+                // Top-left corner
+                EXPECT_INDICES(0, 0,
+                               ({40, 9, 1, 10}), 
+                               ({           { 4, 0 },
+                                  { 0, 9 }, /*(r,c)*/ { 0, 1 },
+                                            { 1, 0 }           }));
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(0, c, 
+                                   ({40+c, c-1, c+1, 10+c}),
+                                   ({             { 4, c },
+                                      { 0, c-1 }, /*(r,c)*/ { 0, c+1 },
+                                                  { 1, c }             }));
+                }
+                // Top-right corner
+                EXPECT_INDICES(0, 9,
+                               ({49, 8, 0, 19}),
+                               ({            { 4, 9 },
+                                  { 0, 8 }, /*(r,c)*/ { 0, 0 },
+                                             { 1, 9 }          }));
+            }
+            { // Inners rows
+                for(std::size_t r=1; r<4; ++r)
+                {
+                    // First col
+                    EXPECT_INDICES(r, 0,
+                                   ({(r-1)*shape[1], r*shape[1]+9, r*shape[1]+1, (r+1)*shape[1]}),
+                                   ({           { r-1, 0 },
+                                      { r, 9 },  /*(r,c)*/  { r, 1 },
+                                                { r+1, 0 }           }));
+                    // Inners cols
+                    for(std::size_t c=1; c<9; ++c)
+                    {
+                        EXPECT_INDICES(r, c, 
+                                       ({(r-1)*shape[1]+c, r*shape[1]+c-1, r*shape[1]+c+1, (r+1)*shape[1]+c}),
+                                       ({             { r-1, c },
+                                          { r, c-1 },  /*(r,c)*/  { r, c+1 },
+                                                      { r+1, c },            }));
+                    }
+                    // last col
+                    EXPECT_INDICES(r, shape[1]-1, 
+                                    ({(r-1)*shape[1]+9, r*shape[1]+8, r*shape[1], (r+1)*shape[1]+9}),
+                                    ({             { r-1, 9 },
+                                       { r,   8 },  /*(r,c)*/  { r,   0 },
+                                                   { r+1, 9 }             }));
+                }
+            }
+            { // Last row 
+                // Bottom-left corner
+                EXPECT_INDICES(4, 0, 
+                               ({30, 49, 41, 0}),
+                               ({           { 3, 0 },
+                                  { 4, 9 }, /*(r,c)*/ { 4, 1 },
+                                            { 0, 0 }           })); 
+                // Inner cols
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_INDICES(4, c, 
+                                   ({3*shape[1]+c, 4*shape[1]+c-1, 4*shape[1]+c+1, c}),
+                                   ({             { 3, c },
+                                      { 4, c-1 }, /*(r,c)*/ { 4, c+1 },
+                                                  { 0, c }             }));  
+                }
+                // Bottom-right corner
+                EXPECT_INDICES(4, 9, 
+                               ({39, 48, 40, 9}),
+                                ({           { 3, 9 },
+                                   { 4, 8 }, /*(r,c)*/ { 4, 0 },
+                                             { 0, 9 }           })); 
+            }
+        }
+#undef EXPECT_INDICES
+
+        TEST_F(rook_raster_grid_fixed, neighbors_distances)
+        {
+            using neighbors_distances_type = grid_type::neighbors_distances_type;
+
+            // Top-left corner
+            EXPECT_EQ(rook_fixed.neighbors_distances(0),
+                      (neighbors_distances_type {1.2, 1.3}));
+
+            // Bottom-right corner
+            EXPECT_EQ(rook_fixed.neighbors_distances(49),
+                      (neighbors_distances_type {1.3, 1.2}));
+
+            // Inners rows/cols    
+            for(std::size_t r=1; r<4; ++r)
+            {
+                for(std::size_t c=1; c<9; ++c)
+                {
+                    EXPECT_EQ(rook_fixed.neighbors_distances(r*shape[1]+c),
+                            (neighbors_distances_type {1.3, 1.2, 1.2, 1.3}));
+                }
+            }
+        }
+
+        TEST_F(rook_raster_grid_looped, neighbors_distances)
+        {
+            using distance_type = grid_type::distance_type;
+            using neighbors_distances_type = grid_type::neighbors_distances_type;
+
+            for(std::size_t r=0; r<5; ++r)
+            {
+                for(std::size_t c=0; c<10; ++c)
+                {
+                    EXPECT_EQ(rook_looped.neighbors_distances(r*shape[1]+c),
+                              (neighbors_distances_type {1.4, 1.8, 1.8, 1.4}));
+                }
+            }
+        }
+
+        TEST_F(rook_raster_grid_looped, neighbors)
+        {  // Do not test extensively, indices and distances are already tested
+            using neighbors_type = xt::xtensor<fs::neighbor, 1>;
+
+            { // First row
+                // Top-left corner
+                EXPECT_EQ(rook_fixed.neighbors(0),
+                          (neighbors_type {   /* Node */   {1, 1.2, fb},
+                                            {10, 1.3, fb},              } ));
+
+                EXPECT_EQ(rook_looped.neighbors(0), 
+                          (neighbors_type {               {40, 1.4, lb},
+                                            {9, 1.8, lb},  /* Node */    {1, 1.8, lb},
+                                                          {10, 1.4, lb}               } ));
+
+                // Inner cols
+                for(std::size_t c=2; c<8; ++c)
+                {
+                    EXPECT_EQ(rook_fixed.neighbors(c), 
+                              (neighbors_type { {c-1, 1.2, fb},   /* Node */    {c+1, 1.2, fb},
+                                                                {c+10, 1.3, co}                } ));
+
+                    EXPECT_EQ(rook_looped.neighbors(c), 
+                              (neighbors_type {                 {c+40, 1.4, lb},
+                                                {c-1, 1.8, lb},    /* Node */    {c+1, 1.8, lb},
+                                                                {c+10, 1.4, co}                 } ));
+                }
+
+                EXPECT_EQ(rook_looped.neighbors(22), 
+                          (neighbors_type {                {12, 1.4, co},
+                                            {21, 1.8, co},   /* Node */   {23, 1.8, co},
+                                                           {32, 1.4, co}                } ));
+            }
+        }
+
+        TEST_F(rook_raster_grid, neighbors_count)
+        {
+            // Top-left corner nodes
+            EXPECT_EQ(rook_fixed.neighbors_count(static_cast<std::size_t>(0)), 2);
+            EXPECT_EQ(rook_hlooped.neighbors_count(static_cast<std::size_t>(0)), 3);
+            EXPECT_EQ(rook_vlooped.neighbors_count(static_cast<std::size_t>(0)), 3);
+            EXPECT_EQ(rook_looped.neighbors_count(static_cast<std::size_t>(0)), 4);
+            
+            // Top-right corner nodes
+            EXPECT_EQ(rook_fixed.neighbors_count(shape[1]-1), 2);
+            EXPECT_EQ(rook_hlooped.neighbors_count(shape[1]-1), 3);
+            EXPECT_EQ(rook_vlooped.neighbors_count(shape[1]-1), 3);
+            EXPECT_EQ(rook_looped.neighbors_count(shape[1]-1), 4);
+
+            // Bottom-left corner nodes
+            EXPECT_EQ(rook_fixed.neighbors_count((shape[0]-1)*shape[1]), 2);
+            EXPECT_EQ(rook_hlooped.neighbors_count((shape[0]-1)*shape[1]), 3);
+            EXPECT_EQ(rook_vlooped.neighbors_count((shape[0]-1)*shape[1]), 3);
+            EXPECT_EQ(rook_looped.neighbors_count((shape[0]-1)*shape[1]), 4);
+
+            // Bottom-right corner nodes
+            EXPECT_EQ(rook_fixed.neighbors_count(shape[0]*shape[1]-1), 2);
+            EXPECT_EQ(rook_hlooped.neighbors_count(shape[0]*shape[1]-1), 3);
+            EXPECT_EQ(rook_vlooped.neighbors_count(shape[0]*shape[1]-1), 3);
+            EXPECT_EQ(rook_looped.neighbors_count(shape[0]*shape[1]-1), 4);
+
+            for (std::size_t c=1; c<shape[1]-1; ++c)
+            {   
+                // Top edge nodes (without corners)
+                EXPECT_EQ(rook_fixed.neighbors_count(c), 3);
+                EXPECT_EQ(rook_hlooped.neighbors_count(c), 3);
+                EXPECT_EQ(rook_vlooped.neighbors_count(c), 4);
+                EXPECT_EQ(rook_looped.neighbors_count(c), 4);
+
+                // Bottom edge nodes (without corners)
+                EXPECT_EQ(rook_fixed.neighbors_count((shape[0]-1)*shape[1]+c), 3);
+                EXPECT_EQ(rook_hlooped.neighbors_count((shape[0]-1)*shape[1]+c), 3);
+                EXPECT_EQ(rook_vlooped.neighbors_count((shape[0]-1)*shape[1]+c), 4);
+                EXPECT_EQ(rook_looped.neighbors_count((shape[0]-1)*shape[1]+c), 4);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                // Left edge nodes (without corners)
+                EXPECT_EQ(rook_fixed.neighbors_count(r*shape[1]), 3);
+                EXPECT_EQ(rook_hlooped.neighbors_count(r*shape[1]), 4);
+                EXPECT_EQ(rook_vlooped.neighbors_count(r*shape[1]), 3);
+                EXPECT_EQ(rook_looped.neighbors_count(r*shape[1]), 4);
+
+                // Right edge nodes (without corners)
+                EXPECT_EQ(rook_fixed.neighbors_count((r+1)*shape[1]-1), 3);
+                EXPECT_EQ(rook_hlooped.neighbors_count((r+1)*shape[1]-1), 4);
+                EXPECT_EQ(rook_vlooped.neighbors_count((r+1)*shape[1]-1), 3);
+                EXPECT_EQ(rook_looped.neighbors_count((r+1)*shape[1]-1), 4);
+            }
+
+            for (std::size_t r=1; r<shape[0]-1; ++r)
+            {
+                for (std::size_t c=1; c<shape[1]-1; ++c)
+                {
+                    // Inner nodes
+                    EXPECT_EQ(rook_fixed.neighbors_count(r*shape[1]+c), 4);
+                    EXPECT_EQ(rook_hlooped.neighbors_count(r*shape[1]+c), 4);
+                    EXPECT_EQ(rook_vlooped.neighbors_count(r*shape[1]+c), 4);
+                    EXPECT_EQ(rook_looped.neighbors_count(r*shape[1]+c), 4);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR is a major refactoring of `raster_grid` class. It is related to #61.

The `raster_connect` is now a template parameter, which allow optimization of the neighbors indices cache based on fixed size objects.

- [x] Rebase after #60 merged

#### Different `raster_connect` than the original one
Capability to easily access neighbors from the class `raster_connect` to an other is preserved using the newly introduced `create_similar_raster` template method:
```cpp
using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::queen>;
using shape_type = typename grid_type::shape_type;

shape_type shape {{5, 10}};
grid_type queen_grid = grid_type(shape, {1.3, 1.2}, node_status::fixed_value_boundary);

auto rook_grid = queen_grid.create_similar_raster<raster_connect::rook>();
```

#### Benchmarks modifications
Improved readability of benchmarks:
- reduce number of tested size, but increase configurations (grids, raster_connect, cache policies)
- use macros to reduce boilerplate
- use `using` declarations to make benchs outputs nicer

ex:
*before*
```
flow_routing__compute_receivers__profile<fs::profile_grid>/256                        2 us          2 us     388090
flow_routing__compute_receivers__profile<fs::profile_grid>/512                        4 us          4 us     179656
flow_routing__compute_receivers__profile<fs::profile_grid>/1024                       9 us          9 us      72550
flow_routing__compute_receivers__profile<fs::profile_grid>/2048                      23 us         23 us      30516
flow_routing__compute_receivers__profile<fs::profile_grid>/4096                      52 us         52 us      12755
flow_routing__compute_receivers__raster<fs::raster_grid>/256/min_time:2.000           2 ms          2 ms       1199
flow_routing__compute_receivers__raster<fs::raster_grid>/512/min_time:2.000          10 ms         10 ms        294
flow_routing__compute_receivers__raster<fs::raster_grid>/1024/min_time:2.000         38 ms         38 ms         73
flow_routing__compute_receivers__raster<fs::raster_grid>/2048/min_time:2.000        167 ms        167 ms         17
flow_routing__compute_receivers__raster<fs::raster_grid>/4096/min_time:2.000        664 ms        664 ms          4
flow_routing__compute_receivers_d8/256/min_time:2.000                                 3 ms          3 ms        938
flow_routing__compute_receivers_d8/512/min_time:2.000                                12 ms         12 ms        241
flow_routing__compute_receivers_d8/1024/min_time:2.000                               46 ms         46 ms         60
flow_routing__compute_receivers_d8/2048/min_time:2.000                              205 ms        204 ms         10
flow_routing__compute_receivers_d8/4096/min_time:2.000                              812 ms        809 ms          4
```
*after*
```
flow_routing__compute_receivers__profile<profile_nocache>/1024          12 us         12 us      58783
flow_routing__compute_receivers__profile<profile_cacheall>/1024         10 us         10 us      69031
flow_routing__compute_receivers__raster<queen_nocache>/1024             53 ms         53 ms         13
flow_routing__compute_receivers__raster<queen_cacheall>/1024            40 ms         40 ms         17
flow_routing__compute_receivers__raster<rook_nocache>/1024              35 ms         35 ms         21
flow_routing__compute_receivers__raster<rook_cacheall>/1024             27 ms         27 ms         26
flow_routing__compute_receivers__raster<bishop_nocache>/1024            39 ms         39 ms         18
flow_routing__compute_receivers__raster<bishop_cacheall>/1024           29 ms         29 ms         25
flow_routing__compute_receivers_d8/1024                                 47 ms         47 ms         15
```

#### Details

This PR includes:
- used template parameter for raster_connect
- inherit raster_connects specific props and methods
- implement bishop `raster_connect`
- extend testing and benchmarking
- simplify bench, focus on public API