### PR TITLE
Fix memory effect

### DIFF
--- a/include/fastscapelib/flow_router.hpp
+++ b/include/fastscapelib/flow_router.hpp
@@ -172,6 +172,8 @@ namespace fastscapelib
             auto& receivers = this->receivers(fgraph);
             auto& dist2receivers = this->receivers_distance(fgraph);
             
+            donors_count.fill(0);
+
             for (auto i : grid.nodes_indices())
             {
                 receivers(i, 0) = i;

--- a/test/test_flow_graph.cpp
+++ b/test/test_flow_graph.cpp
@@ -103,6 +103,25 @@ namespace fastscapelib
             EXPECT_EQ(graph.grid().size(), 16u); // dummy test
         }
 
+       TEST_F(flow_graph, update_routes)
+        {
+            auto router = std::make_unique<fs::single_flow_router<flow_graph_type>>();
+            auto resolver = std::make_unique<fs::no_sink_resolver<flow_graph_type>>();
+
+            flow_graph_type graph(grid, std::move(router), std::move(resolver));
+            graph.update_routes(elevation);
+            graph.update_routes(elevation); // check there is not memory effect
+        
+            xt::xtensor<size_type, 1> expected_fixed_receivers
+                { 1,  2,  7,  7,
+                  9,  9,  7,  7,
+                  9,  9,  9,  7,
+                  9,  9,  9,  14 };
+
+            EXPECT_TRUE(xt::all(xt::equal(xt::col(graph.receivers(), 0),
+                                          expected_fixed_receivers)));
+        }
+
         TEST_F(flow_graph, accumulate)
         {
             auto router = std::make_unique<fs::single_flow_router<flow_graph_type>>();


### PR DESCRIPTION
Description
--

The `single_flow_router` class needs to clean the `donors_count` variable of the `flow_graph` before to re-execute.
It fixes wrong accesses to arrays causing segfault.

- [x] rebase before merge