### PR TITLE
Improve erode stream power performance

### DIFF
--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -27,7 +27,7 @@ void add_flow_graph_bindings(py::module& m) {
         .def("donors", &flow_graph_facade::donors)
         .def("donors_count", &flow_graph_facade::donors_count)
         .def("dfs_stack", &flow_graph_facade::dfs_stack)
-        .def("accumulate", py::overload_cast<const xt::pyarray<double>&>(&flow_graph_facade::accumulate, py::const_))
+        .def("accumulate", py::overload_cast<const xt::pyarray<double, xt::layout_type::row_major>&>(&flow_graph_facade::accumulate, py::const_))
         .def("accumulate", py::overload_cast<const double&>(&flow_graph_facade::accumulate, py::const_));
 }
  

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -39,31 +39,45 @@ namespace fastscapelib
         {
         public:
 
-            using elevation_type = xt::pyarray<double>;
+            using index_type = std::size_t;
+            using neighbors_count_type = std::uint8_t;
+            using distance_type = double;
+
+            using data_type = xt_container_t<pyarray_selector, double>;
+            using donors_type = xt_container_t<pyarray_selector, index_type>;
+            using donors_count_type = xt_container_t<pyarray_selector, neighbors_count_type>;
+
+            using receivers_type = donors_type;
+            using receivers_count_type = donors_count_type;
+            using receivers_weight_type = xt_container_t<pyarray_selector, double>;
+            using receivers_distance_type = xt_container_t<pyarray_selector, distance_type>;
+
+            using stack_type = xt_container_t<pyarray_selector, index_type>;
+
 
             virtual ~flow_graph_wrapper_base() {};
 
             virtual int get_index_type() const = 0;
 
-            virtual const elevation_type& update_routes(const elevation_type& elevation) = 0;
+            virtual const data_type& update_routes(const data_type& elevation) = 0;
             
-            virtual const xt::pyarray<std::size_t>& receivers() const = 0;
+            virtual const receivers_type& receivers() const = 0;
 
-            virtual const xt::pyarray<std::uint8_t>& receivers_count() const = 0;
+            virtual const receivers_count_type& receivers_count() const = 0;
 
-            virtual const xt::pyarray<double>& receivers_distance() const = 0;
+            virtual const receivers_distance_type& receivers_distance() const = 0;
 
-            virtual const xt::pyarray<double>& receivers_weight() const = 0;
+            virtual const receivers_weight_type& receivers_weight() const = 0;
                         
-            virtual const xt::pyarray<std::size_t>& donors() const = 0;
+            virtual const donors_type& donors() const = 0;
 
-            virtual const xt::pyarray<std::uint8_t>& donors_count() const = 0;
+            virtual const donors_count_type& donors_count() const = 0;
 
-            virtual const xt::pyarray<std::size_t>& dfs_stack() const = 0;
+            virtual const stack_type& dfs_stack() const = 0;
 
-            virtual xt::pyarray<double> accumulate(const xt::pyarray<double>& data) const = 0;
+            virtual data_type accumulate(const data_type& data) const = 0;
 
-            virtual xt::pyarray<double> accumulate(const double& data) const = 0;
+            virtual data_type accumulate(const double& data) const = 0;
         };
 
         template <class G>
@@ -72,8 +86,19 @@ namespace fastscapelib
         public:
 
             using wrapped_type = fs::flow_graph<G, double, fs::pyarray_selector>;
-            using elevation_type = typename flow_graph_wrapper_base::elevation_type;
 
