### PR TITLE
Refactor erode stream power algo

### DIFF
--- a/benchmark/benchmark_bedrock_channel.cpp
+++ b/benchmark/benchmark_bedrock_channel.cpp
@@ -9,6 +9,8 @@
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xrandom.hpp"
 
+#include "fastscapelib/raster_grid.hpp"
+#include "fastscapelib/flow_graph.hpp"
 #include "fastscapelib/flow_routing.hpp"
 #include "fastscapelib/bedrock_channel.hpp"
 
@@ -21,108 +23,123 @@ namespace bms = fs::bench_setup;
 
 namespace fastscapelib
 {
-
-namespace benchmark_bedrock_channel
-{
-
-    template<class K, class S>
-    typename std::enable_if_t<std::is_floating_point<K>::value, K>
-    get_k_coef(S&& shape)
+    namespace benchmark_bedrock_channel
     {
-        (void) shape;  // do not show warning
-        return 1e-3;
-    }
 
-
-    template<class K, class S>
-    typename std::enable_if_t<xt::is_xexpression<K>::value, K>
-    get_k_coef(S&& shape)
-    {
-        using T = typename K::value_type;
-
-        K k_coef_arr = xt::empty<T>(shape);
-        k_coef_arr.fill(1e-3);
-
-        return k_coef_arr;
-    }
-
-
-    template<class T, class K, int Nd>
-    void bm_erode_stream_power(benchmark::State& state)
-    {
-        auto ns = static_cast<std::size_t>(state.range(0));
-
-        xt::xtensor<double, Nd> erosion;
-        xt::xtensor<double, Nd> elevation;
-        xt::xtensor<index_t, 1> receivers;
-        xt::xtensor<double, 1> dist2receivers;
-        xt::xtensor<index_t, 1> stack;
-        xt::xtensor<double, Nd> drainage_area;
-
-        if (Nd == 1)
+        template<class K, class S>
+        typename std::enable_if_t<std::is_floating_point<K>::value, K>
+        get_k_coef(S&& shape)
         {
-            double spacing = 300.;
-            double x0 = 300.;
-            double length = (ns - 1) * spacing;
-
-            xt::xtensor<double, Nd> x = xt::linspace<double>(length + x0, x0, ns);
-            erosion = xt::zeros_like(x);
-            elevation = (length + x0 - x) * 1e-4;
-            receivers = xt::arange<index_t>(-1, ns - 1);
-            dist2receivers = xt::full_like(elevation, spacing);
-            stack = xt::arange<index_t>(0, ns);
-            drainage_area = 6.69 * xt::pow(x, 1.67);   // Hack's law
+            (void) shape;  // do not show warning
+            return 1e-3;
         }
 
-        else if (Nd == 2)
+
+        template<class K, class S>
+        typename std::enable_if_t<xt::is_xexpression<K>::value, K>
+        get_k_coef(S&& shape)
         {
-            auto s = bms::FastscapeSetupBase<bms::surface_type::cone, T>(state.range(0));
+            using T = typename K::value_type;
 
-            fs::compute_receivers_d8(s.receivers, s.dist2receivers,
-                                     s.elevation, s.active_nodes,
-                                     s.dx, s.dy);
-            fs::compute_donors(s.ndonors, s.donors, s.receivers);
-            fs::compute_stack(s.stack, s.ndonors,
-                              s.donors, s.receivers);
+            K k_coef_arr = xt::empty<T>(shape);
+            k_coef_arr.fill(1e-3);
 
-            erosion = xt::zeros_like(s.elevation);
-            elevation = s.elevation;
-            receivers = s.receivers;
-            dist2receivers = s.dist2receivers;
-            stack = s.stack;
-            drainage_area = xt::empty_like(s.elevation);
-            fs::compute_drainage_area(drainage_area, stack, receivers, s.dx, s.dy);
+            return k_coef_arr;
         }
 
-        K k_coef = get_k_coef<K>(elevation.shape());
-        double m_exp = 0.5;
-        double n_exp = 1;
 
-        double dt = 1e4;
-
-        index_t ncorr;
-
-        for (auto _ : state)
+        template<class T, class K, int Nd>
+        void bm_erode_stream_power(benchmark::State& state)
         {
-            ncorr = fs::erode_stream_power(erosion, elevation, stack,
-                                           receivers, dist2receivers, drainage_area,
-                                           k_coef, m_exp, n_exp, dt, 1e-3);
+            auto ns = static_cast<std::size_t>(state.range(0));
+
+            xt::xtensor<double, Nd> erosion;
+            xt::xtensor<double, Nd> elevation;
+
+            if (Nd == 1)
+            {
+                using flow_graph_type = fs::flow_graph<fs::profile_grid, double>;
+                using index_type = typename flow_graph_type::index_type;
+
+                double spacing = 300.;
+
+                auto grid = fs::profile_grid(ns, spacing, fs::node_status::fixed_value_boundary);
+            
+                auto flow_graph = flow_graph_type(grid,
+                                                  std::make_unique<fs::single_flow_router<flow_graph_type>>(),
+                                                  std::make_unique<fs::no_sink_resolver<flow_graph_type>>());
+
+                double x0 = 300.;
+                double length = (ns - 1) * spacing;
+
+                xt::xtensor<double, 1> x = xt::linspace<double>(length + x0, x0, ns);
+                erosion = xt::zeros_like(x);
+                elevation = (length + x0 - x) * 1e-4;
+
+                flow_graph.update_routes(elevation);
+
+                auto drainage_area = flow_graph.accumulate(1.);
+
+                K k_coef = get_k_coef<K>(elevation.shape());
+                double m_exp = 0.5;
+                double n_exp = 1;
+                double dt = 1e4;
+
+                index_type ncorr;
+
+                for (auto _ : state)
+                {
+                    ncorr = fs::erode_stream_power(erosion, elevation, drainage_area, flow_graph,
+                                                   k_coef, m_exp, n_exp, dt, 1e-3);
+                }
+            }
+
+            else if (Nd == 2)
+            {
+                using flow_graph_type = fs::flow_graph<fs::raster_grid, double>;
+                using index_type = typename flow_graph_type::index_type;
+
+                auto s = bms::FastscapeSetupBase<bms::surface_type::cone, T>(state.range(0));
+
+                auto grid = fs::raster_grid({{ns, ns}}, {s.dy, s.dy}, fs::node_status::fixed_value_boundary);
+            
+                auto flow_graph = flow_graph_type(grid,
+                                                  std::make_unique<fs::single_flow_router<flow_graph_type>>(),
+                                                  std::make_unique<fs::no_sink_resolver<flow_graph_type>>());
+
+                elevation = s.elevation;
+                erosion = xt::zeros_like(s.elevation);
+                flow_graph.update_routes(elevation);
+
+                auto drainage_area = flow_graph.accumulate(1.);
+
+                K k_coef = get_k_coef<K>(elevation.shape());
+                double m_exp = 0.5;
+                double n_exp = 1;
+                double dt = 1e4;
+
+                index_type ncorr;
+
+                for (auto _ : state)
+                {
+                    ncorr = fs::erode_stream_power(erosion, elevation, drainage_area, flow_graph,
+                                                   k_coef, m_exp, n_exp, dt, 1e-3);
+                }
+            }
         }
-    }
 
 
-    BENCHMARK_TEMPLATE(bm_erode_stream_power, double, double, 1)
-    ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+        BENCHMARK_TEMPLATE(bm_erode_stream_power, double, double, 1)
+        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
 
-    BENCHMARK_TEMPLATE(bm_erode_stream_power, double, xt::xtensor<double, 1>, 1)
-    ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
+        BENCHMARK_TEMPLATE(bm_erode_stream_power, double, xt::xtensor<double, 1>, 1)
+        ->Apply(bms::grid_sizes<benchmark::kMicrosecond>);
 
-    BENCHMARK_TEMPLATE(bm_erode_stream_power, double, double, 2)
-    ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+        BENCHMARK_TEMPLATE(bm_erode_stream_power, double, double, 2)
+        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
 
-    BENCHMARK_TEMPLATE(bm_erode_stream_power, double, xt::xtensor<double, 2>, 2)
-    ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
+        BENCHMARK_TEMPLATE(bm_erode_stream_power, double, xt::xtensor<double, 2>, 2)
+        ->Apply(bms::grid_sizes<benchmark::kMillisecond>);
 
-}  // namespace benchmark_bedrock_channel
-
+    }  // namespace benchmark_bedrock_channel
 }  // namespace fastscapelib

