### PR TITLE
Clean-up raster_grid class

### DIFF
--- a/benchmark/benchmark_profile_grid.cpp
+++ b/benchmark/benchmark_profile_grid.cpp
@@ -33,6 +33,33 @@ namespace fastscapelib
         }
 
         template <class G>
+        void profile_grid__neighbors_indices(benchmark::State& state)
+        {
+            using grid_type = G;
+            using size_type = typename grid_type::size_type;
+            using neighbors_indices_type = typename grid_type::neighbors_indices_type;
+
+            auto size = static_cast<size_type>(state.range(0));
+            auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
+
+            neighbors_indices_type neighbors_indices;
+
+            // warm-up cache
+            for (size_type idx = 0; idx < grid.size(); ++idx)
+            {
+                grid.neighbors_indices(idx, neighbors_indices);
+            }
+
+            for (auto _ : state)
+            {
+                for (size_type idx = 0; idx < grid.size(); ++idx)
+                {
+                    grid.neighbors_indices(idx, neighbors_indices);
+                }
+            }
+        }
+
+        template <class G>
         void profile_grid__neighbors(benchmark::State& state)
         {
             using grid_type = G;
@@ -42,13 +69,13 @@ namespace fastscapelib
             auto size = static_cast<size_type>(state.range(0));
             auto grid = grid_type(size, 1.3, fs::node_status::fixed_value_boundary);
 
+            neighbors_type neighbors;
+
             // warm-up cache
             for (size_type idx = 0; idx < grid.size(); ++idx)
             {
-                auto neighbors = grid.neighbors(idx);
+                grid.neighbors(idx, neighbors);
             }
-
-            neighbors_type neighbors;
 
             for (auto _ : state)
             {
@@ -63,13 +90,14 @@ namespace fastscapelib
         using profile_cacheall = fs::profile_grid;
 
 #define BENCH_GRID(NAME, GRID)                                                                     \
-    BENCHMARK_TEMPLATE(NAME, GRID)->Apply(bms::small_grid_sizes<benchmark::kNanosecond>);
+    BENCHMARK_TEMPLATE(NAME, GRID)->Arg(512)->Unit(benchmark::kNanosecond);
 
 #define BENCH_RASTER(NAME)                                                                         \
     BENCH_GRID(NAME, profile_nocache)                                                              \
     BENCH_GRID(NAME, profile_cacheall)
 
         BENCH_RASTER(profile_grid__ctor);
+        BENCH_RASTER(profile_grid__neighbors_indices);
         BENCH_RASTER(profile_grid__neighbors);
 
     }  // namespace bench

--- a/benchmark/benchmark_raster_grid.cpp
+++ b/benchmark/benchmark_raster_grid.cpp
@@ -63,6 +63,40 @@ namespace fastscapelib
         }
 
         template <class G>
+        void raster_grid__neighbors_indices_raster(benchmark::State& state)
+        {
+            using grid_type = G;
+            using size_type = typename grid_type::size_type;
+            using neighbors_indices_raster_type = typename grid_type::neighbors_indices_raster_type;
+
+            auto n = static_cast<size_type>(state.range(0));
+            std::array<size_type, 2> shape{ { n, n } };
+            auto grid = grid_type(shape, { 1., 1. }, fs::node_status::fixed_value_boundary);
+
+            neighbors_indices_raster_type neighbors_indices;
+
+            // warm-up cache
+            for (size_type r = 0; r < shape[0]; ++r)
+            {
+                for (size_type c = 0; c < shape[1]; ++c)
+                {
+                    grid.neighbors_indices(r, c, neighbors_indices);
+                }
+            }
+
+            for (auto _ : state)
+            {
+                for (size_type r = 0; r < shape[0]; ++r)
+                {
+                    for (size_type c = 0; c < shape[1]; ++c)
+                    {
+                        grid.neighbors_indices(r, c, neighbors_indices);
+                    }
+                }
+            }
+        }
+
+        template <class G>
         void raster_grid__neighbors(benchmark::State& state)
         {
             using grid_type = G;
@@ -86,6 +120,40 @@ namespace fastscapelib
                 for (size_type idx = 0; idx < grid.size(); ++idx)
                 {
                     grid.neighbors(idx, neighbors);
+                }
+            }
+        }
+
+        template <class G>
+        void raster_grid__neighbors_raster(benchmark::State& state)
+        {
+            using grid_type = G;
+            using size_type = typename grid_type::size_type;
+            using neighbors_raster_type = typename grid_type::neighbors_raster_type;
+
+            auto n = static_cast<size_type>(state.range(0));
+            std::array<size_type, 2> shape{ { n, n } };
+            auto grid = grid_type(shape, { 1., 1. }, fs::node_status::fixed_value_boundary);
+
+            neighbors_raster_type neighbors;
+
+            // warm-up cache
+            for (size_type r = 0; r < shape[0]; ++r)
+            {
+                for (size_type c = 0; c < shape[1]; ++c)
+                {
+                    grid.neighbors(r, c, neighbors);
+                }
+            }
+
+            for (auto _ : state)
+            {
+                for (size_type r = 0; r < shape[0]; ++r)
+                {
+                    for (size_type c = 0; c < shape[1]; ++c)
+                    {
+                        grid.neighbors(r, c, neighbors);
+                    }
                 }
             }
         }
