### PR TITLE
Refactor router and resolver implementation methods

### DIFF
--- a/include/fastscapelib/flow_graph.hpp
+++ b/include/fastscapelib/flow_graph.hpp
@@ -84,8 +84,9 @@ namespace fastscapelib
         const elevation_type& update_routes(const elevation_type& elevation)
         {
             const auto& modified_elevation = p_sink_resolver->resolve1(elevation, *this);
-            p_flow_router->route(modified_elevation, *this);
+            p_flow_router->route1(modified_elevation, *this);
             const auto& final_elevation = p_sink_resolver->resolve2(modified_elevation, *this);
+            p_flow_router->route2(final_elevation, *this);
 
             return final_elevation;
         }

--- a/include/fastscapelib/flow_graph.hpp
+++ b/include/fastscapelib/flow_graph.hpp
@@ -83,11 +83,9 @@ namespace fastscapelib
 
         const elevation_type& update_routes(const elevation_type& elevation)
         {
-            const auto& modified_elevation
-                = p_sink_resolver->resolve_before_route(elevation, *this);
+            const auto& modified_elevation = p_sink_resolver->resolve1(elevation, *this);
             p_flow_router->route(modified_elevation, *this);
-            const auto& final_elevation
-                = p_sink_resolver->resolve_after_route(modified_elevation, *this);
+            const auto& final_elevation = p_sink_resolver->resolve2(modified_elevation, *this);
 
             return final_elevation;
         }

--- a/include/fastscapelib/flow_router.hpp
+++ b/include/fastscapelib/flow_router.hpp
@@ -23,7 +23,7 @@ namespace fastscapelib
      * Base class for the implementation of flow routing
      * methods.
      *
-     * All derived classes must implement ``route_impl``.
+     * All derived classes must implement ``route1_impl`` and ``route2_impl``.
      *
      * @tparam FG The flow_graph class.
      */
@@ -41,13 +41,18 @@ namespace fastscapelib
         flow_router& operator=(const flow_router&) = delete;
         flow_router& operator=(flow_router&&) = delete;
 
-        void route(const elevation_type& elevation, FG& fgraph)
+        void route1(const elevation_type& elevation, FG& fgraph)
         {
-            route_impl(elevation, fgraph);
+            route1_impl(elevation, fgraph);
+        }
+        void route2(const elevation_type& elevation, FG& fgraph)
+        {
+            route2_impl(elevation, fgraph);
         }
 
     private:
-        virtual void route_impl(const elevation_type& elevation, FG& fgraph) = 0;
+        virtual void route1_impl(const elevation_type& elevation, FG& fgraph) = 0;
+        virtual void route2_impl(const elevation_type& elevation, FG& fgraph) = 0;
 
     protected:
         using index_type = typename FG::index_type;
@@ -114,7 +119,8 @@ namespace fastscapelib
         virtual ~dummy_flow_router() = default;
 
     private:
-        void route_impl(const elevation_type& /*elevation*/, FG& /*fgraph*/){};
+        void route1_impl(const elevation_type& /*elevation*/, FG& /*fgraph*/){};
+        void route2_impl(const elevation_type& /*elevation*/, FG& /*fgraph*/){};
     };
 
 
@@ -179,7 +185,7 @@ namespace fastscapelib
             }
         };
 
-        void route_impl(const elevation_type& elevation, FG& fgraph)
+        void route1_impl(const elevation_type& elevation, FG& fgraph)
         {
             using neighbors_type = typename FG::grid_type::neighbors_type;
 
@@ -221,6 +227,8 @@ namespace fastscapelib
 
             compute_dfs_stack(fgraph);
         };
+
+        void route2_impl(const elevation_type& /*elevation*/, FG& /*fgraph*/){};
     };
 
 
@@ -248,7 +256,8 @@ namespace fastscapelib
     private:
         double p1 = 0., p2 = 0.;
 
-        void route_impl(const elevation_type& /*elevation*/, FG& /*fgraph*/){};
+        void route1_impl(const elevation_type& /*elevation*/, FG& /*fgraph*/){};
+        void route2_impl(const elevation_type& /*elevation*/, FG& /*fgraph*/){};
     };
 
 

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -2,8 +2,8 @@
  * Common grid element types (node status, neighbors).
  * grid base (abstract) class.
  */