--- a/include/fastscapelib/bedrock_channel.hpp
+++ b/include/fastscapelib/bedrock_channel.hpp
@@ -17,273 +17,271 @@
 namespace fastscapelib
 {
 
-namespace detail
-{
-
-
-template<class T, class S>
-auto k_coef_as_array(T k_coef,
-                     S&& shape,
-                     typename std::enable_if_t<std::is_floating_point<T>::value>* = 0)
-{
-    return xt::broadcast(std::forward<T>(k_coef), shape);
-}
-
-
-template<class K, class S>
-auto k_coef_as_array(K&& k_coef,
-                     S&& shape,
-                     typename std::enable_if_t<xt::is_xexpression<K>::value>* = 0)
-{
-    auto k_coef_arr = xt::flatten(k_coef);
-
-    assert(k_coef_arr.shape() == shape);
-    (void) shape;   // TODO: still unused parameter warning despite assert?
-
-    return k_coef_arr;
-}
-
-
-/**
- * erode_stream_power implementation.
- *
- * The implementation here slightly differs from the one described in
- * Braun & Willet (2013). The problem is reformulated so that the
- * Newton-Raphson method is applied on the difference of elevation
- * between a node and its receiver, rather than on the node's
- * elevation itself. This allows saving some operations.
- */
-template<class Er, class El, class S, class R, class Di, class Dr, class K>
-index_t erode_stream_power_impl(Er&& erosion,
-                                El&& elevation,
-                                S&& stack,
-                                R&& receivers,
-                                Di&& dist2receivers,
-                                Dr&& drainage_area,
-                                K&& k_coef,
-                                double m_exp,
-                                double n_exp,
-                                double dt,
-                                double tolerance)
-{
-    using T = std::common_type_t<typename std::decay_t<Er>::value_type,
-                                 typename std::decay_t<El>::value_type>;
-
-    auto erosion_flat = xt::flatten(erosion);
-    const auto elevation_flat = xt::flatten(elevation);
-    const auto drainage_area_flat = xt::flatten(drainage_area);
-
-    const auto k_coef_arr = k_coef_as_array(k_coef, elevation_flat.shape());
-
-    index_t n_corr = 0;
-
-    for (const auto& istack : stack)
+    namespace detail
     {
-        index_t irec = receivers(istack);
 
-        if (irec == istack)
+        template<class T, class S>
+        auto k_coef_as_array(T k_coef,
+                            S&& shape,
+                            typename std::enable_if_t<std::is_floating_point<T>::value>* = 0)
         {
-            // at basin outlet or pit
-            erosion_flat(istack) = 0.;
-            continue;
+            return xt::broadcast(std::forward<T>(k_coef), shape);
         }
 
-        T istack_elevation = elevation_flat(istack);                   // at time t
-        T irec_elevation = elevation_flat(irec) - erosion_flat(irec);  // at time t+dt
 
-        if (irec_elevation >= istack_elevation)
+        template<class K, class S>
+        auto k_coef_as_array(K&& k_coef,
+                            S&& shape,
+                            typename std::enable_if_t<xt::is_xexpression<K>::value>* = 0)
         {
-            // may happen if flow is routed outside of a depression / flat area
-            erosion_flat(istack) = 0.;
-            continue;
+            auto k_coef_arr = xt::flatten(k_coef);
+
+            assert(k_coef_arr.shape() == shape);
+            (void) shape;   // TODO: still unused parameter warning despite assert?
+
+            return k_coef_arr;
         }
 
-        auto factor = (k_coef_arr(istack) * dt *
-                       std::pow(drainage_area_flat(istack), m_exp));
 
-        T delta_0 = istack_elevation - irec_elevation;
-        T delta_k;
-
-        if (n_exp == 1)
+        /**
+         * erode_stream_power implementation.
+         *
+         * The implementation here slightly differs from the one described in
+         * Braun & Willet (2013). The problem is reformulated so that the
+         * Newton-Raphson method is applied on the difference of elevation
+         * between a node and its receiver, rather than on the node's
+         * elevation itself. This allows saving some operations.
+         */
+        template<class Er, class El, class Dr, class FG, class K>
+        auto erode_stream_power_impl(Er&& erosion,
+                                     El&& elevation,
+                                     Dr&& drainage_area,
+                                     FG& flow_graph,
+                                     K&& k_coef,
+                                     double m_exp,
+                                     double n_exp,
+                                     double dt,
+                                     double tolerance)
+            -> typename FG::index_type
         {
-            // fast path for n_exp = 1 (common use case)
-            factor /= dist2receivers(istack);
-            delta_k = delta_0 / (1. + factor);
-        }
+            using T = std::common_type_t<typename std::decay_t<Er>::value_type,
+                                         typename std::decay_t<El>::value_type>;
+            using index_type = typename FG::index_type;
 
-        else
-        {
-            // 1st order Newton-Raphson iterations (k)
-            factor /= std::pow(dist2receivers(istack), n_exp);
-            delta_k = delta_0;
+            auto erosion_flat = xt::flatten(erosion);
+            const auto elevation_flat = xt::flatten(elevation);
+            const auto drainage_area_flat = xt::flatten(drainage_area);
+            const auto k_coef_arr = k_coef_as_array(k_coef, elevation_flat.shape());
 
-            while (true)
+            const auto& receivers = flow_graph.receivers();
+            const auto& receivers_count = flow_graph.receivers_count();
+            const auto& receivers_distance = flow_graph.receivers_distance();
+            const auto& receivers_weight = flow_graph.receivers_weight();
+            const auto& dfs_stack = flow_graph.dfs_stack();
+
+            index_type n_corr = 0;
+
+            for (const auto& istack : dfs_stack)
             {
-                auto factor_delta_exp = factor * std::pow(delta_k, n_exp);
-                auto func = delta_k + factor_delta_exp - delta_0;
+                auto r_count = receivers_count[istack];
 
-                if (func <= tolerance)
+                for (index_type r=0; r<r_count; ++r)
                 {
-                    break;
-                }
+                    index_type irec = receivers(istack, r);
 
-                auto func_deriv = 1 + n_exp * factor_delta_exp / delta_k;
-                delta_k -= func / func_deriv;
+                    if (irec == istack)
+                    {
+                        // at basin outlet or pit
+                        erosion_flat(istack) = 0.;
+                        continue;
+                    }
 
-                if (delta_k <= 0)
-                {
-                    break;
+                    T istack_elevation = elevation_flat(istack);                   // at time t
+                    T irec_elevation = elevation_flat(irec) - erosion_flat(irec);  // at time t+dt
+
+                    if (irec_elevation >= istack_elevation)
+                    {
+                        // may happen if flow is routed outside of a depression / flat area
+                        erosion_flat(istack) = 0.;
+                        continue;
+                    }
+
+                    auto factor = (k_coef_arr(istack) * dt *
+                                   std::pow(drainage_area_flat(istack), m_exp));
+
+                    T delta_0 = istack_elevation - irec_elevation;
+                    T delta_k;
+
+                    if (n_exp == 1)
+                    {
+                        // fast path for n_exp = 1 (common use case)
+                        factor /= receivers_distance(istack, r);
+                        delta_k = delta_0 / (1. + factor);
+                    }
+
+                    else
+                    {
+                        // 1st order Newton-Raphson iterations (k)
+                        factor /= std::pow(receivers_distance(istack, r), n_exp);
+                        delta_k = delta_0;
+
+                        while (true)
+                        {
+                            auto factor_delta_exp = factor * std::pow(delta_k, n_exp);
+                            auto func = delta_k + factor_delta_exp - delta_0;
+
+                            if (func <= tolerance)
+                            {
+                                break;
+                            }
+
+                            auto func_deriv = 1 + n_exp * factor_delta_exp / delta_k;
+                            delta_k -= func / func_deriv;
+
+                            if (delta_k <= 0)
+                            {
+                                break;
+                            }
+                        }
+                    }
+
+                    if (delta_k <= 0)
+                    {
+                        // prevent the creation of new depressions / flat channels
+                        // by arbitrarily limiting erosion
+                        n_corr++;
+                        delta_k = std::numeric_limits<T>::min();
+                    }
+
+                    if (r_count == 1)
+                    {
+                        erosion_flat(istack) = (delta_0 - delta_k);
+                    } 
+                    else
+                    {
+                        erosion_flat(istack) += (delta_0 - delta_k) * receivers_weight(istack, r);
+                    }
                 }
             }
+
+            return n_corr;
         }
 
-        if (delta_k <= 0)
-        {
-            // prevent the creation of new depressions / flat channels
-            // by arbitrarily limiting erosion
-            n_corr++;
-            delta_k = std::numeric_limits<T>::min();
-        }
+    }  // namespace detail
 
-        erosion_flat(istack) = delta_0 - delta_k;
+
+    /**
+     * Compute bedrock channel erosion during a single time step using the
+     * Stream Power Law.
+     *
+     * It numerically solves the Stream Power Law [dh/dt = K A^m (dh/dx)^n]
+     * using an implicit finite difference scheme 1st order in space and time.
+     * The method is detailed in Braun and Willet's (2013) and has been
+     * slightly reformulated/optimized.
+     *
+     * As it requires some input information on the flow tree topology
+     * (e.g., flow receivers and stack order) and geometry (e.g., distance
+     * to receivers), this generic function is grid/mesh agnostic and can
+     * be applied in both 1-d (river profile) and 2-d (river network)
+     * cases.
+     *
+     * The implicit scheme ensure numerical stability but doesn't totally
+     * prevent erosion from lowering the elevation of a node below that of
+     * its receiver. If this occurs, erosion will be limited so that the
+     * node will be lowered (nearly) down to the level of its receiver. In
+     * general it is better to adjust input values (e.g., ``dt``) so that
+     * such arbitrary limitation doesn't occur. The value returned by this
+     * function allows to detect and track the number of these
+     * occurrences.
+     *
+     * @param erosion : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
+     *     Erosion at grid node.
+     * @param elevation : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
+     *     Elevation at grid node.
+     * @param flow_graph :``[intent=in]``
+     *     Flow graph of the grid.
+     * @param k_coef : ``[intent=in]``
+     *     Stream Power Law coefficient.
+     * @param m_exp : ``[intent=in]``
+     *     Stream Power Law drainage area exponent.
+     * @param n_exp : ``[intent=in]``
+     *     Stream Power Law slope exponent.
+     * @param dt : ``[intent=in]``
+     *     Time step duration.
+     * @param tolerance : ``[intent=in]``
+     *     Tolerance used for Newton's iterations (``n_exp`` != 1).
+     *
+     * @returns
+     *     Total number of nodes for which erosion has been
+     *     arbitrarily limited to ensure consistency.
+     */
+    template<class Er, class El, class Dr, class FG>
+    auto erode_stream_power(xtensor_t<Er>& erosion,
+                            const xtensor_t<El>& elevation,
+                            const xtensor_t<Dr>& drainage_area,
+                            const FG& flow_graph,
+                            double k_coef,
+                            double m_exp,
+                            double n_exp,
+                            double dt,
+                            double tolerance)
+        -> typename FG::index_type
+    {
+        return detail::erode_stream_power_impl(erosion.derived_cast(),
+                                              elevation.derived_cast(),
+                                              drainage_area.derived_cast(),
+                                              flow_graph,
+                                              k_coef, m_exp, n_exp,
+                                              dt, tolerance);
     }
 
-    return n_corr;
-}
 
-}  // namespace detail
-
-
-/**
- * Compute bedrock channel erosion during a single time step using the
- * Stream Power Law.
- *
- * It numerically solves the Stream Power Law [dh/dt = K A^m (dh/dx)^n]
- * using an implicit finite difference scheme 1st order in space and time.
- * The method is detailed in Braun and Willet's (2013) and has been
- * slightly reformulated/optimized.
- *
- * As it requires some input information on the flow tree topology
- * (e.g., flow receivers and stack order) and geometry (e.g., distance
- * to receivers), this generic function is grid/mesh agnostic and can
- * be applied in both 1-d (river profile) and 2-d (river network)
- * cases.
- *
- * The implicit scheme ensure numerical stability but doesn't totally
- * prevent erosion from lowering the elevation of a node below that of
- * its receiver. If this occurs, erosion will be limited so that the
- * node will be lowered (nearly) down to the level of its receiver. In
- * general it is better to adjust input values (e.g., ``dt``) so that
- * such arbitrary limitation doesn't occur. The value returned by this
- * function allows to detect and track the number of these
- * occurrences.
- *
- * @param erosion : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
- *     Erosion at grid node.
- * @param elevation : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
- *     Elevation at grid node.
- * @param stack :``[intent=in, shape=(nnodes)]``
- *     Stack position at grid node.
- * @param receivers : ``[intent=in, shape=(nnodes)]``
- *     Index of flow receiver at grid node.
- * @param dist2receivers : ``[intent=out, shape=(nnodes)]``
- *     Distance to receiver at grid node.
- * @param drainage_area : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
- *     Drainage area at grid node.
- * @param k_coef : ``[intent=in]``
- *     Stream Power Law coefficient.
- * @param m_exp : ``[intent=in]``
- *     Stream Power Law drainage area exponent.
- * @param n_exp : ``[intent=in]``
- *     Stream Power Law slope exponent.
- * @param dt : ``[intent=in]``
- *     Time step duration.
- * @param tolerance : ``[intent=in]``
- *     Tolerance used for Newton's iterations (``n_exp`` != 1).
- *
- * @returns
- *     Total number of nodes for which erosion has been
- *     arbitrarily limited to ensure consistency.
- */
-template<class Er, class El, class S, class R, class Di, class Dr>
-index_t erode_stream_power(xtensor_t<Er>& erosion,
-                           const xtensor_t<El>& elevation,
-                           const xtensor_t<S>& stack,
-                           const xtensor_t<R>& receivers,
-                           const xtensor_t<Di>& dist2receivers,
-                           const xtensor_t<Dr>& drainage_area,
-                           double k_coef,
-                           double m_exp,
-                           double n_exp,
-                           double dt,
-                           double tolerance)
-{
-    return detail::erode_stream_power_impl(erosion.derived_cast(),
-                                           elevation.derived_cast(),
-                                           stack.derived_cast(),
-                                           receivers.derived_cast(),
-                                           dist2receivers.derived_cast(),
-                                           drainage_area.derived_cast(),
-                                           k_coef, m_exp, n_exp,
-                                           dt, tolerance);
-}
-
-
-/**
- * Compute bedrock channel erosion during a single time step using the
- * Stream Power Law.
- *
- * This version accepts a spatially variable stream-power law coefficient.
- *
- * @param erosion : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
- *     Erosion at grid node.
- * @param elevation : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
- *     Elevation at grid node.
- * @param stack :``[intent=in, shape=(nnodes)]``
- *     Stack position at grid node.
- * @param receivers : ``[intent=in, shape=(nnodes)]``
- *     Index of flow receiver at grid node.
- * @param dist2receivers : ``[intent=out, shape=(nnodes)]``
- *     Distance to receiver at grid node.
- * @param drainage_area : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
- *     Drainage area at grid node.
- * @param k_coef : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
- *     Stream Power Law coefficient.
- * @param m_exp : ``[intent=in]``
- *     Stream Power Law drainage area exponent.
- * @param n_exp : ``[intent=in]``
- *     Stream Power Law slope exponent.
- * @param dt : ``[intent=in]``
- *     Time step duration.
- * @param tolerance : ``[intent=in]``
- *     Tolerance used for Newton's iterations (``n_exp`` != 1).
- *
- * @returns
- *     Total number of nodes for which erosion has been
- *     arbitrarily limited to ensure consistency.
- */
-template<class Er, class El, class S, class R, class Di, class Dr, class K>
-index_t erode_stream_power(xtensor_t<Er>& erosion,
-                           const xtensor_t<El>& elevation,
-                           const xtensor_t<S>& stack,
-                           const xtensor_t<R>& receivers,
-                           const xtensor_t<Di>& dist2receivers,
-                           const xtensor_t<Dr>& drainage_area,
-                           const xtensor_t<K>& k_coef,
-                           double m_exp,
-                           double n_exp,
-                           double dt,
-                           double tolerance)
-{
-    return detail::erode_stream_power_impl(erosion.derived_cast(),
-                                           elevation.derived_cast(),
-                                           stack.derived_cast(),
-                                           receivers.derived_cast(),
-                                           dist2receivers.derived_cast(),
-                                           drainage_area.derived_cast(),
-                                           k_coef.derived_cast(),
-                                           m_exp, n_exp,
-                                           dt, tolerance);
-}
+    /**
+     * Compute bedrock channel erosion during a single time step using the
+     * Stream Power Law.
+     *
+     * This version accepts a spatially variable stream-power law coefficient.
+     *
+     * @param erosion : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
+     *     Erosion at grid node.
+     * @param elevation : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
+     *     Elevation at grid node.
+     * @param flow_graph :``[intent=in]``
+     *     Flow graph of the grid.
+     * @param k_coef : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
+     *     Stream Power Law coefficient.
+     * @param m_exp : ``[intent=in]``
+     *     Stream Power Law drainage area exponent.
+     * @param n_exp : ``[intent=in]``
+     *     Stream Power Law slope exponent.
+     * @param dt : ``[intent=in]``
+     *     Time step duration.
+     * @param tolerance : ``[intent=in]``
+     *     Tolerance used for Newton's iterations (``n_exp`` != 1).
+     *
+     * @returns
+     *     Total number of nodes for which erosion has been
+     *     arbitrarily limited to ensure consistency.
+     */
+    template<class Er, class El, class Dr, class FG, class K>
+    auto erode_stream_power(xtensor_t<Er>& erosion,
+                            const xtensor_t<El>& elevation,
+                            const xtensor_t<Dr>& drainage_area,
+                            const FG& flow_graph,
+                            const xtensor_t<K>& k_coef,
+                            double m_exp,
+                            double n_exp,
+                            double dt,
+                            double tolerance)
+        -> typename FG::index_type
+    {
+        return detail::erode_stream_power_impl(erosion.derived_cast(),
+                                               elevation.derived_cast(),
+                                               drainage_area.derived_cast(),
+                                               flow_graph,
+                                               k_coef.derived_cast(),
+                                               m_exp, n_exp,
+                                               dt, tolerance);
+    }
 
 }  // namespace fastscapelib