@@ -170,7 +238,9 @@ namespace fastscapelib
 
         BENCH_ALL(raster_grid__ctor);
         BENCH_ALL(raster_grid__neighbors_indices);
+        BENCH_ALL(raster_grid__neighbors_indices_raster);
         BENCH_ALL(raster_grid__neighbors);
+        BENCH_ALL(raster_grid__neighbors_raster);
         BENCH_RC(raster_grid__neighbor_classic);
 
     }  // namespace bench

--- a/benchmark/benchmark_raster_grid.cpp
+++ b/benchmark/benchmark_raster_grid.cpp
@@ -91,30 +91,6 @@ namespace fastscapelib
         }
 
         template <class G>
-        void raster_grid__neighbor_view(benchmark::State& state)
-        {
-            using grid_type = G;
-            using size_type = typename grid_type::size_type;
-
-            auto n = static_cast<size_type>(state.range(0));
-            std::array<size_type, 2> shape{ { n, n } };
-
-            auto rg = grid_type(shape, { 1., 1. }, fs::node_status::fixed_value_boundary);
-            xt::xtensor<double, 2> field(shape, 1.);
-
-            for (auto _ : state)
-            {
-                for (size_type r = 0; r < shape[0]; ++r)
-                {
-                    for (size_type c = 0; c < shape[1]; ++c)
-                    {
-                        auto nb_field_view = rg.neighbor_view(field, r * shape[1] + c);
-                    }
-                }
-            }
-        }
-
-        template <class G>
         void raster_grid__neighbor_classic(benchmark::State& state)
         {
             using grid_type = G;
@@ -196,7 +172,6 @@ namespace fastscapelib
         BENCH_ALL(raster_grid__neighbors_indices);
         BENCH_ALL(raster_grid__neighbors);
         BENCH_RC(raster_grid__neighbor_classic);
-        BENCH_ALL(raster_grid__neighbor_view);
 
     }  // namespace bench
 }  // namespace fastscapelib

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -389,9 +389,13 @@ namespace fastscapelib
         const derived_grid_type& derived_grid() const noexcept;
         derived_grid_type& derived_grid() noexcept;
 
-        const neighbors_indices_impl_type& neighbors_indices_impl(const size_type& idx);
+        void neighbors_indices_impl(neighbors_indices_impl_type& neighbors,
+                                    const size_type& idx) const;
 
-        const neighbors_distances_impl_type& neighbors_distances_impl(const size_type& idx) const;
+        inline const neighbors_indices_impl_type& neighbors_indices_cache(const size_type& idx);
+
+        inline const neighbors_distances_impl_type& neighbors_distances_impl(
+            const size_type& idx) const;
 
         neighbors_cache_type m_neighbors_indices_cache;
     };