-#ifndef GRID_H_
-#define GRID_H_
+#ifndef FASTSCAPELIB_GRID_H
+#define FASTSCAPELIB_GRID_H
 
 #include <cstddef>
 #include <cstdint>
@@ -587,4 +587,4 @@ namespace fastscapelib
 
 }
 
-#endif  // GRID_H_
+#endif  // FASTSCAPELIB_GRID_H

--- a/include/fastscapelib/sink_resolver.hpp
+++ b/include/fastscapelib/sink_resolver.hpp
@@ -17,8 +17,8 @@ namespace fastscapelib
      * Base class for the implementation of depression
      * filling or pit resolving.
      *
-     * All derived classes must implement ``resolve_before_route``
-     * and ``resolve_after_route`` methods.
+     * All derived classes must implement ``resolve1``
+     * and ``resolve2`` methods.
      *
      * @tparam FG The flow_graph class.
      */
@@ -36,12 +36,8 @@ namespace fastscapelib
         sink_resolver& operator=(const sink_resolver&) = delete;
         sink_resolver& operator=(sink_resolver&&) = delete;
 
-        virtual const elevation_type& resolve_before_route(const elevation_type& elevation,
-                                                           FG& fgraph)
-            = 0;
-        virtual const elevation_type& resolve_after_route(const elevation_type& elevation,
-                                                          FG& fgraph)
-            = 0;
+        virtual const elevation_type& resolve1(const elevation_type& elevation, FG& fgraph) = 0;
+        virtual const elevation_type& resolve2(const elevation_type& elevation, FG& fgraph) = 0;
 
     protected:
         sink_resolver() = default;
@@ -65,14 +61,12 @@ namespace fastscapelib
 
         virtual ~no_sink_resolver() = default;
 
-        const elevation_type& resolve_before_route(const elevation_type& elevation,
-                                                   FG& /*fgraph*/) override
+        const elevation_type& resolve1(const elevation_type& elevation, FG& /*fgraph*/) override
         {
             return elevation;
         }
 
-        const elevation_type& resolve_after_route(const elevation_type& elevation,
-                                                  FG& /*fgraph*/) override
+        const elevation_type& resolve2(const elevation_type& elevation, FG& /*fgraph*/) override
         {
             return elevation;
         }

--- a/include/fastscapelib/unstructured_mesh.hpp
+++ b/include/fastscapelib/unstructured_mesh.hpp
@@ -1,5 +1,5 @@
-#ifndef UNSTRUCTURED_MESH_H_
-#define UNSTRUCTURED_MESH_H_
+#ifndef FASTSCAPELIB_UNSTRUCTURED_MESH_H
+#define FASTSCAPELIB_UNSTRUCTURED_MESH_H
 
 #include "fastscapelib/grid.hpp"
 #include "fastscapelib/xtensor_utils.hpp"
@@ -101,4 +101,4 @@ namespace fastscapelib
     using unstructured_mesh = unstructured_mesh_xt<xtensor_selector>;
 }
 
-#endif  // UNSTRUCTURED_MESH_H_
+#endif  // FASTSCAPELIB_UNSTRUCTURED_MESH_H

--- a/test/test_flow_graph.cpp
+++ b/test/test_flow_graph.cpp
@@ -31,15 +31,13 @@ namespace fastscapelib
 
             virtual ~constant_before_sink_resolver() = default;
 
-            const elevation_type& resolve_before_route(const elevation_type& elevation,
-                                                       FG& /*fgraph*/) override
+            const elevation_type& resolve1(const elevation_type& elevation, FG& /*fgraph*/) override
             {
                 m_elevation = xt::ones_like(elevation) * 2.;
                 return m_elevation;
             }
 
-            const elevation_type& resolve_after_route(const elevation_type& elevation,
-                                                      FG& /*fgraph*/) override
+            const elevation_type& resolve2(const elevation_type& elevation, FG& /*fgraph*/) override
             {
                 return elevation;
             }