--- a/include/fastscapelib/flow_graph.hpp
+++ b/include/fastscapelib/flow_graph.hpp
@@ -43,6 +43,9 @@ namespace fastscapelib
 
         using elevation_type = xt_container_t<S, elev_t, G::xt_ndims>;
 
+        template <class T>
+        using data_type = xt_container_t<S, T, G::xt_ndims>;
+
         using donors_type = xt_container_t<S, index_type, 2>;
         using donors_count_type = xt_container_t<S, neighbors_count_type, 1>;
 
@@ -89,24 +92,26 @@ namespace fastscapelib
 
         G& grid() { return m_grid; };
 
-        index_type size() { return m_grid.size(); };
+        index_type size() const { return m_grid.size(); };
 
-        const receivers_type& receivers() { return m_receivers; };
+        const receivers_type& receivers() const { return m_receivers; };
 
-        const receivers_count_type& receivers_count() { return m_receivers_count; };
+        const receivers_count_type& receivers_count() const { return m_receivers_count; };
 
-        const receivers_distance_type& receivers_distance() { return m_receivers_distance; };
+        const receivers_distance_type& receivers_distance() const { return m_receivers_distance; };
 
-        const receivers_weight_type& receivers_weight() { return m_receivers_weight; };
+        const receivers_weight_type& receivers_weight() const { return m_receivers_weight; };
 
