### PR TITLE
Use one selector for array and tensor types

### DIFF
--- a/benchmark/benchmark_flow_routing.cpp
+++ b/benchmark/benchmark_flow_routing.cpp
@@ -88,23 +88,23 @@ namespace fastscapelib
             }
         }
 
-        using profile_nocache = fs::profile_grid_xt<xtensor_selector, neighbors_no_cache<2>>;
+        using profile_nocache = fs::profile_grid_xt<xt_selector, neighbors_no_cache<2>>;
         using profile_cacheall = fs::profile_grid;
 
         using queen_nocache
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, neighbors_no_cache<8>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::queen, neighbors_no_cache<8>>;
         using queen_cacheall
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, neighbors_cache<8>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::queen, neighbors_cache<8>>;
 
         using rook_nocache
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, neighbors_no_cache<4>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::rook, neighbors_no_cache<4>>;
         using rook_cacheall
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, neighbors_cache<4>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::rook, neighbors_cache<4>>;
 
         using bishop_nocache
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, neighbors_no_cache<4>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::bishop, neighbors_no_cache<4>>;
         using bishop_cacheall
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, neighbors_cache<4>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::bishop, neighbors_cache<4>>;
 
 
 #define BENCH_GRID(NAME, GRID)                                                                     \

--- a/benchmark/benchmark_profile_grid.cpp
+++ b/benchmark/benchmark_profile_grid.cpp
@@ -86,7 +86,7 @@ namespace fastscapelib
             }
         }
 
-        using profile_nocache = fs::profile_grid_xt<xtensor_selector, neighbors_no_cache<2>>;
+        using profile_nocache = fs::profile_grid_xt<xt_selector, neighbors_no_cache<2>>;
         using profile_cacheall = fs::profile_grid;
 
 #define BENCH_GRID(NAME, GRID)                                                                     \

--- a/benchmark/benchmark_raster_grid.cpp
+++ b/benchmark/benchmark_raster_grid.cpp
@@ -204,19 +204,19 @@ namespace fastscapelib
         }
 
         using queen_nocache
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, neighbors_no_cache<8>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::queen, neighbors_no_cache<8>>;
         using queen_cacheall
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::queen, neighbors_cache<8>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::queen, neighbors_cache<8>>;
 
         using rook_nocache
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, neighbors_no_cache<4>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::rook, neighbors_no_cache<4>>;
         using rook_cacheall
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::rook, neighbors_cache<4>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::rook, neighbors_cache<4>>;
 
         using bishop_nocache
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, neighbors_no_cache<4>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::bishop, neighbors_no_cache<4>>;
         using bishop_cacheall
-            = fs::raster_grid_xt<xtensor_selector, raster_connect::bishop, neighbors_cache<4>>;
+            = fs::raster_grid_xt<xt_selector, raster_connect::bishop, neighbors_cache<4>>;
 
 
 #define BENCH_GRID(NAME, GRID)                                                                     \

--- a/include/fastscapelib/flow/flow_graph.hpp
+++ b/include/fastscapelib/flow/flow_graph.hpp
@@ -28,7 +28,7 @@ namespace fastscapelib
      *
      * @tparam G The grid type.
      * @tparam elev_t Type used to store elevation values.
-     * @tparam G The xtensor selector type.
+     * @tparam S The xtensor selector type.
      */
     template <class G, class elev_t, class S = typename G::xt_selector>
     class flow_graph
@@ -41,20 +41,20 @@ namespace fastscapelib
         using distance_type = typename grid_type::distance_type;
         using neighbors_count_type = typename grid_type::neighbors_count_type;
 
-        using elevation_type = xt_container_t<S, elev_t, G::xt_ndims>;
+        using elevation_type = xt_array_t<S, elev_t>;
 
         template <class T>
-        using data_type = xt_container_t<S, T, G::xt_ndims>;
+        using data_type = xt_array_t<S, T>;
 
-        using donors_type = xt_container_t<S, index_type, 2>;
-        using donors_count_type = xt_container_t<S, neighbors_count_type, 1>;
+        using donors_type = xt_tensor_t<S, index_type, 2>;
+        using donors_count_type = xt_tensor_t<S, neighbors_count_type, 1>;
 
         using receivers_type = donors_type;
         using receivers_count_type = donors_count_type;