@@ -62,14 +60,12 @@ namespace fastscapelib
 
             virtual ~constant_after_sink_resolver() = default;
 
-            const elevation_type& resolve_before_route(const elevation_type& elevation,
-                                                       FG& /*fgraph*/) override
+            const elevation_type& resolve1(const elevation_type& elevation, FG& /*fgraph*/) override
             {
                 return elevation;
             }
 
-            const elevation_type& resolve_after_route(const elevation_type& elevation,
-                                                      FG& /*fgraph*/) override
+            const elevation_type& resolve2(const elevation_type& elevation, FG& /*fgraph*/) override
             {
                 m_elevation = xt::ones_like(elevation) * 5.;
                 return m_elevation;

--- a/test/test_sink_resolver.cpp
+++ b/test/test_sink_resolver.cpp
@@ -31,15 +31,13 @@ namespace fastscapelib
 
             virtual ~constant_before_sink_resolver() = default;
 
-            const elevation_type& resolve_before_route(const elevation_type& elevation,
-                                                       FG& /*fgraph*/) override
+            const elevation_type& resolve1(const elevation_type& elevation, FG& /*fgraph*/) override
             {
                 m_elevation = xt::ones_like(elevation) * 2.;
                 return m_elevation;
             }
 
-            const elevation_type& resolve_after_route(const elevation_type& elevation,
-                                                      FG& /*fgraph*/) override
+            const elevation_type& resolve2(const elevation_type& elevation, FG& /*fgraph*/) override
             {
                 return elevation;
             }
@@ -62,14 +60,12 @@ namespace fastscapelib
 
             virtual ~constant_after_sink_resolver() = default;
 
-            const elevation_type& resolve_before_route(const elevation_type& elevation,
-                                                       FG& /*fgraph*/) override
+            const elevation_type& resolve1(const elevation_type& elevation, FG& /*fgraph*/) override
             {
                 return elevation;
             }
 
-            const elevation_type& resolve_after_route(const elevation_type& elevation,
-                                                      FG& /*fgraph*/) override
+            const elevation_type& resolve2(const elevation_type& elevation, FG& /*fgraph*/) override
             {
                 m_elevation = xt::ones_like(elevation) * 5.;
                 return m_elevation;
@@ -114,7 +110,7 @@ namespace fastscapelib
         }
 
 
-        TEST_F(sink_resolver, resolve_before_route)
+        TEST_F(sink_resolver, resolve1)
         {
             auto router = std::make_unique<fs::single_flow_router<flow_graph_type>>();
             auto resolver = std::make_unique<constant_before_sink_resolver<flow_graph_type>>();
@@ -132,7 +128,7 @@ namespace fastscapelib
         }
 
 
-        TEST_F(sink_resolver, resolve_after_route)
+        TEST_F(sink_resolver, resolve2)
         {
             auto router = std::make_unique<fs::single_flow_router<flow_graph_type>>();
             auto resolver = std::make_unique<constant_after_sink_resolver<flow_graph_type>>();


### PR DESCRIPTION
The new workflow for updating flow routes is:

```cpp
auto new_elevation = sink_resolver->resolve1(elevation, flow_graph);

flow_router->route1(new_elevation, flow_graph);

auto final_elevation = sink_resolver->resolve2(new_elevation, flow_graph);

flow_router->route2(final_elevation, flow_graph);
```

The 2nd route method allows supporting the approach used in [fastscapelib-fortran](https://github.com/fastscape-lem/fastscapelib-fortran) for multiple direction flow routing:

- `resolve1`: do nothing 
- `route1`: compute single flow routing
- `resolve2`:
    - update flow paths to resolve flow trapped in closed depressions (Cordonnier et al. algorithm) 
    - update elevation (fill closed depressions with a tiny slope) over one traversal of the flow-graph formed by the updated (single) flow paths
- `route2`: compute multiple flow routing from single flow paths

This workflow also allows other approaches like:

- `resolve1`: update elevation (fill closed depressions with a tiny slope) using a "priority-flood" algorithm variant
- `route1`: compute multiple flow routing directly from the updated elevation
- `resolve2`: do nothing
- `route2`: do nothing
