### PR TITLE
Add iterators

### DIFF
--- a/benchmark/benchmark_flow_routing.cpp
+++ b/benchmark/benchmark_flow_routing.cpp
@@ -90,17 +90,17 @@ namespace fastscapelib
             }
         }
 
-        using profile_nocache = fs::profile_grid_xt<xtensor_selector, detail::neighbors_no_cache<2>>;
+        using profile_nocache = fs::profile_grid_xt<xtensor_selector, neighbors_no_cache<2>>;
         using profile_cacheall = fs::profile_grid;
 
-        using queen_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, detail::neighbors_no_cache<8>>;
-        using queen_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, detail::neighbors_cache<8>>;
+        using queen_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, neighbors_no_cache<8>>;
+        using queen_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, neighbors_cache<8>>;
 
-        using rook_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, detail::neighbors_no_cache<4>>;
-        using rook_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, detail::neighbors_cache<4>>;
+        using rook_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, neighbors_no_cache<4>>;
+        using rook_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, neighbors_cache<4>>;
 
-        using bishop_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, detail::neighbors_no_cache<4>>;
-        using bishop_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, detail::neighbors_cache<4>>;
+        using bishop_nocache = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, neighbors_no_cache<4>>;
+        using bishop_cacheall = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, neighbors_cache<4>>;
 
 
 #define BENCH_GRID(NAME, GRID)                         \

--- a/include/fastscapelib/fastscapelib.hpp
+++ b/include/fastscapelib/fastscapelib.hpp
@@ -16,7 +16,6 @@
 #include "fastscapelib/structured_grid.hpp"
 #include "fastscapelib/profile_grid.hpp"
 #include "fastscapelib/raster_grid.hpp"
-#include "fastscapelib/sinks.hpp"
 #include "fastscapelib/hillslope.hpp"
 #include "fastscapelib/sinks.hpp"
 

--- a/include/fastscapelib/flow_router.hpp
+++ b/include/fastscapelib/flow_router.hpp
@@ -172,23 +172,21 @@ namespace fastscapelib
             auto& receivers = this->receivers(fgraph);
             auto& dist2receivers = this->receivers_distance(fgraph);
             