-        using receivers_weight_type = xt_container_t<S, double, 2>;
-        using receivers_distance_type = xt_container_t<S, distance_type, 2>;
+        using receivers_weight_type = xt_tensor_t<S, double, 2>;
+        using receivers_distance_type = xt_tensor_t<S, distance_type, 2>;
 
-        using stack_type = xt_container_t<S, index_type, 1>;
+        using stack_type = xt_tensor_t<S, index_type, 1>;
 
         using const_dfs_iterator = const index_type*;
         using const_reverse_dfs_iterator = std::reverse_iterator<const index_type*>;
@@ -67,8 +67,9 @@ namespace fastscapelib
             , p_flow_router(std::move(router))
             , p_sink_resolver(std::move(resolver))
         {
-            shape_type receivers_shape = { grid.size(), grid_type::max_neighbors() };
-            shape_type donors_shape = { grid.size(), grid_type::max_neighbors() + 1 };
+            using shape_type = std::array<index_type, 2>;
+            const shape_type receivers_shape = { grid.size(), grid_type::max_neighbors() };
+            const shape_type donors_shape = { grid.size(), grid_type::max_neighbors() + 1 };
 
             m_receivers = xt::ones<index_type>(receivers_shape) * -1;
             m_receivers_count = xt::zeros<index_type>({ grid.size() });
@@ -162,8 +163,6 @@ namespace fastscapelib
         };
 
     private:
-        using shape_type = typename xt_container_t<S, index_type, 2>::shape_type;
-
         G& m_grid;
 
         donors_type m_donors;

--- a/include/fastscapelib/grid/base.hpp
+++ b/include/fastscapelib/grid/base.hpp
@@ -312,7 +312,7 @@ namespace fastscapelib
         // using xt:xtensor for indices as not all containers support resizing
         // (e.g., using pyarray may cause segmentation faults with Python)
         using neighbors_indices_type = xt::xtensor<size_type, 1>;
-        using neighbors_distances_type = xt_container_t<xt_selector, distance_type, 1>;
+        using neighbors_distances_type = xt_tensor_t<xt_selector, distance_type, 1>;
 
         using node_status_type = typename inner_types::node_status_type;
 

--- a/include/fastscapelib/grid/profile_grid.hpp
+++ b/include/fastscapelib/grid/profile_grid.hpp
@@ -108,7 +108,7 @@ namespace fastscapelib
         static constexpr std::size_t xt_ndims = 1;
 
         using xt_selector = XT;
-        using xt_type = xt_container_t<xt_selector, int, xt_ndims>;
+        using xt_type = xt_tensor_t<xt_selector, int, xt_ndims>;
 
         using size_type = typename xt_type::size_type;
         using shape_type = typename xt_type::shape_type;
@@ -122,7 +122,7 @@ namespace fastscapelib
         using neighbors_distances_impl_type = typename std::array<distance_type, max_neighbors>;
 
         using boundary_status_type = profile_boundary_status;
-        using node_status_type = xt_container_t<xt_selector, node_status, xt_ndims>;
+        using node_status_type = xt_tensor_t<xt_selector, node_status, xt_ndims>;
     };
 
     /**
@@ -404,7 +404,7 @@ namespace fastscapelib
      * This is mainly for convenience when using in C++ applications.
      *
      */
-    using profile_grid = profile_grid_xt<xtensor_selector>;
+    using profile_grid = profile_grid_xt<xt_selector>;
 }
 
 #endif

--- a/include/fastscapelib/grid/raster_grid.hpp
+++ b/include/fastscapelib/grid/raster_grid.hpp
@@ -389,7 +389,7 @@ namespace fastscapelib
         static constexpr std::size_t xt_ndims = 2;
 
         using xt_selector = XT;
-        using xt_type = xt_container_t<xt_selector, int, xt_ndims>;
+        using xt_type = xt_tensor_t<xt_selector, int, xt_ndims>;
 
         using size_type = typename xt_type::size_type;
         using shape_type = typename xt_type::shape_type;
@@ -403,7 +403,7 @@ namespace fastscapelib
         using neighbors_distances_impl_type = typename std::array<distance_type, max_neighbors>;
 
         using boundary_status_type = raster_boundary_status;