-        const donors_type& donors() { return m_donors; };
+        const donors_type& donors() const { return m_donors; };
 
-        const donors_count_type& donors_count() { return m_donors_count; };
+        const donors_count_type& donors_count() const { return m_donors_count; };
 
         template <class T>
         T accumulate(const T& data) const;
 
-        const stack_type& dfs_stack() { return m_dfs_stack; };
+        data_type<double> accumulate(const double& data) const;
+
+        const stack_type& dfs_stack() const { return m_dfs_stack; };
 
         const_dfs_iterator dfs_cbegin() { return m_dfs_stack.cbegin(); };
 
@@ -141,7 +146,8 @@ namespace fastscapelib
 
     template <class G, class elev_t, class S>
     template <class T>
-    T flow_graph<G, elev_t, S>::accumulate(const T& data) const
+    auto flow_graph<G, elev_t, S>::accumulate(const T& data) const
+        -> T
     {
         T acc = xt::zeros_like(data);
 
@@ -160,6 +166,14 @@ namespace fastscapelib
         }
 
         return acc;
+    }
+
+    template <class G, class elev_t, class S>
+    auto flow_graph<G, elev_t, S>::accumulate(const double& data) const
+        -> data_type<double>
+    {
+        data_type<double> tmp = xt::ones<double>(m_grid.shape()) * data;
+        return accumulate(tmp);
     }
 }
 