-            for (std::size_t i=0; i<grid.size(); ++i)
+            for (auto i : grid.nodes_indices())
             {
                 receivers(i, 0) = i;
                 dist2receivers(i, 0) = 0;
                 slope_max = std::numeric_limits<double>::min();
                 
-                grid.neighbors(i, neighbors);
-
-                for (auto n=neighbors.begin(); n != neighbors.end(); ++n)
+                for (auto n : grid.neighbors(i, neighbors))
                 {          
-                    slope = (elevation.data()[i] - elevation.data()[n->idx]) / n->distance;
+                    slope = (elevation.data()[i] - elevation.data()[n.idx]) / n.distance;
 
                     if(slope > slope_max)
                     {
                         slope_max = slope;
-                        receivers(i, 0) = n->idx;
-                        dist2receivers(i, 0) = n->distance;
+                        receivers(i, 0) = n.idx;
+                        dist2receivers(i, 0) = n.distance;
                     }
                 }
                 donors(receivers(i, 0), donors_count(receivers(i, 0))++) = i;

--- a/include/fastscapelib/iterators.hpp
+++ b/include/fastscapelib/iterators.hpp
@@ -1,0 +1,199 @@
+#ifndef FASTSCAPELIB_ITERATORS_H
+#define FASTSCAPELIB_ITERATORS_H
+
+#include "xtl/xiterator_base.hpp"
+
+
+namespace fastscapelib
+{
+
+    template <class G>
+    struct index_iterator : public xtl::xbidirectional_iterator_base<index_iterator<G>, typename G::size_type>
+    {
+    public:
+
+        using self_type = index_iterator<G>;
+        using base_type = xtl::xbidirectional_iterator_base<self_type, typename G::size_type>;
+
+        using value_type = typename base_type::value_type;
+        using reference = typename base_type::reference;
+        using pointer = typename base_type::pointer;
+        using difference_type = typename base_type::difference_type;
+
+        index_iterator() = default;
+
+        index_iterator(G& grid, value_type position = 0)
+            : m_idx(position), m_grid(&grid)
+        {}
+
+        inline self_type& operator++()
+        {
+            ++m_idx;
+            return *this;
+        }
+
+        inline self_type& operator--()
+        {
+            --m_idx;
+            return *this;
+        }
+
+        inline reference operator*() const
+        {
+            return m_idx;
+        }
+
+        mutable value_type m_idx = 0;
+
+    private:
+
+        G* m_grid;
+    };
+
+
+    template <class G>
+    struct index_reverse_iterator : public xtl::xbidirectional_iterator_base<index_reverse_iterator<G>, typename G::size_type>
+    {
+    public:
+
+        using self_type = index_reverse_iterator<G>;
+        using base_type = xtl::xbidirectional_iterator_base<self_type, typename G::size_type>;
+
+        using value_type = typename base_type::value_type;
+        using reference = typename base_type::reference;
+        using pointer = typename base_type::pointer;
+        using difference_type = typename base_type::difference_type;
+
+        index_reverse_iterator() = default;
+
+        index_reverse_iterator(G& grid, value_type position = std::numeric_limits<typename G::size_type>::max())
+            : m_idx(position), m_grid(&grid)
+        {}
+
+        inline self_type& operator++()
+        {
+            --m_idx;
+            return *this;
+        }
+
+        inline self_type& operator--()
+        {
+            ++m_idx;
+            return *this;
+        }
+
+        inline reference operator*() const
+        {
+            return m_idx;
+        }
+
+        mutable value_type m_idx = std::numeric_limits<typename G::size_type>::max();
+
+    private:
+
+        G* m_grid;
+    };
+
+    template <class G>
+    inline bool operator==(const index_iterator<G>& lhs, const index_iterator<G>& rhs)
+    {
+        return lhs.m_idx == rhs.m_idx;
+    }
+
+    template <class G>
+    inline bool operator==(const index_reverse_iterator<G>& lhs, const index_reverse_iterator<G>& rhs)
+    {
+        return lhs.m_idx == rhs.m_idx;
+    }
+
+
+    template <class G, class F>
+    struct filtered_index_iterator : public xtl::xbidirectional_iterator_base<filtered_index_iterator<G, F>, typename G::size_type>
+    {
+    public:
+
+        using self_type = filtered_index_iterator<G, F>;
+        using base_type = xtl::xbidirectional_iterator_base<self_type, typename G::size_type>;
+
+        using value_type = typename base_type::value_type;
+        using reference = typename base_type::reference;
+        using pointer = typename base_type::pointer;
+        using difference_type = typename base_type::difference_type;
+
+        filtered_index_iterator(G& grid, F filter_functor, value_type position = 0)
+            : m_idx(position), m_grid(grid), m_filter_func(filter_functor)
+        {
+            if ((position == 0) && !m_filter_func(grid, position)) { ++m_idx; }
+            if ((position == grid.size()) && !m_filter_func(grid, position)) { --m_idx; }
+        }
+
+        inline self_type& operator++()
+        {
+            do
+            {
+                ++m_idx;
+            }
+            while ((!m_filter_func(m_grid, m_idx)) && (m_idx < m_grid.size()));
+   
+            return *this;
+        }
+
+        inline self_type& operator--()
+        {
+            do
+            {
+                --m_idx;
+            }
+            while ((!m_filter_func(m_grid, m_idx)) && (m_idx > 0));
+   
+            return *this;
+        }
+
+        inline reference operator*() const
+        {
+            return m_idx;
+        }
+
+    private:
+
+        mutable value_type m_idx;
+
+        G& m_grid;
+
+        F m_filter_func;
+    };
+
+
+    template <class G, class F>
+    inline bool operator==(const filtered_index_iterator<G, F>& lhs, const filtered_index_iterator<G, F>& rhs)
+    {
+        return lhs.m_idx == rhs.m_idx;
+    }
+
+
+    namespace detail
+    {
+
+        template <class G>
+        class node_indices_iterator
+        {
+        public:
+
+            using iterator_type = index_iterator<G>;
+
+            node_indices_iterator(G& grid)
+                : m_grid(grid)
+            {}
+
+            inline iterator_type begin() { return m_grid.nodes_indices_begin(); };
+
+            inline iterator_type end() { return m_grid.nodes_indices_end(); };
+
+        private:
+
+            G& m_grid;
+        };
+
+    }
+}
+#endif

--- a/include/fastscapelib/iterators.hpp
+++ b/include/fastscapelib/iterators.hpp
@@ -8,12 +8,20 @@ namespace fastscapelib
 {
 
     template <class G>
-    struct index_iterator : public xtl::xbidirectional_iterator_base<index_iterator<G>, typename G::size_type>
+    struct index_iterator : public xtl::xbidirectional_iterator_base<index_iterator<G>,
+                                                                     typename G::size_type,
+                                                                     std::ptrdiff_t,
+                                                                     typename G::size_type*,
+                                                                     typename G::size_type>
     {
     public:
 
         using self_type = index_iterator<G>;
-        using base_type = xtl::xbidirectional_iterator_base<self_type, typename G::size_type>;
+        using base_type = xtl::xbidirectional_iterator_base<self_type,
+                                                            typename G::size_type,
+                                                            std::ptrdiff_t,
+                                                            typename G::size_type*,
+                                                            typename G::size_type>;
 
         using value_type = typename base_type::value_type;
         using reference = typename base_type::reference;
@@ -50,65 +58,16 @@ namespace fastscapelib
         G* m_grid;
     };
 
-
-    template <class G>
-    struct index_reverse_iterator : public xtl::xbidirectional_iterator_base<index_reverse_iterator<G>, typename G::size_type>
-    {
-    public:
-
-        using self_type = index_reverse_iterator<G>;
-        using base_type = xtl::xbidirectional_iterator_base<self_type, typename G::size_type>;
-
-        using value_type = typename base_type::value_type;
-        using reference = typename base_type::reference;
-        using pointer = typename base_type::pointer;
-        using difference_type = typename base_type::difference_type;
-
-        index_reverse_iterator() = default;
-
-        index_reverse_iterator(G& grid, value_type position = std::numeric_limits<typename G::size_type>::max())
-            : m_idx(position), m_grid(&grid)
-        {}
-
-        inline self_type& operator++()
-        {
-            --m_idx;
-            return *this;
-        }
-
-        inline self_type& operator--()
-        {
-            ++m_idx;
-            return *this;
-        }
-
-        inline reference operator*() const
-        {
-            return m_idx;
-        }
-
-        mutable value_type m_idx = std::numeric_limits<typename G::size_type>::max();
-
-    private:
-
-        G* m_grid;
-    };
-
     template <class G>
     inline bool operator==(const index_iterator<G>& lhs, const index_iterator<G>& rhs)
     {
         return lhs.m_idx == rhs.m_idx;
     }
 
-    template <class G>
-    inline bool operator==(const index_reverse_iterator<G>& lhs, const index_reverse_iterator<G>& rhs)
-    {
-        return lhs.m_idx == rhs.m_idx;
-    }
-
 
     template <class G, class F>
-    struct filtered_index_iterator : public xtl::xbidirectional_iterator_base<filtered_index_iterator<G, F>, typename G::size_type>
+    struct filtered_index_iterator : public xtl::xbidirectional_iterator_base<filtered_index_iterator<G, F>,
+                                                                              typename G::size_type>
     {
     public:
 

--- a/include/fastscapelib/iterators.hpp
+++ b/include/fastscapelib/iterators.hpp
@@ -124,7 +124,6 @@ namespace fastscapelib
             : m_idx(position), m_grid(grid), m_filter_func(filter_functor)
         {
             if ((position == 0) && !m_filter_func(grid, position)) { ++m_idx; }
-            if ((position == grid.size()) && !m_filter_func(grid, position)) { --m_idx; }
         }
 
         inline self_type& operator++()

--- a/include/fastscapelib/structured_grid.hpp
+++ b/include/fastscapelib/structured_grid.hpp
@@ -75,7 +75,7 @@ namespace fastscapelib
         template<class V>
         auto make_node_status_filter(V value)
         {
-        return node_status_filter(value);
+            return node_status_filter<V>(value);
         }
 
         inline bool node_status_cmp(node_status a, node_status b)

--- a/include/fastscapelib/structured_grid.hpp
+++ b/include/fastscapelib/structured_grid.hpp
@@ -346,22 +346,22 @@ namespace fastscapelib
 
         inline filtered_index_iterator<structured_grid, detail::node_status_filter<node_status>> nodes_indices_begin(node_status status)
         {
-            return filtered_index_iterator(*this, detail::make_node_status_filter(status), 0);
+            return filtered_index_iterator<structured_grid, detail::node_status_filter<node_status>>(*this, detail::make_node_status_filter(status), 0);
         }
 
         inline filtered_index_iterator<structured_grid, detail::node_status_filter<node_status>> nodes_indices_end(node_status status)
         {
-            return filtered_index_iterator(*this, detail::make_node_status_filter(status), size());
+            return filtered_index_iterator<structured_grid, detail::node_status_filter<node_status>>(*this, detail::make_node_status_filter(status), size());
         }
 
         inline index_iterator<structured_grid> nodes_indices_begin()
         {
-            return index_iterator(*this, 0);
+            return index_iterator<structured_grid>(*this, 0);
         }
 
         inline index_iterator<structured_grid> nodes_indices_end()
         {
-            return index_iterator(*this, size());
+            return index_iterator<structured_grid>(*this, size());
         }
 
         inline index_reverse_iterator<structured_grid> nodes_indices_rbegin()

--- a/include/fastscapelib/structured_grid.hpp
+++ b/include/fastscapelib/structured_grid.hpp
@@ -364,16 +364,6 @@ namespace fastscapelib
             return index_iterator<structured_grid>(*this, size());
         }
 
-        inline index_reverse_iterator<structured_grid> nodes_indices_rbegin()
-        {
-            return index_reverse_iterator<structured_grid>(*this, size()-1);
-        }
-
-        inline index_reverse_iterator<structured_grid> nodes_indices_rend()
-        {
-            return index_reverse_iterator<structured_grid>(*this, std::numeric_limits<size_type>::max());
-        }      
-/*
         inline std::reverse_iterator<index_iterator<structured_grid>> nodes_indices_rbegin()
         {
             return std::reverse_iterator<index_iterator<structured_grid>>(nodes_indices_end());
@@ -383,7 +373,6 @@ namespace fastscapelib
         {
             return std::reverse_iterator<index_iterator<structured_grid>>(nodes_indices_begin());
         }
-*/
 
         inline detail::node_indices_iterator<structured_grid> nodes_indices() { return *this; };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -95,7 +95,8 @@ set(FASTSCAPELIB_TEST_SRC
     test_raster_grid.cpp
     test_raster_rook_grid.cpp
     test_raster_queen_grid.cpp
-    test_raster_bishop_grid.cpp    
+    test_raster_bishop_grid.cpp
+    test_structured_grid.cpp
     test_sinks.cpp
     test_sink_resolver.cpp
     test_bedrock_channel.cpp

--- a/test/test_profile_grid.cpp
+++ b/test/test_profile_grid.cpp
@@ -11,27 +11,6 @@ namespace fastscapelib
     namespace testing
     {
 
-        class neighbor: public ::testing::Test
-        {
-            protected:
-
-                fs::neighbor n {3, 1.35, fs::node_status::core};
-        };
-
-        TEST_F(neighbor, ctor)
-        {
-            EXPECT_EQ(n.idx, 3u);
-            EXPECT_EQ(n.distance, 1.35);
-            EXPECT_EQ(n.status, fs::node_status::core);
-        }
-
-        TEST_F(neighbor, equal)
-        {
-            fs::neighbor other_n {3, 1.35, fs::node_status::core};
-            EXPECT_EQ(n, other_n);
-        }
-
-
         class profile_boundary_status: public ::testing::Test
         {
             protected:
@@ -190,6 +169,20 @@ namespace fastscapelib
             EXPECT_EQ(grid_from_length.length(), 1500.);
             EXPECT_EQ(grid_from_length.size(), 151u);
             EXPECT_EQ(grid_from_length.spacing(), 10.);
+        }
+
+        TEST_F(profile_grid, status_filter)
+        {
+            node_status_filter boundaries_filter(fixed_grid, fs::node_status::fixed_value_boundary);
+            EXPECT_EQ(boundaries_filter(), 0u);
+            EXPECT_EQ(boundaries_filter(), 4u);
+            EXPECT_EQ(boundaries_filter(), 5u);
+
+            node_status_filter core_filter(fixed_grid, fs::node_status::core);
+            EXPECT_EQ(core_filter(), 1u);
+            EXPECT_EQ(core_filter(), 2u);
+            EXPECT_EQ(core_filter(), 3u);
+            EXPECT_EQ(core_filter(), 5u);
         }
     }
 }

--- a/test/test_profile_grid.cpp
+++ b/test/test_profile_grid.cpp
@@ -170,19 +170,5 @@ namespace fastscapelib
             EXPECT_EQ(grid_from_length.size(), 151u);
             EXPECT_EQ(grid_from_length.spacing(), 10.);
         }
-
-        TEST_F(profile_grid, status_filter)
-        {
-            node_status_filter boundaries_filter(fixed_grid, fs::node_status::fixed_value_boundary);
-            EXPECT_EQ(boundaries_filter(), 0u);
-            EXPECT_EQ(boundaries_filter(), 4u);
-            EXPECT_EQ(boundaries_filter(), 5u);
-
-            node_status_filter core_filter(fixed_grid, fs::node_status::core);
-            EXPECT_EQ(core_filter(), 1u);
-            EXPECT_EQ(core_filter(), 2u);
-            EXPECT_EQ(core_filter(), 3u);
-            EXPECT_EQ(core_filter(), 5u);
-        }
     }
 }

