### PR TITLE
Extend neighbors indices api

### DIFF
--- a/include/fastscapelib/structured_grid.hpp
+++ b/include/fastscapelib/structured_grid.hpp
@@ -303,6 +303,8 @@ namespace fastscapelib
 
         neighbors_indices_type neighbors_indices(const size_type& idx);
 
+        void neighbors_indices(const size_type& idx, neighbors_indices_type& neighbors_indices);
+
         neighbors_type neighbors(const size_type& idx);
 
         void neighbors(const size_type& idx, neighbors_type& neighbors);
@@ -475,6 +477,32 @@ namespace fastscapelib
         neighbors(idx, node_neighbors);
 
         return node_neighbors;
+    }
+
+    /**
+     * Iterate over the neighbors indices of a given grid node.
+     *
+     * Follows looped boundary conditions, if any.
+     *
+     * @param idx Index of the grid node.
+     * @param neighbors_indices Reference to the vector to be filled with the neighbors 
+     *                          indices of that grid node.
+     */
+    template <class G, class C>
+    inline void structured_grid<G, C>::neighbors_indices(const size_type& idx, neighbors_indices_type& neighbors_indices)
+    {    
+        const auto& n_count = neighbors_count(idx);
+        const auto& n_indices = neighbors_indices_impl(idx);
+
+        if (neighbors_indices.size() != n_count)
+        {
+            neighbors_indices.resize({n_count});
+        }
+        
+        for (neighbors_count_type i=0; i<n_count; ++i)
+        {   
+            neighbors_indices[i] = n_indices[i];
+        }
     }
 
     /**

--- a/test/test_raster_bishop_grid.cpp
+++ b/test/test_raster_bishop_grid.cpp
@@ -17,6 +17,10 @@ namespace fastscapelib
     EXPECT_EQ(bishop_fixed.neighbors_indices(ROW*shape[1]+COL),        \
               (xt::xtensor<std::size_t, 1> INDICES));                  \
                                                                        \
+    bishop_fixed.neighbors_indices(ROW*shape[1]+COL, neighbors_idx);   \
+    EXPECT_EQ(neighbors_idx,                                           \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
     EXPECT_EQ((bishop_fixed.neighbors_indices(ROW, COL)),              \
               (grid_type::neighbors_indices_raster_type RC_INDICES));    
 
@@ -95,6 +99,10 @@ namespace fastscapelib
 
 #define EXPECT_INDICES(ROW, COL, INDICES, RC_INDICES)                  \
     EXPECT_EQ(bishop_looped.neighbors_indices(ROW*shape[1]+COL),       \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
+    bishop_looped.neighbors_indices(ROW*shape[1]+COL, neighbors_idx);  \
+    EXPECT_EQ(neighbors_idx,                                           \
               (xt::xtensor<std::size_t, 1> INDICES));                  \
                                                                        \
     EXPECT_EQ((bishop_looped.neighbors_indices(ROW, COL)),             \

--- a/test/test_raster_grid.hpp
+++ b/test/test_raster_grid.hpp
@@ -72,6 +72,8 @@ namespace fastscapelib
                 grid_type queen_hlooped = grid_type(shape, {1.3, 1.2}, hlooped_status);
                 grid_type queen_vlooped = grid_type(shape, {1.3, 1.2}, vlooped_status);
                 grid_type queen_looped = grid_type(shape, {1.4, 1.8}, hvlooped_status);
+
+                grid_type::neighbors_indices_type neighbors_idx;
         };
 
        class queen_raster_grid_fixed: public queen_raster_grid
@@ -90,6 +92,8 @@ namespace fastscapelib
                 grid_type rook_hlooped = grid_type(shape, {1.3, 1.2}, hlooped_status);
                 grid_type rook_vlooped = grid_type(shape, {1.3, 1.2}, vlooped_status);
                 grid_type rook_looped = grid_type(shape, {1.4, 1.8}, hvlooped_status);
+
+                grid_type::neighbors_indices_type neighbors_idx;
         };
         
        class rook_raster_grid_fixed: public rook_raster_grid
@@ -109,15 +113,7 @@ namespace fastscapelib
                 grid_type bishop_vlooped = grid_type(shape, {1.3, 1.2}, vlooped_status);
                 grid_type bishop_looped = grid_type(shape, {1.4, 1.8}, hvlooped_status);
 
-                fs::node_status status_fixed(std::size_t row, std::size_t col)
-                { 
-                    return ((row == 0) || (row == 4) || (col == 0) || (col == 9)) ? fs::node_status::fixed_value_boundary : fs::node_status::core; 
-                };
-
-                fs::node_status status_looped(std::size_t row, std::size_t col)
-                { 
-                    return ((row == 0) || (row == 4) || (col == 0) || (col == 9)) ? fs::node_status::looped_boundary : fs::node_status::core; 
-                };
+                grid_type::neighbors_indices_type neighbors_idx;
         };
 
        class bishop_raster_grid_fixed: public bishop_raster_grid

--- a/test/test_raster_queen_grid.cpp
+++ b/test/test_raster_queen_grid.cpp
@@ -17,8 +17,12 @@ namespace fastscapelib
     EXPECT_EQ(queen_fixed.neighbors_indices(ROW*shape[1]+COL),         \
               (xt::xtensor<std::size_t, 1> INDICES));                  \
                                                                        \
+    queen_fixed.neighbors_indices(ROW*shape[1]+COL, neighbors_idx);    \
+    EXPECT_EQ(neighbors_idx,                                           \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
     EXPECT_EQ((queen_fixed.neighbors_indices(ROW, COL)),               \
-              (grid_type::neighbors_indices_raster_type RC_INDICES));    
+              (grid_type::neighbors_indices_raster_type RC_INDICES));
 
         TEST_F(queen_raster_grid_fixed, neighbors_indices)
         {
@@ -95,6 +99,10 @@ namespace fastscapelib
 
 #define EXPECT_INDICES(ROW, COL, INDICES, RC_INDICES)                  \
     EXPECT_EQ(queen_looped.neighbors_indices(ROW*shape[1]+COL),        \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
+    queen_looped.neighbors_indices(ROW*shape[1]+COL, neighbors_idx);   \
+    EXPECT_EQ(neighbors_idx,                                           \
               (xt::xtensor<std::size_t, 1> INDICES));                  \
                                                                        \
     EXPECT_EQ((queen_looped.neighbors_indices(ROW, COL)),              \

--- a/test/test_raster_rook_grid.cpp
+++ b/test/test_raster_rook_grid.cpp
@@ -17,6 +17,10 @@ namespace fastscapelib
     EXPECT_EQ(rook_fixed.neighbors_indices(ROW*shape[1]+COL),          \
               (xt::xtensor<std::size_t, 1> INDICES));                  \
                                                                        \
+    rook_fixed.neighbors_indices(ROW*shape[1]+COL, neighbors_idx);     \
+    EXPECT_EQ(neighbors_idx,                                           \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
     EXPECT_EQ((rook_fixed.neighbors_indices(ROW, COL)),                \
               (grid_type::neighbors_indices_raster_type RC_INDICES));    
 
@@ -93,6 +97,10 @@ namespace fastscapelib
 
 #define EXPECT_INDICES(ROW, COL, INDICES, RC_INDICES)                  \
     EXPECT_EQ(rook_looped.neighbors_indices(ROW*shape[1]+COL),         \
+              (xt::xtensor<std::size_t, 1> INDICES));                  \
+                                                                       \
+    rook_looped.neighbors_indices(ROW*shape[1]+COL, neighbors_idx);    \
+    EXPECT_EQ(neighbors_idx,                                           \
               (xt::xtensor<std::size_t, 1> INDICES));                  \
                                                                        \
     EXPECT_EQ((rook_looped.neighbors_indices(ROW, COL)),               \


### PR DESCRIPTION
Description
--

Iterate over a `grid` node `neighbors_indices` reusing the same container passed by reference.
Related to #71 .

Details:
- add an overload to `structured_grid::neighbors_indices` method
- test on all raster grids