--- a/include/fastscapelib/structured_grid.hpp
+++ b/include/fastscapelib/structured_grid.hpp
@@ -328,6 +328,8 @@ namespace fastscapelib
 
         length_type length() const noexcept;
 
+        shape_type shape() const noexcept;
+
         const node_status_type& status_at_nodes() const;
 
         distance_type node_area(const size_type& idx) const noexcept;
@@ -447,6 +449,16 @@ namespace fastscapelib
         -> length_type
     {
         return derived_grid().m_length;
+    }
+
+    /**
+     * Returns the shape of the grid.
+     */
+    template <class G, class C>
+    inline auto structured_grid<G, C>::shape() const noexcept
+        -> shape_type
+    {
+        return derived_grid().m_shape;
     }
 
     /**

--- a/python/fastscapelib/tests/test_bedrock_channel.py
+++ b/python/fastscapelib/tests/test_bedrock_channel.py
@@ -2,47 +2,72 @@ import pytest
 import numpy as np
 
 from fastscapelib.algo import erode_stream_power_d, erode_stream_power_var_d
+from fastscapelib.grid import ProfileGrid, RasterGrid, Node, NodeStatus, RasterBoundaryStatus, RasterNode
+from fastscapelib.flow_graph import FlowGraph, DummyFlowRouter, MultipleFlowRouter, SingleFlowRouter
 
 
-@pytest.mark.parametrize("k_coef_type", ["constant", "variable"])
-def test_erode_stream_power(k_coef_type):
-    # Test on a tiny (2x2) 2-d square grid with a planar surface
-    # tilted in y (rows) and with all outlets on the 1st row.
-    spacing = 300.
+class TestErodeStreamPower():
 
-    receivers = np.array([0, 1, 0, 1], dtype=np.intp)
-    dist2receivers = np.array([0., 0., spacing, spacing], dtype='d')
-    stack = np.array([0, 2, 1, 3], dtype=np.intp)
+    @pytest.mark.parametrize("func,k", [(erode_stream_power_d, 1e-3),
+                                        (erode_stream_power_var_d, np.full(4, 1e-3))])
+    def test_profile_grid(self, func, k):
+        spacing = 300.
+        grid = ProfileGrid(4, 300, [NodeStatus.FIXED_VALUE_BOUNDARY]*2, [])
+        flow_graph = FlowGraph(grid, SingleFlowRouter())
+        
+        h = 1.
+        elevation = np.array([0., h, h, 0.], dtype='d')
+        graph_elevation = flow_graph.update_routes(elevation)
 
-    a = spacing**2
-    drainage_area = np.array([[2 * a, 2 * a], [a, a]], dtype='d')
+        drainage_area = flow_graph.accumulate(1.)
+        erosion = np.zeros_like(elevation)
+        m_exp = 0.5
+        n_exp = 1.
 
-    h = 1.
-    elevation = np.array([[0., 0.], [h, h]], dtype='d')
+        dt = 1.   # use small time step (compare with explicit scheme)
+        tolerance = 1e-3
 
-    erosion = np.empty_like(elevation)
+        n_corr = func(erosion, elevation, drainage_area, flow_graph,
+                      k, m_exp, n_exp, dt, tolerance)
 
-    k_coef = 1e-3
-    m_exp = 0.5
-    n_exp = 1.
+        slope = h / spacing
+        a = spacing
+        k_coef = 1e-3
+        err = dt * k_coef * a**m_exp * slope**n_exp
+        expected_erosion = np.array([0., err, err, 0.], dtype='d')
 
-    dt = 1   # use small time step (compare with explicit scheme)
-    tolerance = 1e-3
+        np.testing.assert_allclose(erosion, expected_erosion, atol=1e-5)
+        assert n_corr == 0
 
-    if k_coef_type == 'constant':
-        func = erode_stream_power_d
-        k = k_coef
-    elif k_coef_type == 'variable':
-        func = erode_stream_power_var_d
-        k = np.full_like(elevation, k_coef)
+    @pytest.mark.parametrize("func,k", [(erode_stream_power_d, 1e-3),
+                                        (erode_stream_power_var_d, np.full((2, 2), 1e-3))])
+    def test_raster_grid(self, func, k):
+        # Test on a tiny (2x2) 2-d square grid with a planar surface
+        # tilted in y (rows) and with all outlets on the 1st row.
+        spacing = 300.
+        grid = RasterGrid([2, 2], [spacing, spacing], RasterBoundaryStatus(NodeStatus.FIXED_VALUE_BOUNDARY), [])
+        flow_graph = FlowGraph(grid, SingleFlowRouter())
 
-    n_corr = func(erosion, elevation, stack,
-                  receivers, dist2receivers, drainage_area,
-                  k, m_exp, n_exp, dt, tolerance)
+        h = 1.
+        elevation = np.array([[0., 0.], [h, h]], dtype='d')
+        graph_elevation = flow_graph.update_routes(elevation)
 
-    slope = h / spacing
-    err = dt * k_coef * a**m_exp * slope**n_exp
-    expected_erosion = np.array([[0., 0.], [err, err]], dtype='d')
+        drainage_area = flow_graph.accumulate(1.)
+        erosion = np.zeros_like(elevation)
+        m_exp = 0.5
+        n_exp = 1.
 
-    np.testing.assert_allclose(erosion, expected_erosion, atol=1e-5)
-    assert n_corr == 0
+        dt = 1   # use small time step (compare with explicit scheme)
+        tolerance = 1e-3
+
+        n_corr = func(erosion, elevation, drainage_area, flow_graph,
+                      k, m_exp, n_exp, dt, tolerance)
+
+        slope = h / spacing
+        a = spacing**2
+        k_coef = 1e-3
+        err = dt * k_coef * a**m_exp * slope**n_exp
+        expected_erosion = np.array([[0., 0.], [err, err]], dtype='d')
+
+        np.testing.assert_allclose(erosion, expected_erosion, atol=1e-5)
+        assert n_corr == 0

--- a/python/fastscapelib/tests/test_flow_graph.py
+++ b/python/fastscapelib/tests/test_flow_graph.py
@@ -67,6 +67,10 @@ class TestFlowGraph():
         npt.assert_almost_equal(flow_graph.accumulate(np.ones(elevation.shape)),
                                 expected)
 
+        npt.assert_almost_equal(flow_graph.accumulate(1.), expected)
+
+        npt.assert_almost_equal(flow_graph.accumulate(5.), 5 * expected)
+
         data = np.array([[1.1, 1.0, 1.1, 1.0],
                          [1.1, 1.0, 1.1, 1.0],
                          [1.1, 1.0, 1.1, 1.0],

--- a/python/fastscapelib/tests/test_profile_grid.py
+++ b/python/fastscapelib/tests/test_profile_grid.py
@@ -98,7 +98,7 @@ class TestProfileGrid():
         assert self.g.spacing == 2.2
 
     def test_shape(self):
-        assert self.g.shape == 10
+        npt.assert_almost_equal(self.g.shape, np.r_[10])
 
     def test_length(self):
         assert self.g.length == 19.8

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -27,6 +27,7 @@ void add_flow_graph_bindings(py::module& m) {
         .def("donors", &flow_graph_facade::donors)
         .def("donors_count", &flow_graph_facade::donors_count)
         .def("dfs_stack", &flow_graph_facade::dfs_stack)
-        .def("accumulate", &flow_graph_facade::accumulate);
+        .def("accumulate", py::overload_cast<const xt::pyarray<double>&>(&flow_graph_facade::accumulate, py::const_))
+        .def("accumulate", py::overload_cast<const double&>(&flow_graph_facade::accumulate, py::const_));
 }
  

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -47,21 +47,23 @@ namespace fastscapelib
 
             virtual const elevation_type& update_routes(const elevation_type& elevation) = 0;
             
-            virtual const xt::pyarray<std::size_t>& receivers() = 0;
+            virtual const xt::pyarray<std::size_t>& receivers() const = 0;
 
-            virtual const xt::pyarray<std::uint8_t>& receivers_count() = 0;
+            virtual const xt::pyarray<std::uint8_t>& receivers_count() const = 0;
 
-            virtual const xt::pyarray<double>& receivers_distance() = 0;
+            virtual const xt::pyarray<double>& receivers_distance() const = 0;
 
-            virtual const xt::pyarray<double>& receivers_weight() = 0;
+            virtual const xt::pyarray<double>& receivers_weight() const = 0;
                         
-            virtual const xt::pyarray<std::size_t>& donors() = 0;
+            virtual const xt::pyarray<std::size_t>& donors() const = 0;
 
-            virtual const xt::pyarray<std::uint8_t>& donors_count() = 0;
+            virtual const xt::pyarray<std::uint8_t>& donors_count() const = 0;
 
-            virtual const xt::pyarray<std::size_t>& dfs_stack() = 0;
+            virtual const xt::pyarray<std::size_t>& dfs_stack() const = 0;
 
-            virtual xt::pyarray<double> accumulate(const xt::pyarray<double>& data) = 0;
+            virtual xt::pyarray<double> accumulate(const xt::pyarray<double>& data) const = 0;
+
+            virtual xt::pyarray<double> accumulate(const double& data) const = 0;
         };
 
         template <class G>
@@ -94,21 +96,23 @@ namespace fastscapelib
 
             const elevation_type& update_routes(const elevation_type& elevation) { return m_wrapped->update_routes(elevation); };
 
-            const xt::pyarray<std::size_t>& receivers() { return m_wrapped->receivers(); };
+            const xt::pyarray<std::size_t>& receivers() const { return m_wrapped->receivers(); };
 
-            const xt::pyarray<std::uint8_t>& receivers_count() { return m_wrapped->receivers_count(); };
+            const xt::pyarray<std::uint8_t>& receivers_count() const { return m_wrapped->receivers_count(); };
 
-            const xt::pyarray<double>& receivers_distance() { return m_wrapped->receivers_distance(); };
+            const xt::pyarray<double>& receivers_distance() const { return m_wrapped->receivers_distance(); };
 
-            const xt::pyarray<double>& receivers_weight() { return m_wrapped->receivers_weight(); };
+            const xt::pyarray<double>& receivers_weight() const { return m_wrapped->receivers_weight(); };
 
-            const xt::pyarray<std::size_t>& donors() { return m_wrapped->donors(); };
+            const xt::pyarray<std::size_t>& donors() const { return m_wrapped->donors(); };
 
-            const xt::pyarray<std::uint8_t>& donors_count() { return m_wrapped->donors_count(); };
+            const xt::pyarray<std::uint8_t>& donors_count() const { return m_wrapped->donors_count(); };
 
-            const xt::pyarray<std::size_t>& dfs_stack() { return m_wrapped->dfs_stack(); };
+            const xt::pyarray<std::size_t>& dfs_stack() const { return m_wrapped->dfs_stack(); };
 
-            xt::pyarray<double> accumulate(const xt::pyarray<double>& data) { return m_wrapped->accumulate(data); };
+            xt::pyarray<double> accumulate(const xt::pyarray<double>& data) const { return m_wrapped->accumulate(data); };
+
+            xt::pyarray<double> accumulate(const double& data) const { return m_wrapped->accumulate(data); };
 
         private:
 
@@ -122,14 +126,15 @@ namespace fastscapelib
 
             using self_type = flow_graph_facade;
             using elevation_type = xt::pyarray<double>;
+            using index_type = std::size_t;
 
             template <class G>
             flow_graph_facade(G& obj, std::shared_ptr<flow_router_method> router, std::shared_ptr<sink_resolver_method> resolver)
                 : p_impl(std::make_unique<flow_graph_wrapper<G>>(obj, router, resolver))
-                {}
+            {}
 
             template <class G>
-            fs::flow_graph<G, elevation_type> get_implementation()
+            fs::flow_graph<G, double, fs::pyarray_selector>& get_implementation()
             {
                 auto& derived = dynamic_cast<flow_graph_wrapper<G>&>(*p_impl);
                 return derived.get_wrapped();
@@ -139,21 +144,23 @@ namespace fastscapelib
 
             const elevation_type& update_routes(const elevation_type& elevation) { return p_impl->update_routes(elevation); };
 
-            const xt::pyarray<std::size_t>& receivers() { return p_impl->receivers(); };
+            const xt::pyarray<std::size_t>& receivers() const { return p_impl->receivers(); };
 
-            const xt::pyarray<std::uint8_t>& receivers_count() { return p_impl->receivers_count(); };
+            const xt::pyarray<std::uint8_t>& receivers_count() const { return p_impl->receivers_count(); };
 
-            const xt::pyarray<double>& receivers_distance() { return p_impl->receivers_distance(); };
+            const xt::pyarray<double>& receivers_distance() const { return p_impl->receivers_distance(); };
 
-            const xt::pyarray<double>& receivers_weight() { return p_impl->receivers_weight(); };
+            const xt::pyarray<double>& receivers_weight() const { return p_impl->receivers_weight(); };
 
-            const xt::pyarray<std::size_t>& donors() { return p_impl->donors(); };
+            const xt::pyarray<std::size_t>& donors() const { return p_impl->donors(); };
 
-            const xt::pyarray<std::uint8_t>& donors_count() { return p_impl->donors_count(); };
+            const xt::pyarray<std::uint8_t>& donors_count() const { return p_impl->donors_count(); };
 
-            const xt::pyarray<std::size_t>& dfs_stack() { return p_impl->dfs_stack(); };
+            const xt::pyarray<std::size_t>& dfs_stack() const { return p_impl->dfs_stack(); };
 
-            xt::pyarray<double> accumulate(const xt::pyarray<double>& data) { return p_impl->accumulate(data); };
+            xt::pyarray<double> accumulate(const xt::pyarray<double>& data) const { return p_impl->accumulate(data); };
+
+            xt::pyarray<double> accumulate(const double& data) const { return p_impl->accumulate(data); };
 
         private:
 

--- a/python/src/grid.cpp
+++ b/python/src/grid.cpp
@@ -67,7 +67,7 @@ void add_grid_bindings(py::module& m) {
     pgrid.def_static("from_length", &profile_grid::from_length);
 
     pgrid.def_property_readonly("size", [](const profile_grid& g) { return g.size(); })
-         .def_property_readonly("shape", [](const profile_grid& g) { return g.size(); })
+         .def_property_readonly("shape", [](const profile_grid& g) { return g.shape(); })
          .def_property_readonly("spacing", [](const profile_grid& g) { return g.spacing(); })
          .def_property_readonly("length", [](const profile_grid& g) { return g.length(); })
          .def_property_readonly("status_at_nodes", [](const profile_grid& g) { return g.status_at_nodes(); })
@@ -116,7 +116,7 @@ void add_grid_bindings(py::module& m) {
                     );
     
     rgrid.def_property_readonly("size", [](const raster_grid& g) { return g.size(); })
-         .def_property_readonly("shape", &raster_grid::shape)
+         .def_property_readonly("shape", [](const raster_grid& g) { return g.shape(); })
          .def_property_readonly("spacing", [](const raster_grid& g) -> xt::pytensor<double, 1> { return g.spacing(); })
          .def_property_readonly("length", [](const raster_grid& g) -> xt::pytensor<double, 1> { return g.length(); })
          .def_property_readonly("status_at_nodes", [](const raster_grid& g) { return g.status_at_nodes(); });

--- a/python/src/modelings.cpp
+++ b/python/src/modelings.cpp
@@ -2,9 +2,12 @@
  * @file
  * @brief Fastscapelib modelings Python bindings.
  */