--- a/test/test_structured_grid.cpp
+++ b/test/test_structured_grid.cpp
@@ -82,11 +82,12 @@ namespace fastscapelib
         TEST_F(structured_grid, nodes_indices_end)
         {
             auto boundaries_filter = fixed_grid.nodes_indices_end(fs::node_status::fixed_value_boundary);
-            EXPECT_EQ(*boundaries_filter, 4u);
+            EXPECT_EQ(*boundaries_filter, 5u);
+            EXPECT_EQ(*(--boundaries_filter), 4u);
             EXPECT_EQ(*(--boundaries_filter), 0u);
 
             auto core_filter_end = fixed_grid.nodes_indices_end(fs::node_status::core);
-            EXPECT_EQ(*core_filter_end, 4u);
+            EXPECT_EQ(*core_filter_end, 5u);
             EXPECT_EQ(*(--core_filter_end), 3u);
         }
 

--- a/test/test_structured_grid.cpp
+++ b/test/test_structured_grid.cpp
@@ -1,0 +1,148 @@
+#include "fastscapelib/structured_grid.hpp"
+#include "fastscapelib/profile_grid.hpp"
+
+#include "gtest/gtest.h"
+
+
+namespace fs = fastscapelib;
+
+
+namespace fastscapelib
+{
+    namespace testing
+    {
+
+        class neighbor: public ::testing::Test
+        {
+            protected:
+
+                fs::neighbor n {3, 1.35, fs::node_status::core};
+        };
+
+        TEST_F(neighbor, ctor)
+        {
+            EXPECT_EQ(n.idx, 3u);
+            EXPECT_EQ(n.distance, 1.35);
+            EXPECT_EQ(n.status, fs::node_status::core);
+        }
+
+        TEST_F(neighbor, equal)
+        {
+            fs::neighbor other_n {3, 1.35, fs::node_status::core};
+            EXPECT_EQ(n, other_n);
+        }
+
+
+        class structured_grid: public ::testing::Test
+        {
+            protected:
+
+                using node_s = fs::node_status;
+
+                fs::node_status fixed = fs::node_status::fixed_value_boundary;
+                std::array<node_s, 2> loop {{fs::node_status::looped_boundary, fs::node_status::looped_boundary}};
+
+                fs::profile_boundary_status fixed_status {fixed};
+                fs::profile_boundary_status looped_status {loop};
+
+                using grid_type = fs::profile_grid_xt<fs::xtensor_selector>;
+                using size_type = typename grid_type::size_type;
+
+                size_type shape {5};
+                grid_type fixed_grid = grid_type(shape, 1.3, fs::node_status::fixed_value_boundary);
+                grid_type looped_grid = grid_type(shape, 1.4, fs::node_status::looped_boundary);
+        };
+
+        TEST_F(structured_grid, index_iterator)
+        {
+            index_iterator it(fixed_grid);
+
+            EXPECT_EQ(*(it++), 0u);
+            EXPECT_EQ(*(it++), 1u);
+
+/*
+            int sum = 0;
+            for (auto it : index_iterator(fixed_grid))
+            {
+                sum += *it;
+            }
+*/
+        }
+
+        TEST_F(structured_grid, nodes_indices_begin)
+        {
+            auto boundaries_filter = fixed_grid.nodes_indices_begin(fs::node_status::fixed_value_boundary);
+            EXPECT_EQ(*boundaries_filter, 0u);
+            EXPECT_EQ(*(boundaries_filter++), 0u);
+            EXPECT_EQ(*(boundaries_filter++), 4u);
+            EXPECT_EQ(*boundaries_filter, 5u);
+            EXPECT_EQ(*(--boundaries_filter), 4u);
+            EXPECT_EQ(*(++boundaries_filter), 5u);
+            EXPECT_EQ(*(++boundaries_filter), 6u);
+
+            auto core_filter = fixed_grid.nodes_indices_begin(fs::node_status::core);
+            EXPECT_EQ(*(core_filter++), 1u);
+            EXPECT_EQ(*(core_filter++), 2u);
+            EXPECT_EQ(*core_filter, 3u);
+            EXPECT_EQ(*(--core_filter), 2u);
+        }
+
+        TEST_F(structured_grid, nodes_indices_end)
+        {
+            auto boundaries_filter = fixed_grid.nodes_indices_end(fs::node_status::fixed_value_boundary);
+            EXPECT_EQ(*boundaries_filter, 4u);
+            EXPECT_EQ(*(--boundaries_filter), 0u);
+
+            auto core_filter_end = fixed_grid.nodes_indices_end(fs::node_status::core);
+            EXPECT_EQ(*core_filter_end, 4u);
+            EXPECT_EQ(*(--core_filter_end), 3u);
+        }
+
+        TEST_F(structured_grid, nodes_indices_rbegin)
+        {
+            auto node_it = fixed_grid.nodes_indices_rbegin();
+            EXPECT_EQ(*node_it, 4u);
+            EXPECT_EQ(*(++node_it), 3u);
+        }
+
+        TEST_F(structured_grid, nodes_indices_rend)
+        {
+            auto node_it = fixed_grid.nodes_indices_rend();
+            EXPECT_EQ(*node_it, std::numeric_limits<grid_type::size_type>::max());
+            EXPECT_EQ(*(--node_it), 0u);
+        }
+
+        TEST_F(structured_grid, nodes_indices)
+        {
+            std::size_t sum = 0;
+            std::size_t size = 0;
+            for (auto it=fixed_grid.nodes_indices_begin(); it!=fixed_grid.nodes_indices_end(); ++it)
+            {
+                sum += *it;
+                ++size;
+            }
+            EXPECT_EQ(sum, 10u);
+            EXPECT_EQ(size, fixed_grid.size());
+
+            sum = 0;
+            size = 0;
+            for (auto it=fixed_grid.nodes_indices_rbegin(); it!=fixed_grid.nodes_indices_rend(); ++it)
+            {
+                sum += *it;
+                ++size;
+            }
+            EXPECT_EQ(sum, 10u);
+            EXPECT_EQ(size, fixed_grid.size());
+
+            sum = 0;
+            size = 0;
+            for (auto idx : fixed_grid.nodes_indices())
+            {
+                sum += idx;
+                ++size;
+            }
+            EXPECT_EQ(sum, 10u);
+            EXPECT_EQ(size, fixed_grid.size());
+        }
+    }
+}

--- a/test/test_structured_grid.cpp
+++ b/test/test_structured_grid.cpp
@@ -55,18 +55,10 @@ namespace fastscapelib
 
         TEST_F(structured_grid, index_iterator)
         {
-            index_iterator it(fixed_grid);
+            index_iterator<grid_type> it(fixed_grid);
 
             EXPECT_EQ(*(it++), 0u);
             EXPECT_EQ(*(it++), 1u);
-
-/*
-            int sum = 0;
-            for (auto it : index_iterator(fixed_grid))
-            {
-                sum += *it;
-            }
-*/
         }
 
         TEST_F(structured_grid, nodes_indices_begin)


### PR DESCRIPTION
Description
--

Add iterators for `nodes_indices`, accepting filter on `node_status`.
Improve API of `neighbors_indices` and `neighbors` methods of `structured_grid` to allow the following syntax:

```cpp
neighbors_type neighbors;
neighbors_indices_type neighbors_indices;

for (auto i : grid.nodes_indices())
{
    for (auto n : grid.neighbors(i, neighbors))
    {          
        // do something
    }
   
    for (auto n : grid.neighbors_indices(i, neighbors_indices))
    {          
        // do something
    }
}
```

Related to #71 