-        using node_status_type = xt_container_t<xt_selector, node_status, xt_ndims>;
+        using node_status_type = xt_tensor_t<xt_selector, node_status, xt_ndims>;
     };
 
 
@@ -652,6 +652,8 @@ namespace fastscapelib
         const std::vector<raster_node>& status_at_nodes)
     {
         node_status_type temp_status_at_nodes(m_shape, node_status::core);
+        const auto nrows = static_cast<size_type>(m_shape[0]);
+        const auto ncols = static_cast<size_type>(m_shape[1]);
 
         // set border nodes
         auto left = xt::view(temp_status_at_nodes, xt::all(), 0);
@@ -667,12 +669,11 @@ namespace fastscapelib
         bottom = m_status_at_bounds.bottom;
 
         // set corner nodes
-        std::vector<corner_node> corners = {
-            { 0, 0, m_status_at_bounds.top, m_status_at_bounds.left },
-            { 0, m_shape[1] - 1, m_status_at_bounds.top, m_status_at_bounds.right },
-            { m_shape[0] - 1, 0, m_status_at_bounds.bottom, m_status_at_bounds.left },
-            { m_shape[0] - 1, m_shape[1] - 1, m_status_at_bounds.bottom, m_status_at_bounds.right }
-        };
+        std::vector<corner_node> corners
+            = { { 0, 0, m_status_at_bounds.top, m_status_at_bounds.left },
+                { 0, ncols - 1, m_status_at_bounds.top, m_status_at_bounds.right },
+                { nrows - 1, 0, m_status_at_bounds.bottom, m_status_at_bounds.left },
+                { nrows - 1, ncols - 1, m_status_at_bounds.bottom, m_status_at_bounds.right } };
 
         for (const auto& c : corners)
         {
@@ -946,7 +947,7 @@ namespace fastscapelib
      * This is mainly for convenience when using in C++ applications.
      *
      */
-    using raster_grid = raster_grid_xt<xtensor_selector, raster_connect::queen>;
+    using raster_grid = raster_grid_xt<xt_selector, raster_connect::queen>;
 
 }
 

--- a/include/fastscapelib/grid/unstructured_mesh.hpp
+++ b/include/fastscapelib/grid/unstructured_mesh.hpp
@@ -20,7 +20,7 @@ namespace fastscapelib
         static constexpr std::size_t xt_ndims = 1;
 
         using xt_selector = XT;
-        using xt_type = xt_container_t<xt_selector, int, xt_ndims>;
+        using xt_type = xt_tensor_t<xt_selector, int, xt_ndims>;
 
         using size_type = typename xt_type::size_type;
         using shape_type = typename xt_type::shape_type;
@@ -29,7 +29,7 @@ namespace fastscapelib
         using neighbors_count_type = std::uint8_t;
         using neighbors_distances_impl_type = typename std::array<distance_type, max_neighbors>;
 
-        using node_status_type = xt_container_t<xt_selector, node_status, xt_ndims>;
+        using node_status_type = xt_tensor_t<xt_selector, node_status, xt_ndims>;
     };
 
     /**
@@ -98,7 +98,7 @@ namespace fastscapelib
      * This is mainly for convenience when using in C++ applications.
      *
      */
-    using unstructured_mesh = unstructured_mesh_xt<xtensor_selector>;
+    using unstructured_mesh = unstructured_mesh_xt<xt_selector>;
 }
 
 #endif  // FASTSCAPELIB_GRID_UNSTRUCTURED_MESH_H

--- a/include/fastscapelib/utils/xtensor_utils.hpp
+++ b/include/fastscapelib/utils/xtensor_utils.hpp
@@ -14,30 +14,23 @@
 namespace fastscapelib
 {
 
-    struct xtensor_selector;
-    struct xarray_selector;
+    struct xt_selector;
 
-
-    template <class X, class T, std::size_t N = 0>
+    template <class S, class T, std::size_t N = 0>
     struct xt_container;
 
-
     template <class T, std::size_t N>
-    struct xt_container<xtensor_selector, T, N>
+    struct xt_container<xt_selector, T, N>
     {
-        using type = xt::xtensor<T, N>;
+        using tensor_type = xt::xtensor<T, N>;
+        using array_type = xt::xarray<T>;
     };
 
+    template <class S, class T, std::size_t N>
+    using xt_tensor_t = typename xt_container<S, T, N>::tensor_type;
 
-    template <class T>
-    struct xt_container<xarray_selector, T>
-    {
-        using type = xt::xarray<T>;
-    };
-
-
-    template <class X, class T, std::size_t N = 0>
-    using xt_container_t = typename xt_container<X, T, N>::type;
+    template <class S, class T>
+    using xt_array_t = typename xt_container<S, T>::array_type;
 
 }  // namespace fastscapelib
 

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -1,5 +1,7 @@
 #include <memory>
 