@@ -455,7 +459,7 @@ namespace fastscapelib
     template <class G, class C>
     inline auto grid<G, C>::neighbors_indices(const size_type& idx) -> neighbors_indices_type
     {
-        neighbors_indices_type indices = xt::adapt(neighbors_indices_impl(idx));
+        neighbors_indices_type indices = xt::adapt(neighbors_indices_cache(idx));
         auto view = xt::view(indices, xt::range(0, neighbors_count(idx)));
 
         return view;
@@ -506,7 +510,7 @@ namespace fastscapelib
         -> neighbors_indices_type&
     {
         const auto& n_count = neighbors_count(idx);
-        const auto& n_indices = neighbors_indices_impl(idx);
+        const auto& n_indices = neighbors_indices_cache(idx);
 
         if (neighbors_indices.size() != n_count)
         {
@@ -535,7 +539,7 @@ namespace fastscapelib
     {
         size_type n_idx;
         const auto& n_count = neighbors_count(idx);
-        const auto& n_indices = neighbors_indices_impl(idx);
+        const auto& n_indices = neighbors_indices_cache(idx);
         const auto& n_distances = neighbors_distances_impl(idx);
 
         if (neighbors.size() != n_count)
@@ -565,7 +569,7 @@ namespace fastscapelib
      * @return Reference to the array of the neighbors indices of that grid node.
      */
     template <class G, class C>
-    inline auto grid<G, C>::neighbors_indices_impl(const size_type& idx)
+    inline auto grid<G, C>::neighbors_indices_cache(const size_type& idx)
         -> const neighbors_indices_impl_type&
     {
         if (m_neighbors_indices_cache.has(idx))
@@ -579,6 +583,13 @@ namespace fastscapelib
             this->derived_grid().neighbors_indices_impl(n_indices, idx);
             return n_indices;
         }
+    }
+
+    template <class G, class C>
+    inline auto grid<G, C>::neighbors_indices_impl(neighbors_indices_impl_type& neighbors,
+                                                   const size_type& idx) const -> void
+    {
+        return derived_grid().neighbors_indices_impl(neighbors, idx);
     }
 
     template <class G, class C>

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -309,7 +309,9 @@ namespace fastscapelib
         using xt_selector = typename inner_types::xt_selector;
         using neighbors_type = std::vector<neighbor>;
         using neighbors_count_type = typename inner_types::neighbors_count_type;
-        using neighbors_indices_type = xt_container_t<xt_selector, size_type, 1>;
+        // using xt:xtensor for indices as not all containers support resizing
+        // (e.g., using pyarray may cause segmentation faults with Python)
+        using neighbors_indices_type = xt::xtensor<size_type, 1>;
         using neighbors_distances_type = xt_container_t<xt_selector, distance_type, 1>;
 
         using node_status_type = typename inner_types::node_status_type;

--- a/include/fastscapelib/grid.hpp
+++ b/include/fastscapelib/grid.hpp
@@ -489,10 +489,10 @@ namespace fastscapelib
     template <class G, class C>
     inline auto grid<G, C>::neighbors(const size_type& idx) -> neighbors_type
     {
-        neighbors_type node_neighbors;
-        neighbors(idx, node_neighbors);
+        neighbors_type nb;
+        neighbors(idx, nb);
 
-        return node_neighbors;
+        return nb;
     }
 
     /**
@@ -558,12 +558,7 @@ namespace fastscapelib
     //@}
 
     /**
-     * Iterate over the neighbors indices of a given grid node.
      *
-     * Returns a fixed size std::array for performance considerations,
-     * always use this method with the `neighbors_count` one.
-     *
-     * Follows looped boundary conditions, if any.
      *
      * @param idx Index of the grid node.
      * @return Reference to the array of the neighbors indices of that grid node.

--- a/include/fastscapelib/raster_grid.hpp
+++ b/include/fastscapelib/raster_grid.hpp
@@ -524,9 +524,6 @@ namespace fastscapelib
 
         inline const neighbors_offsets_type& neighbor_offsets(code_type code) const noexcept;
 
-        inline neighbors_indices_impl_type get_neighbors_indices(
-            const size_type& idx) const noexcept;
-
         inline const neighbors_distances_impl_type& neighbors_distances_impl(
             const size_type& idx) const noexcept;
 
@@ -838,31 +835,16 @@ namespace fastscapelib
     }
 
     template <class XT, raster_connect RC, class C>
-    inline auto raster_grid_xt<XT, RC, C>::get_neighbors_indices(
-        const size_type& idx) const noexcept -> neighbors_indices_impl_type
-    {
-        const auto& offsets = neighbor_offsets(node_code(idx));
-        neighbors_indices_impl_type indices;
-
-        auto id_it = indices.begin();
-        for (auto it = offsets.cbegin(); it != offsets.cend(); ++it)
-        {
-            (*id_it++) = static_cast<size_type>((*it)[0]) * m_shape[1]
-                         + static_cast<size_type>((*it)[1]) + idx;
-        }
-
-        return indices;
-    }
-
-    template <class XT, raster_connect RC, class C>
     inline auto raster_grid_xt<XT, RC, C>::neighbors_indices_impl(
         neighbors_indices_impl_type& neighbors, const size_type& idx) const -> void
     {
-        auto indices = get_neighbors_indices(idx);
+        const auto& offsets = neighbor_offsets(node_code(idx));
 
-        for (size_type i = 0; i < indices.size(); ++i)
+        for (size_type i = 0; i < offsets.size(); ++i)
         {
-            neighbors.at(i) = indices[i];
+            const auto offset = offsets[i];
+            neighbors.at(i) = static_cast<size_type>((offset)[0]) * m_shape[1]
+                              + static_cast<size_type>((offset)[1]) + idx;
         }
     }
 

--- a/include/fastscapelib/raster_grid.hpp
+++ b/include/fastscapelib/raster_grid.hpp
@@ -467,9 +467,6 @@ namespace fastscapelib
         inline neighbors_indices_raster_type neighbors_indices(const size_type& row,
                                                                const size_type& col);
 
-        template <class E>
-        inline auto neighbor_view(E&& field, size_type idx);
-
         code_type node_code(const size_type& row, const size_type& col) const noexcept;
         code_type node_code(const size_type& idx) const noexcept;
 
@@ -862,13 +859,6 @@ namespace fastscapelib
         }
 
         return indices;
-    }
-
-    template <class XT, raster_connect RC, class C>
-    template <class E>
-    inline auto raster_grid_xt<XT, RC, C>::neighbor_view(E&& field, size_type idx)
-    {
-        return xt::index_view(std::forward<E>(field), neighbors_indices(idx));
     }
 
     /**

--- a/python/fastscapelib/tests/test_raster_grid.py
+++ b/python/fastscapelib/tests/test_raster_grid.py
@@ -159,6 +159,22 @@ class TestRasterGrid:
         with pytest.raises(IndexError, match="grid index out of range"):
             self.g.neighbors(51)
 
+    def test_neighbors_raster_indices(self):
+        assert self.g.neighbors_indices(0, 0) == [(0, 1), (1, 0), (1, 1)]
+        assert self.g.neighbors_indices(1, 5) == [
+            (0, 4),
+            (0, 5),
+            (0, 6),
+            (1, 4),
+            (1, 6),
+            (2, 4),
+            (2, 5),
+            (2, 6),
+        ]
+
+        with pytest.raises(IndexError, match="grid index out of range"):
+            self.g.neighbors(10, 10)
+
     def test_neighbors_distances(self):
         dist_diag = np.sqrt(2.2**2 + 2.4**2)
         npt.assert_equal(self.g.neighbors_distances(0), np.array([2.4, 2.2, dist_diag]))
@@ -180,3 +196,15 @@ class TestRasterGrid:
 
         with pytest.raises(IndexError, match="grid index out of range"):
             self.g.neighbors(51)
+
+    def test_raster_neighbors(self):
+        dist_diag = np.sqrt(2.2**2 + 2.4**2)
+
+        assert self.g.neighbors(0, 0) == [
+            RasterNeighbor(1, 0, 1, 2.4, NodeStatus.FIXED_VALUE_BOUNDARY),
+            RasterNeighbor(10, 1, 0, 2.2, NodeStatus.FIXED_VALUE_BOUNDARY),
+            RasterNeighbor(11, 1, 1, dist_diag, NodeStatus.CORE),
+        ]
+
+        with pytest.raises(IndexError, match="grid index out of range"):
+            self.g.neighbors(10, 10)

--- a/python/src/grid.cpp
+++ b/python/src/grid.cpp
@@ -151,4 +151,9 @@ add_grid_bindings(py::module& m)
         .def_property_readonly("status_at_nodes", &fs::py_raster_grid::status_at_nodes);
 
     fs::add_neighbor_methods(rgrid);
+
+    auto raster_grid_funcs = fs::py_raster_grid_funcs();
+
+    rgrid.def("neighbors_indices", raster_grid_funcs.m_neighbors_indices)
+        .def("neighbors", raster_grid_funcs.m_neighbors);
 }

--- a/python/src/grid.hpp
+++ b/python/src/grid.hpp
@@ -90,8 +90,8 @@ namespace fastscapelib
     {
     public:
         using size_type = typename py_raster_grid::size_type;
-        using indices_type = py_raster_grid::neighbors_indices_raster_type;
-        using neighbors_type = py_raster_grid::neighbors_raster_type;
+        using indices_type = typename py_raster_grid::neighbors_indices_raster_type;
+        using neighbors_type = typename py_raster_grid::neighbors_raster_type;
 
         py_raster_grid_funcs() = default;
 

--- a/python/src/grid.hpp
+++ b/python/src/grid.hpp
@@ -26,7 +26,7 @@ namespace fastscapelib
     using py_unstructured_mesh = fs::unstructured_mesh_xt<fs::pyarray_selector>;
 
     template <class G>
-    struct py_grid_funcs
+    class py_grid_funcs
     {
     public:
         using size_type = typename G::size_type;
@@ -68,7 +68,7 @@ namespace fastscapelib
     private:
         inline void check_in_bounds(const G& g, size_type idx)
         {
-            if (idx < 0 || idx >= g.size())
+            if (idx >= g.size())
             {
                 throw std::out_of_range("grid index out of range");
             }
@@ -85,6 +85,40 @@ namespace fastscapelib
             .def("neighbors_distances", grid_funcs.m_neighbors_distances)
             .def("neighbors", grid_funcs.m_neighbors);
     }
+
+    class py_raster_grid_funcs
+    {
+    public:
+        using size_type = typename py_raster_grid::size_type;
+        using indices_type = py_raster_grid::neighbors_indices_raster_type;
+        using neighbors_type = py_raster_grid::neighbors_raster_type;
+
+        py_raster_grid_funcs() = default;
+
+        std::function<indices_type(py_raster_grid&, size_type, size_type)> m_neighbors_indices
+            = [this](py_raster_grid& g, size_type row, size_type col)
+        {
+            check_in_bounds(g, row, col);
+            return g.neighbors_indices(row, col);
+        };
+
+        std::function<neighbors_type(py_raster_grid&, size_type, size_type)> m_neighbors
+            = [this](py_raster_grid& g, size_type row, size_type col)
+        {
+            check_in_bounds(g, row, col);
+            return g.neighbors(row, col);
+        };
+
+    private:
+        inline void check_in_bounds(const py_raster_grid& g, size_type row, size_type col)
+        {
+            const auto& shape = g.shape();
+            if (row >= shape[0] || col >= shape[1])
+            {
+                throw std::out_of_range("grid index out of range");
+            }
+        }
+    };
 
 }
 

--- a/test/test_raster_queen_grid.cpp
+++ b/test/test_raster_queen_grid.cpp
@@ -404,6 +404,30 @@ namespace fastscapelib
             }
         }
 
+        TEST_F(queen_raster_grid_fixed, raster_neighbors)
+        {
+            using neighbors_type = std::vector<fs::raster_neighbor>;
+
+            double d1 = std::sqrt(1.3 * 1.3 + 1.2 * 1.2);
+
+            {
+                EXPECT_EQ(queen_fixed.neighbors(0, 0),
+                          (neighbors_type{ /* Node */ { 1, 0, 1, 1.2, fb },
+                                           { 10, 1, 0, 1.3, fb },
+                                           { 11, 1, 1, d1, co } }));
+
+                EXPECT_EQ(queen_fixed.neighbors(1, 1),
+                          (neighbors_type{ { 0, 0, 0, d1, fb },
+                                           { 1, 0, 1, 1.3, fb },
+                                           { 2, 0, 2, d1, fb },
+                                           { 10, 1, 0, 1.2, fb },
+                                           /* Node */ { 12, 1, 2, 1.2, co },
+                                           { 20, 2, 0, d1, fb },
+                                           { 21, 2, 1, 1.3, co },
+                                           { 22, 2, 2, d1, co } }));
+            }
+        }
+
         TEST_F(queen_raster_grid, neighbors_count)
         {
             // Top-left corner nodes


### PR DESCRIPTION
- [x] use cache for all neighbor methods (including raster-specific methods)
- [x] get rid of `get_neighbors_indices` internally? (only used in `neighbors_indices_impl`)
- [x] remove `neighbors_view`: it is less efficient and there not much use case for that
- [x] add `neighbors` override with `row` and `col` inputs, returns an array of `raster_neighbor`
- [x] update python bindings
- [x] add C++ and Python tests for raster neighbor overloads