### PR TITLE
Grid shape python binding

### DIFF
--- a/python/fastscapelib/tests/test_profile_grid.py
+++ b/python/fastscapelib/tests/test_profile_grid.py
@@ -97,6 +97,9 @@ class TestProfileGrid():
     def test_spacing(self):
         assert self.g.spacing == 2.2
 
+    def test_shape(self):
+        assert self.g.shape == 10
+
     def test_length(self):
         assert self.g.length == 19.8
 

--- a/python/fastscapelib/tests/test_raster_grid.py
+++ b/python/fastscapelib/tests/test_raster_grid.py
@@ -112,5 +112,8 @@ class TestRasterGrid():
     def test_size(self):
         assert self.g.size == 50
 
+    def test_shape(self):
+        npt.assert_almost_equal(self.g.shape, [5, 10])
+
     def test_spacing(self):
         npt.assert_almost_equal(self.g.spacing, [2.2, 2.4])

--- a/python/src/grid.cpp
+++ b/python/src/grid.cpp
@@ -67,6 +67,7 @@ void add_grid_bindings(py::module& m) {
     pgrid.def_static("from_length", &profile_grid::from_length);
 
     pgrid.def_property_readonly("size", [](const profile_grid& g) { return g.size(); })
+         .def_property_readonly("shape", [](const profile_grid& g) { return g.size(); })
          .def_property_readonly("spacing", [](const profile_grid& g) { return g.spacing(); })
          .def_property_readonly("length", [](const profile_grid& g) { return g.length(); })
          .def_property_readonly("status_at_nodes", [](const profile_grid& g) { return g.status_at_nodes(); })
@@ -115,6 +116,7 @@ void add_grid_bindings(py::module& m) {
                     );
     
     rgrid.def_property_readonly("size", [](const raster_grid& g) { return g.size(); })
+         .def_property_readonly("shape", &raster_grid::shape)
          .def_property_readonly("spacing", [](const raster_grid& g) -> xt::pytensor<double, 1> { return g.spacing(); })
          .def_property_readonly("length", [](const raster_grid& g) -> xt::pytensor<double, 1> { return g.length(); })
          .def_property_readonly("status_at_nodes", [](const raster_grid& g) { return g.status_at_nodes(); });


### PR DESCRIPTION
Description
--

Add the `Grid.shape` property to Python bindings (both `ProfileGrid` and `RasterGrid`).

- [x] rebase before merge