+#include "xtensor-python/pytensor.hpp"
+
 #include "pybind11/pybind11.h"
 
 #include "grid.hpp"

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -44,16 +44,16 @@ namespace fastscapelib
             using neighbors_count_type = std::uint8_t;
             using distance_type = double;
 
-            using data_type = xt_container_t<pyarray_selector, double>;
-            using donors_type = xt_container_t<pyarray_selector, index_type>;
-            using donors_count_type = xt_container_t<pyarray_selector, neighbors_count_type>;
+            using data_type = xt_array_t<py_selector, double>;
+            using donors_type = xt_tensor_t<py_selector, index_type, 2>;
+            using donors_count_type = xt_tensor_t<py_selector, neighbors_count_type, 1>;
 
             using receivers_type = donors_type;
             using receivers_count_type = donors_count_type;
-            using receivers_weight_type = xt_container_t<pyarray_selector, double>;
-            using receivers_distance_type = xt_container_t<pyarray_selector, distance_type>;
+            using receivers_weight_type = xt_tensor_t<py_selector, double, 2>;
+            using receivers_distance_type = xt_tensor_t<py_selector, distance_type, 2>;
 
-            using stack_type = xt_container_t<pyarray_selector, index_type>;
+            using stack_type = xt_tensor_t<py_selector, index_type, 1>;
 
 
             virtual ~flow_graph_wrapper_base(){};