+            using index_type = typename flow_graph_wrapper_base::index_type;
+            using neighbors_count_type = typename flow_graph_wrapper_base::neighbors_count_type;
+            using distance_type = typename flow_graph_wrapper_base::distance_type;
+            using data_type = typename flow_graph_wrapper_base::data_type;
+            using donors_type = typename flow_graph_wrapper_base::donors_type;
+            using donors_count_type = typename flow_graph_wrapper_base::donors_count_type;
+            using receivers_type = typename flow_graph_wrapper_base::receivers_type;
+            using receivers_count_type = typename flow_graph_wrapper_base::receivers_count_type;
+            using receivers_weight_type = typename flow_graph_wrapper_base::receivers_weight_type;
+            using receivers_distance_type = typename flow_graph_wrapper_base::receivers_distance_type;
+            using stack_type = typename flow_graph_wrapper_base::stack_type;
+            
             flow_graph_wrapper(G& grid, std::shared_ptr<flow_router_method> router, std::shared_ptr<sink_resolver_method> resolver)
             {
                 auto router_ptr = fs::detail::flow_router_factory<wrapped_type>::build(router->method, 
@@ -94,25 +119,25 @@ namespace fastscapelib
             
             int get_index_type() const { return 0; };
 
-            const elevation_type& update_routes(const elevation_type& elevation) { return m_wrapped->update_routes(elevation); };
+            const data_type& update_routes(const data_type& elevation) { return m_wrapped->update_routes(elevation); };
 
-            const xt::pyarray<std::size_t>& receivers() const { return m_wrapped->receivers(); };
+            const receivers_type& receivers() const { return m_wrapped->receivers(); };
 
-            const xt::pyarray<std::uint8_t>& receivers_count() const { return m_wrapped->receivers_count(); };
+            const receivers_count_type& receivers_count() const { return m_wrapped->receivers_count(); };
 
-            const xt::pyarray<double>& receivers_distance() const { return m_wrapped->receivers_distance(); };
+            const receivers_distance_type& receivers_distance() const { return m_wrapped->receivers_distance(); };
 
-            const xt::pyarray<double>& receivers_weight() const { return m_wrapped->receivers_weight(); };
+            const receivers_weight_type& receivers_weight() const { return m_wrapped->receivers_weight(); };
 
-            const xt::pyarray<std::size_t>& donors() const { return m_wrapped->donors(); };
+            const donors_type& donors() const { return m_wrapped->donors(); };
 
-            const xt::pyarray<std::uint8_t>& donors_count() const { return m_wrapped->donors_count(); };
+            const donors_count_type& donors_count() const { return m_wrapped->donors_count(); };
 
-            const xt::pyarray<std::size_t>& dfs_stack() const { return m_wrapped->dfs_stack(); };
+            const stack_type& dfs_stack() const { return m_wrapped->dfs_stack(); };
 
-            xt::pyarray<double> accumulate(const xt::pyarray<double>& data) const { return m_wrapped->accumulate(data); };
+            data_type accumulate(const data_type& data) const { return m_wrapped->accumulate(data); };
 
-            xt::pyarray<double> accumulate(const double& data) const { return m_wrapped->accumulate(data); };
+            data_type accumulate(const double& data) const { return m_wrapped->accumulate(data); };
 
         private:
 
@@ -125,8 +150,21 @@ namespace fastscapelib
         public:
 
             using self_type = flow_graph_facade;
-            using elevation_type = xt::pyarray<double>;
+
             using index_type = std::size_t;
+            using neighbors_count_type = std::uint8_t;
+            using distance_type = double;
+
+            using data_type = xt_container_t<pyarray_selector, double>;
+            using donors_type = xt_container_t<pyarray_selector, index_type>;
+            using donors_count_type = xt_container_t<pyarray_selector, neighbors_count_type>;
+
+            using receivers_type = donors_type;
+            using receivers_count_type = donors_count_type;
+            using receivers_weight_type = xt_container_t<pyarray_selector, double>;
+            using receivers_distance_type = xt_container_t<pyarray_selector, distance_type>;
+
+            using stack_type = xt_container_t<pyarray_selector, index_type>;
 
             template <class G>
             flow_graph_facade(G& obj, std::shared_ptr<flow_router_method> router, std::shared_ptr<sink_resolver_method> resolver)
@@ -142,25 +180,25 @@ namespace fastscapelib
 
             int get_implementation_index_type() const { return p_impl->get_index_type(); }
 
-            const elevation_type& update_routes(const elevation_type& elevation) { return p_impl->update_routes(elevation); };
+            const data_type& update_routes(const data_type& elevation) { return p_impl->update_routes(elevation); };
 
-            const xt::pyarray<std::size_t>& receivers() const { return p_impl->receivers(); };
+            const receivers_type& receivers() const { return p_impl->receivers(); };
 
-            const xt::pyarray<std::uint8_t>& receivers_count() const { return p_impl->receivers_count(); };
+            const receivers_count_type& receivers_count() const { return p_impl->receivers_count(); };
 
-            const xt::pyarray<double>& receivers_distance() const { return p_impl->receivers_distance(); };
+            const data_type& receivers_distance() const { return p_impl->receivers_distance(); };
 
-            const xt::pyarray<double>& receivers_weight() const { return p_impl->receivers_weight(); };
+            const receivers_weight_type& receivers_weight() const { return p_impl->receivers_weight(); };
 
-            const xt::pyarray<std::size_t>& donors() const { return p_impl->donors(); };
+            const donors_type& donors() const { return p_impl->donors(); };
 
-            const xt::pyarray<std::uint8_t>& donors_count() const { return p_impl->donors_count(); };
+            const donors_count_type& donors_count() const { return p_impl->donors_count(); };
 
-            const xt::pyarray<std::size_t>& dfs_stack() const { return p_impl->dfs_stack(); };
+            const stack_type& dfs_stack() const { return p_impl->dfs_stack(); };
 
-            xt::pyarray<double> accumulate(const xt::pyarray<double>& data) const { return p_impl->accumulate(data); };
+            data_type accumulate(const data_type& data) const { return p_impl->accumulate(data); };
 
-            xt::pyarray<double> accumulate(const double& data) const { return p_impl->accumulate(data); };
+            data_type accumulate(const double& data) const { return p_impl->accumulate(data); };
 
         private:
 

--- a/python/src/modelings.cpp
+++ b/python/src/modelings.cpp
@@ -97,9 +97,9 @@ void compute_drainage_area_grid_py(xt::pytensor<T, 2>& drainage_area,
 
 
 template <class K, class T>
-auto erode_stream_power_py(xt::pyarray<T>& erosion,
-                           const xt::pyarray<T>& elevation,
-                           const xt::pyarray<T>& drainage_area,
+auto erode_stream_power_py(xt::pyarray<T, xt::layout_type::row_major>& erosion,
+                           const xt::pyarray<T, xt::layout_type::row_major>& elevation,
+                           const xt::pyarray<T, xt::layout_type::row_major>& drainage_area,
                            fs::detail::flow_graph_facade& flow_graph,
                            const K k_coef,
                            double m_exp,
@@ -133,7 +133,7 @@ void add_erosion_bindings(py::module& m)
               "Compute bedrock channel erosion during a single time step "
               "using the Stream Power Law.");
 
-        m.def("erode_stream_power_var_d", &erode_stream_power_py<xt::pyarray<double>, double>,
+        m.def("erode_stream_power_var_d", &erode_stream_power_py<xt::pyarray<double, xt::layout_type::row_major>, double>,
               "Compute bedrock channel erosion during a single time step "
               "using the Stream Power Law.\n\n"
               "Version with spatially variable stream power coefficient.");

--- a/python/src/pytensor_utils.hpp
+++ b/python/src/pytensor_utils.hpp
@@ -11,7 +11,7 @@ namespace fastscapelib
     template <class T, std::size_t N>
     struct xt_container<pyarray_selector, T, N>
     {
-        using type = xt::pyarray<T>;
+        using type = xt::pyarray<T, xt::layout_type::row_major>;
     };
 }
 


### PR DESCRIPTION
Description
--

Use `xt::layout_type::row_major` for `xt::pyarray` in Python bindings to improve `erode_stream_power` algo performance.
This is related to the use of `xt::flatten` to provide a flat view of pyarrays.