+#include "flow_graph.hpp"
+
 #include "fastscapelib/bedrock_channel.hpp"
 #include "fastscapelib/hillslope.hpp"
 #include "fastscapelib/flow_routing.hpp"
+#include "fastscapelib/raster_grid.hpp"
 
 #include "xtensor-python/pytensor.hpp"
 #include "xtensor-python/pyarray.hpp"
@@ -12,9 +15,9 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
+
 namespace py = pybind11;
 namespace fs = fastscapelib;
-
 
 template<class T>
 void compute_receivers_d8_py(xt::pytensor<index_t, 1>& receivers,
@@ -93,27 +96,22 @@ void compute_drainage_area_grid_py(xt::pytensor<T, 2>& drainage_area,
 }
 
 
-template<class K, class T>
-index_t erode_stream_power_py(xt::pyarray<T>& erosion,
-                              const xt::pyarray<T>& elevation,
-                              const xt::pytensor<index_t, 1>& stack,
-                              const xt::pytensor<index_t, 1>& receivers,
-                              const xt::pytensor<T, 1>& dist2receivers,
-                              const xt::pyarray<T>& drainage_area,
-                              const K k_coef,
-                              double m_exp,
-                              double n_exp,
-                              double dt,
-                              double tolerance)
+template <class K, class T>
+auto erode_stream_power_py(xt::pyarray<T>& erosion,
+                           const xt::pyarray<T>& elevation,
+                           const xt::pyarray<T>& drainage_area,
+                           fs::detail::flow_graph_facade& flow_graph,
+                           const K k_coef,
+                           double m_exp,
+                           double n_exp,
+                           double dt,
+                           double tolerance)
+      -> std::size_t
 {
     py::gil_scoped_release release;
-    return fs::erode_stream_power(erosion, elevation,
-                                  stack, receivers,
-                                  dist2receivers, drainage_area,
-                                  k_coef, m_exp, n_exp,
-                                  dt, tolerance);
+    return fs::erode_stream_power(erosion, elevation, drainage_area, flow_graph,
+                                  k_coef, m_exp, n_exp, dt, tolerance);
 }
-
 
 template<class K, class T>
 void erode_linear_diffusion_py(xt::pytensor<T, 2>& erosion,
@@ -127,7 +125,37 @@ void erode_linear_diffusion_py(xt::pytensor<T, 2>& erosion,
     fs::erode_linear_diffusion(erosion, elevation, k_coef, dt, dx, dy);
 }
 
-void add_modelings_bindings(py::module& m)
+
+void add_erosion_bindings(py::module& m)
+{
+    {
+        m.def("erode_stream_power_d", &erode_stream_power_py<double, double>,
+              "Compute bedrock channel erosion during a single time step "
+              "using the Stream Power Law.");
+
+        m.def("erode_stream_power_var_d", &erode_stream_power_py<xt::pyarray<double>, double>,
+              "Compute bedrock channel erosion during a single time step "
+              "using the Stream Power Law.\n\n"
+              "Version with spatially variable stream power coefficient.");
+    }
+
+    {
+        m.def("erode_linear_diffusion_d", &erode_linear_diffusion_py<double, double>,
+            "Compute hillslope erosion by linear diffusion on a 2-d regular "
+            "grid using finite differences with an Alternating Direction"
+            "Implicit (ADI) scheme.");
+
+        m.def("erode_linear_diffusion_var_d",
+            &erode_linear_diffusion_py<xt::pytensor<double, 2>&, double>,
+            "Compute hillslope erosion by linear diffusion on a 2-d regular "
+            "grid using finite differences with an Alternating Direction"
+            "Implicit (ADI) scheme.\n\n"
+            "Version with spatially variable diffusion coefficient.");
+    }
+}
+
+
+void add_flow_routing_bindings(py::module& m)
 {
     m.def("compute_receivers_d8_d", &compute_receivers_d8_py<double>,
           "Compute D8 flow receivers, a single receiver for each grid node.");
@@ -152,26 +180,11 @@ void add_modelings_bindings(py::module& m)
     m.def("compute_drainage_area_grid_d",
           &compute_drainage_area_grid_py<double>,
           "Compute drainage area on a 2D grid.");
-
-    m.def("erode_stream_power_d", &erode_stream_power_py<double, double>,
-          "Compute bedrock channel erosion during a single time step "
-          "using the Stream Power Law.");
-
-    m.def("erode_stream_power_var_d", &erode_stream_power_py<xt::pyarray<double>&, double>,
-          "Compute bedrock channel erosion during a single time step "
-          "using the Stream Power Law.\n\n"
-          "Version with spatially variable stream power coefficient.");
-
-    m.def("erode_linear_diffusion_d", &erode_linear_diffusion_py<double, double>,
-          "Compute hillslope erosion by linear diffusion on a 2-d regular "
-          "grid using finite differences with an Alternating Direction"
-          "Implicit (ADI) scheme.");
-
-    m.def("erode_linear_diffusion_var_d",
-          &erode_linear_diffusion_py<xt::pytensor<double, 2>&, double>,
-          "Compute hillslope erosion by linear diffusion on a 2-d regular "
-          "grid using finite differences with an Alternating Direction"
-          "Implicit (ADI) scheme.\n\n"
-          "Version with spatially variable diffusion coefficient.");
 }
- 
+
+
+void add_modelings_bindings(py::module& m)
+{
+    add_flow_routing_bindings(m);
+    add_erosion_bindings(m);
+}

--- a/test/test_flow_graph.cpp
+++ b/test/test_flow_graph.cpp
@@ -150,6 +150,8 @@ namespace fastscapelib
                  {1.452,  1.32, 2.772,  1.32}};
 
             EXPECT_TRUE(xt::allclose(expected1, graph.accumulate(data1)));
+            EXPECT_TRUE(xt::allclose(expected1, graph.accumulate(1.)));
+            EXPECT_TRUE(xt::allclose(expected1 * 5., graph.accumulate(5.)));
             EXPECT_TRUE(xt::allclose(expected2, graph.accumulate(data2)));
         }
     }


### PR DESCRIPTION
Description
--

Refactor the `erode_stream_power` algo to use `grid` and `flow_graph` API.

Details:
- add an overload to `flow_graph::accumulate` to pass a scalar to broadcast
- update python bindings
- update benchmarks
- update c++ and python tests