@@ -85,7 +85,7 @@ namespace fastscapelib
         class flow_graph_wrapper : public flow_graph_wrapper_base
         {
         public:
-            using wrapped_type = fs::flow_graph<G, double, fs::pyarray_selector>;
+            using wrapped_type = fs::flow_graph<G, double, fs::py_selector>;
 
             using index_type = typename flow_graph_wrapper_base::index_type;
             using neighbors_count_type = typename flow_graph_wrapper_base::neighbors_count_type;
@@ -198,16 +198,16 @@ namespace fastscapelib
             using neighbors_count_type = std::uint8_t;
             using distance_type = double;
 
-            using data_type = xt_container_t<pyarray_selector, double>;
-            using donors_type = xt_container_t<pyarray_selector, index_type>;
-            using donors_count_type = xt_container_t<pyarray_selector, neighbors_count_type>;
+            using data_type = xt_array_t<py_selector, double>;
+            using donors_type = xt_tensor_t<py_selector, index_type, 2>;
+            using donors_count_type = xt_tensor_t<py_selector, neighbors_count_type, 1>;
 
             using receivers_type = donors_type;
             using receivers_count_type = donors_count_type;
-            using receivers_weight_type = xt_container_t<pyarray_selector, double>;
-            using receivers_distance_type = xt_container_t<pyarray_selector, distance_type>;
+            using receivers_weight_type = xt_tensor_t<py_selector, double, 2>;
+            using receivers_distance_type = xt_tensor_t<py_selector, distance_type, 2>;
 
-            using stack_type = xt_container_t<pyarray_selector, index_type>;
+            using stack_type = xt_tensor_t<py_selector, index_type, 1>;
 
             template <class G>
             flow_graph_facade(G& obj,
@@ -218,7 +218,7 @@ namespace fastscapelib
             }
 
             template <class G>
-            fs::flow_graph<G, double, fs::pyarray_selector>& get_implementation()
+            fs::flow_graph<G, double, fs::py_selector>& get_implementation()
             {
                 auto& derived = dynamic_cast<flow_graph_wrapper<G>&>(*p_impl);
                 return derived.get_wrapped();
@@ -244,7 +244,7 @@ namespace fastscapelib
                 return p_impl->receivers_count();
             };
 
-            const data_type& receivers_distance() const
+            const receivers_distance_type& receivers_distance() const
             {
                 return p_impl->receivers_distance();
             };

--- a/python/src/flow_router.hpp
+++ b/python/src/flow_router.hpp
@@ -69,7 +69,7 @@ namespace fastscapelib
         template <class G>
         void register_flow_routers()
         {
-            using flow_graph_type = fs::flow_graph<G, double, pyarray_selector>;
+            using flow_graph_type = fs::flow_graph<G, double, py_selector>;
             using factory = fs::detail::flow_router_factory<flow_graph_type>;
 
             factory::insert(fs::flow_router_methods::dummy,

--- a/python/src/grid.hpp
+++ b/python/src/grid.hpp
@@ -21,9 +21,9 @@ namespace fs = fastscapelib;
 namespace fastscapelib
 {
 
-    using py_profile_grid = fs::profile_grid_xt<fs::pyarray_selector>;
-    using py_raster_grid = fs::raster_grid_xt<fs::pyarray_selector, fs::raster_connect::queen>;
-    using py_unstructured_mesh = fs::unstructured_mesh_xt<fs::pyarray_selector>;
+    using py_profile_grid = fs::profile_grid_xt<fs::py_selector>;
+    using py_raster_grid = fs::raster_grid_xt<fs::py_selector, fs::raster_connect::queen>;
+    using py_unstructured_mesh = fs::unstructured_mesh_xt<fs::py_selector>;
 
     template <class G>
     class py_grid_funcs

--- a/python/src/pytensor_utils.hpp
+++ b/python/src/pytensor_utils.hpp
@@ -4,18 +4,20 @@
 #include <cstddef>
 
 #include "xtensor-python/pyarray.hpp"
+#include "xtensor-python/pytensor.hpp"
 
 #include "fastscapelib/utils/xtensor_utils.hpp"
 
 
 namespace fastscapelib
 {
-    struct pyarray_selector;
+    struct py_selector;
 
     template <class T, std::size_t N>
-    struct xt_container<pyarray_selector, T, N>
+    struct xt_container<py_selector, T, N>
     {
-        using type = xt::pyarray<T, xt::layout_type::row_major>;
+        using tensor_type = xt::pytensor<T, N, xt::layout_type::row_major>;
+        using array_type = xt::pyarray<T, xt::layout_type::row_major>;
     };
 }
 

--- a/python/src/sink_resolver.hpp
+++ b/python/src/sink_resolver.hpp
@@ -41,7 +41,7 @@ namespace fastscapelib
         template <class G>
         void register_sink_resolvers()
         {
-            using flow_graph_type = fs::flow_graph<G, double, pyarray_selector>;
+            using flow_graph_type = fs::flow_graph<G, double, py_selector>;
             using factory = fs::detail::sink_resolver_factory<flow_graph_type>;
 
             factory::insert(fs::sink_resolver_methods::none,

--- a/test/test_flow_router.cpp
+++ b/test/test_flow_router.cpp
@@ -29,10 +29,10 @@ namespace fastscapelib
 
             grid_type grid = grid_type({ 4, 4 }, { 1.1, 1.2 }, fixed_value_status);
 
-            xt::xtensor<double, 2> elevation{ { 0.82, 0.16, 0.14, 0.20 },
-                                              { 0.71, 0.97, 0.41, 0.09 },
-                                              { 0.49, 0.01, 0.19, 0.38 },
-                                              { 0.29, 0.82, 0.09, 0.88 } };
+            xt::xarray<double> elevation{ { 0.82, 0.16, 0.14, 0.20 },
+                                          { 0.71, 0.97, 0.41, 0.09 },
+                                          { 0.49, 0.01, 0.19, 0.38 },
+                                          { 0.29, 0.82, 0.09, 0.88 } };
 
             flow_graph_type graph
                 = flow_graph_type(grid,

--- a/test/test_profile_grid.cpp
+++ b/test/test_profile_grid.cpp
@@ -56,7 +56,7 @@ namespace fastscapelib
             fs::profile_boundary_status fixed_value_status{ fixed };
             fs::profile_boundary_status looped_status{ loop };
 
-            using grid_type = fs::profile_grid_xt<fs::xtensor_selector>;
+            using grid_type = fs::profile_grid_xt<fs::xt_selector>;
             using size_type = typename grid_type::size_type;
 
             size_type shape{ 5 };

--- a/test/test_raster_grid.cpp
+++ b/test/test_raster_grid.cpp
@@ -110,7 +110,7 @@ namespace fastscapelib
 
         TEST_F(raster_grid, clone)
         {
-            using queen_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::queen>;
+            using queen_type = fs::raster_grid_xt<fs::xt_selector, fs::raster_connect::queen>;
             using neighbors_type = std::vector<fs::neighbor>;
 
             double d1 = std::sqrt(1.3 * 1.3 + 1.2 * 1.2);

--- a/test/test_raster_grid.hpp
+++ b/test/test_raster_grid.hpp
@@ -62,7 +62,7 @@ namespace fastscapelib
         class queen_raster_grid : public raster_grid_base
         {
         protected:
-            using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::queen>;
+            using grid_type = fs::raster_grid_xt<fs::xt_selector, fs::raster_connect::queen>;
 
             grid_type queen_fixed = grid_type(shape, { 1.3, 1.2 }, fixed_value_status);
             grid_type queen_hlooped = grid_type(shape, { 1.3, 1.2 }, hlooped_status);
@@ -83,7 +83,7 @@ namespace fastscapelib
         class rook_raster_grid : public raster_grid_base
         {
         protected:
-            using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::rook>;
+            using grid_type = fs::raster_grid_xt<fs::xt_selector, fs::raster_connect::rook>;
 
             grid_type rook_fixed = grid_type(shape, { 1.3, 1.2 }, fixed_value_status);
             grid_type rook_hlooped = grid_type(shape, { 1.3, 1.2 }, hlooped_status);
@@ -104,7 +104,7 @@ namespace fastscapelib
         class bishop_raster_grid : public raster_grid_base
         {
         protected:
-            using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::bishop>;
+            using grid_type = fs::raster_grid_xt<fs::xt_selector, fs::raster_connect::bishop>;
 
             grid_type bishop_fixed = grid_type(shape, { 1.3, 1.2 }, fixed_value_status);
             grid_type bishop_hlooped = grid_type(shape, { 1.3, 1.2 }, hlooped_status);

--- a/test/test_single_flow_router.cpp
+++ b/test/test_single_flow_router.cpp
@@ -207,7 +207,7 @@ namespace fastscapelib
         class single_flow_router__raster_queen : public single_flow_router__raster_base
         {
         protected:
-            using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::queen>;
+            using grid_type = fs::raster_grid_xt<fs::xt_selector, fs::raster_connect::queen>;
             using flow_graph_type = fs::flow_graph<grid_type, double>;
 
             grid_type fixed_grid
@@ -408,7 +408,7 @@ namespace fastscapelib
         class single_flow_router__raster_rook : public single_flow_router__raster_base
         {
         protected:
-            using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::rook>;
+            using grid_type = fs::raster_grid_xt<fs::xt_selector, fs::raster_connect::rook>;
             using flow_graph_type = fs::flow_graph<grid_type, double>;
 
             grid_type fixed_grid
@@ -616,7 +616,7 @@ namespace fastscapelib
         class single_flow_router__raster_bishop : public single_flow_router__raster_base
         {
         protected:
-            using grid_type = fs::raster_grid_xt<fs::xtensor_selector, fs::raster_connect::bishop>;
+            using grid_type = fs::raster_grid_xt<fs::xt_selector, fs::raster_connect::bishop>;
             using flow_graph_type = fs::flow_graph<grid_type, double>;
 
             grid_type fixed_grid

--- a/test/test_structured_grid.cpp
+++ b/test/test_structured_grid.cpp
@@ -44,7 +44,7 @@ namespace fastscapelib
             fs::profile_boundary_status fixed_status{ fixed };
             fs::profile_boundary_status looped_status{ loop };
 
-            using grid_type = fs::profile_grid_xt<fs::xtensor_selector>;
+            using grid_type = fs::profile_grid_xt<fs::xt_selector>;
             using size_type = typename grid_type::size_type;
 
             size_type shape{ 5 };


### PR DESCRIPTION
`xt_container` has now two members `array_type` and `tensor_type`. Either one or the other might be picked from the selector (needed in some cases). 