### PR TITLE
Refactor eroders

### DIFF
--- a/include/fastscapelib/eroders/spl.hpp
+++ b/include/fastscapelib/eroders/spl.hpp
@@ -6,9 +6,11 @@
 
 #include <cassert>
 #include <cmath>
+#include <stdexcept>
 #include <limits>
 #include <type_traits>
 
+#include "xtensor/xbroadcast.hpp"
 #include "xtensor/xtensor.hpp"
 #include "xtensor/xmanipulation.hpp"
 
@@ -19,29 +21,45 @@
 namespace fastscapelib
 {
 
+    /**
+     * Bedrock channel erosion modelled using the Stream Power Law.
+     *
+     * It numerically solves the Stream Power Law [dh/dt = K A^m (dh/dx)^n]
+     * using an implicit finite difference scheme 1st order in space and time.
+     * The method is detailed in Braun and Willet's (2013) and has been
+     * slightly reformulated/optimized.
+     *
+     * The implicit scheme ensure numerical stability but doesn't totally
+     * prevent erosion from lowering the elevation of a node below that of its
+     * receiver. If this occurs, erosion will be limited so that the node will
+     * be lowered (nearly) down to the level of its receiver. In general it is
+     * better to adjust input values (e.g., time step or input parameters) so
+     * that such arbitrary limitation doesn't occur.
+     *
+     * `n_corr` is the total number of nodes for which erosion has been
+     * arbitrarily limited to ensure consistency.
+     */
     template <class FG, class S = typename FG::xt_selector>
     class spl_eroder
     {
     public:
         using flow_graph_type = FG;
         using xt_selector = S;
-        using grid_type = typename flow_graph_type::grid_type;
 
-        using size_type = typename grid_type::size_type;
-        using shape_type = typename grid_type::shape_type;
-        using data_type = typename grid_type::grid_data_type;
+        using size_type = typename flow_graph_type::size_type;
+        using shape_type = typename flow_graph_type::shape_type;
+        using data_type = typename flow_graph_type::data_type;
         using data_array_type = xt_array_t<xt_selector, data_type>;
-        using elevation_type = data_array_type;
 
         template <class K>
-        spl_eroder(FG& flow_graph, K&& k_coef, double m_exp, double n_exp, double tolerance)
+        spl_eroder(FG& flow_graph, K&& k_coef, double area_exp, double slope_exp, double tolerance)
             : m_flow_graph(flow_graph)
-            , m_shape(flow_graph.grid().shape())
+            , m_shape(flow_graph.grid_shape())
             , m_tolerance(tolerance)
         {
             set_k_coef(k_coef);
-            set_m_exp(m_exp);
-            set_n_exp(n_exp);
+            set_area_exp(area_exp);
+            set_slope_exp(slope_exp);
 
             m_erosion = xt::zeros<data_type>(m_shape);
         };
@@ -60,30 +78,33 @@ namespace fastscapelib
         template <class K>
         void set_k_coef(K&& value, typename std::enable_if_t<xt::is_xexpression<K>::value>* = 0)
         {
-            assert(value.shape() == m_shape);
+            if (!xt::same_shape(value.shape(), m_shape))
+            {
+                throw std::runtime_error("cannot set k_coef value: shape mismatch");
+            }
             m_k_coef = xt::flatten(value);
         };
 
-        double m_exp()
+        double area_exp()
         {
-            return m_m_exp;
+            return m_area_exp;
         };
 
-        void set_m_exp(double value)
+        void set_area_exp(double value)
         {
             // TODO: validate value
-            m_m_exp = value;
+            m_area_exp = value;
         };
 
-        double n_exp()
+        double slope_exp()
         {
-            return m_n_exp;
+            return m_slope_exp;
         };
 
-        void set_n_exp(double value)
+        void set_slope_exp(double value)
         {
             // TODO: validate value
-            m_n_exp = value;
+            m_slope_exp = value;
         };
 
         double tolerance()
@@ -105,22 +126,26 @@ namespace fastscapelib
         shape_type m_shape;
         data_array_type m_k_coef;
         data_array_type m_erosion;
-        double m_m_exp;
-        double m_n_exp;
+        double m_area_exp;
+        double m_slope_exp;
         double m_tolerance;
         size_type m_n_corr;
     };
 
-
+    /**
+     * SPL erosion implementation.
+     *
+     * The implementation here slightly differs from the one described in
+     * Braun & Willet (2013). The problem is reformulated so that the
+     * Newton-Raphson method is applied on the difference of elevation
+     * between a node and its receiver, rather than on the node's
+     * elevation itself. This allows saving some operations.
+     */
     template <class FG, class S>
     auto spl_eroder<FG, S>::erode(const data_array_type& elevation,
                                   const data_array_type& drainage_area,
                                   double dt) -> const data_array_type&
     {
-        auto erosion_flat = xt::flatten(m_erosion);
-        const auto elevation_flat = xt::flatten(elevation);
-        const auto drainage_area_flat = xt::flatten(drainage_area);
-
         auto& flow_graph_impl = m_flow_graph.impl();
 
         const auto& receivers = flow_graph_impl.receivers();
@@ -142,30 +167,30 @@ namespace fastscapelib
                 if (irec == istack)
                 {
                     // at basin outlet or pit
-                    erosion_flat(istack) = 0.;
+                    m_erosion.flat(istack) = 0.;
                     continue;
                 }
 
-                data_type istack_elevation = elevation_flat(istack);  // at time t
+                data_type istack_elevation = elevation.flat(istack);  // at time t
                 data_type irec_elevation
-                    = elevation_flat(irec) - erosion_flat(irec);  // at time t+dt
+                    = elevation.flat(irec) - m_erosion.flat(irec);  // at time t+dt
 
                 if (irec_elevation >= istack_elevation)
                 {
                     // may happen if flow is routed outside of a depression / flat area
-                    erosion_flat(istack) = 0.;
+                    m_erosion.flat(istack) = 0.;
                     continue;
                 }
 
                 auto factor
-                    = (m_k_coef(istack) * dt * std::pow(drainage_area_flat(istack), m_m_exp));
+                    = (m_k_coef(istack) * dt * std::pow(drainage_area.flat(istack), m_area_exp));
 
                 data_type delta_0 = istack_elevation - irec_elevation;
                 data_type delta_k;
 
-                if (m_n_exp == 1)
+                if (m_slope_exp == 1)
                 {
-                    // fast path for n_exp = 1 (common use case)
+                    // fast path for slope_exp = 1 (common use case)
                     factor /= receivers_distance(istack, r);
                     delta_k = delta_0 / (1. + factor);
                 }
@@ -173,12 +198,13 @@ namespace fastscapelib
                 else
                 {
                     // 1st order Newton-Raphson iterations (k)
-                    factor /= std::pow(receivers_distance(istack, r), m_n_exp);
+                    factor /= std::pow(receivers_distance(istack, r), m_slope_exp);
                     delta_k = delta_0;
 
+                    // TODO: add convergence control parameters (max_iterations, atol, mtol)
                     while (true)
                     {
-                        auto factor_delta_exp = factor * std::pow(delta_k, m_n_exp);
+                        auto factor_delta_exp = factor * std::pow(delta_k, m_slope_exp);
                         auto func = delta_k + factor_delta_exp - delta_0;
 
                         if (func <= m_tolerance)
@@ -186,7 +212,7 @@ namespace fastscapelib
                             break;
                         }
 
-                        auto func_deriv = 1 + m_n_exp * factor_delta_exp / delta_k;
+                        auto func_deriv = 1 + m_slope_exp * factor_delta_exp / delta_k;
                         delta_k -= func / func_deriv;
 
                         if (delta_k <= 0)
@@ -206,11 +232,11 @@ namespace fastscapelib
 
                 if (r_count == 1)
                 {
-                    erosion_flat(istack) = (delta_0 - delta_k);
+                    m_erosion.flat(istack) = (delta_0 - delta_k);
                 }
                 else
                 {
-                    erosion_flat(istack) += (delta_0 - delta_k) * receivers_weight(istack, r);
+                    m_erosion.flat(istack) += (delta_0 - delta_k) * receivers_weight(istack, r);
                 }
             }
         }
@@ -221,283 +247,10 @@ namespace fastscapelib
 
     template <class FG, class K>
     spl_eroder<FG> make_spl_eroder(
-        FG& graph, K&& k_coef, double m_exp, double n_exp, double tolerance)
+        FG& graph, K&& k_coef, double area_exp, double slope_exp, double tolerance)
     {
-        return spl_eroder<FG>(graph, k_coef, m_exp, n_exp, tolerance);
+        return spl_eroder<FG>(graph, k_coef, area_exp, slope_exp, tolerance);
     }
-
-
-    namespace detail
-    {
-
-        template <class T, class S>
-        auto k_coef_as_array(T k_coef,
-                             S&& shape,
-                             typename std::enable_if_t<std::is_floating_point<T>::value>* = 0)
-        {
-            return xt::broadcast(std::forward<T>(k_coef), shape);
-        }
-
-
-        template <class K, class S>
-        auto k_coef_as_array(K&& k_coef,
-                             S&& shape,
-                             typename std::enable_if_t<xt::is_xexpression<K>::value>* = 0)
-        {
-            auto k_coef_arr = xt::flatten(k_coef);
-
-            assert(k_coef_arr.shape() == shape);
-            (void) shape;  // TODO: still unused parameter warning despite assert?
-
-            return k_coef_arr;
-        }
-
-
-        /**
-         * erode_stream_power implementation.
-         *
-         * The implementation here slightly differs from the one described in
-         * Braun & Willet (2013). The problem is reformulated so that the
-         * Newton-Raphson method is applied on the difference of elevation
-         * between a node and its receiver, rather than on the node's
-         * elevation itself. This allows saving some operations.
-         */
-        template <class Er, class El, class Dr, class FG, class K>
-        auto erode_stream_power_impl(Er&& erosion,
-                                     El&& elevation,
-                                     Dr&& drainage_area,
-                                     FG& flow_graph,
-                                     K&& k_coef,
-                                     double m_exp,
-                                     double n_exp,
-                                     double dt,
-                                     double tolerance) -> typename FG::size_type
-        {
-            using T = std::common_type_t<typename std::decay_t<Er>::value_type,
-                                         typename std::decay_t<El>::value_type>;
-            using size_type = typename FG::size_type;
-
-            auto erosion_flat = xt::flatten(erosion);
-            const auto elevation_flat = xt::flatten(elevation);
-            const auto drainage_area_flat = xt::flatten(drainage_area);
-            const auto k_coef_arr = k_coef_as_array(k_coef, elevation_flat.shape());
-
-            auto& flow_graph_impl = flow_graph.impl();
-
-            const auto& receivers = flow_graph_impl.receivers();
-            const auto& receivers_count = flow_graph.impl().receivers_count();
-            const auto& receivers_distance = flow_graph.impl().receivers_distance();
-            const auto& receivers_weight = flow_graph.impl().receivers_weight();
-            const auto& dfs_stack = flow_graph.impl().dfs_stack();
-
-            size_type n_corr = 0;
-
-            for (const auto& istack : dfs_stack)
-            {
-                auto r_count = receivers_count[istack];
-
-                for (size_type r = 0; r < r_count; ++r)
-                {
-                    size_type irec = receivers(istack, r);
-
-                    if (irec == istack)
-                    {
-                        // at basin outlet or pit
-                        erosion_flat(istack) = 0.;
-                        continue;
-                    }
-
-                    T istack_elevation = elevation_flat(istack);                   // at time t
-                    T irec_elevation = elevation_flat(irec) - erosion_flat(irec);  // at time t+dt
-
-                    if (irec_elevation >= istack_elevation)
-                    {
-                        // may happen if flow is routed outside of a depression / flat area
-                        erosion_flat(istack) = 0.;
-                        continue;
-                    }
-
-                    auto factor
-                        = (k_coef_arr(istack) * dt * std::pow(drainage_area_flat(istack), m_exp));
-
-                    T delta_0 = istack_elevation - irec_elevation;
-                    T delta_k;
-
-                    if (n_exp == 1)
-                    {
-                        // fast path for n_exp = 1 (common use case)
-                        factor /= receivers_distance(istack, r);
-                        delta_k = delta_0 / (1. + factor);
-                    }
-
-                    else
-                    {
-                        // 1st order Newton-Raphson iterations (k)
-                        factor /= std::pow(receivers_distance(istack, r), n_exp);
-                        delta_k = delta_0;
-
-                        while (true)
-                        {
-                            auto factor_delta_exp = factor * std::pow(delta_k, n_exp);
-                            auto func = delta_k + factor_delta_exp - delta_0;
-
-                            if (func <= tolerance)
-                            {
-                                break;
-                            }
-
-                            auto func_deriv = 1 + n_exp * factor_delta_exp / delta_k;
-                            delta_k -= func / func_deriv;
-
-                            if (delta_k <= 0)
-                            {
-                                break;
-                            }
-                        }
-                    }
-
-                    if (delta_k <= 0)
-                    {
-                        // prevent the creation of new depressions / flat channels
-                        // by arbitrarily limiting erosion
-                        n_corr++;
-                        delta_k = std::numeric_limits<T>::min();
-                    }
-
-                    if (r_count == 1)
-                    {
-                        erosion_flat(istack) = (delta_0 - delta_k);
-                    }
-                    else
-                    {
-                        erosion_flat(istack) += (delta_0 - delta_k) * receivers_weight(istack, r);
-                    }
-                }
-            }
-
-            return n_corr;
-        }
-
-    }  // namespace detail
-
-
-    /**
-     * Compute bedrock channel erosion during a single time step using the
-     * Stream Power Law.
-     *
-     * It numerically solves the Stream Power Law [dh/dt = K A^m (dh/dx)^n]
-     * using an implicit finite difference scheme 1st order in space and time.
-     * The method is detailed in Braun and Willet's (2013) and has been
-     * slightly reformulated/optimized.
-     *
-     * As it requires some input information on the flow tree topology
-     * (e.g., flow receivers and stack order) and geometry (e.g., distance
-     * to receivers), this generic function is grid/mesh agnostic and can
-     * be applied in both 1-d (river profile) and 2-d (river network)
-     * cases.
-     *
-     * The implicit scheme ensure numerical stability but doesn't totally
-     * prevent erosion from lowering the elevation of a node below that of
-     * its receiver. If this occurs, erosion will be limited so that the
-     * node will be lowered (nearly) down to the level of its receiver. In
-     * general it is better to adjust input values (e.g., ``dt``) so that
-     * such arbitrary limitation doesn't occur. The value returned by this
-     * function allows to detect and track the number of these
-     * occurrences.
-     *
-     * @param erosion : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
-     *     Erosion at grid node.
-     * @param elevation : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
-     *     Elevation at grid node.
-     * @param flow_graph :``[intent=in]``
-     *     Flow graph of the grid.
-     * @param k_coef : ``[intent=in]``
-     *     Stream Power Law coefficient.
-     * @param m_exp : ``[intent=in]``
-     *     Stream Power Law drainage area exponent.
-     * @param n_exp : ``[intent=in]``
-     *     Stream Power Law slope exponent.
-     * @param dt : ``[intent=in]``
-     *     Time step duration.
-     * @param tolerance : ``[intent=in]``
-     *     Tolerance used for Newton's iterations (``n_exp`` != 1).
-     *
-     * @returns
-     *     Total number of nodes for which erosion has been
-     *     arbitrarily limited to ensure consistency.
-     */
-    template <class Er, class El, class Dr, class FG>
-    auto erode_stream_power(xtensor_t<Er>& erosion,
-                            const xtensor_t<El>& elevation,
-                            const xtensor_t<Dr>& drainage_area,
-                            const FG& flow_graph,
-                            double k_coef,
-                            double m_exp,
-                            double n_exp,
-                            double dt,
-                            double tolerance) -> typename FG::size_type
-    {
-        return detail::erode_stream_power_impl(erosion.derived_cast(),
-                                               elevation.derived_cast(),
-                                               drainage_area.derived_cast(),
-                                               flow_graph,
-                                               k_coef,
-                                               m_exp,
-                                               n_exp,
-                                               dt,
-                                               tolerance);
-    }
-
-
-    /**
-     * Compute bedrock channel erosion during a single time step using the
-     * Stream Power Law.
-     *
-     * This version accepts a spatially variable stream-power law coefficient.
-     *
-     * @param erosion : ``[intent=out, shape=(nrows, ncols)||(nnodes)]``
-     *     Erosion at grid node.
-     * @param elevation : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
-     *     Elevation at grid node.
-     * @param flow_graph :``[intent=in]``
-     *     Flow graph of the grid.
-     * @param k_coef : ``[intent=in, shape=(nrows, ncols)||(nnodes)]``
-     *     Stream Power Law coefficient.
-     * @param m_exp : ``[intent=in]``
-     *     Stream Power Law drainage area exponent.
-     * @param n_exp : ``[intent=in]``
-     *     Stream Power Law slope exponent.
-     * @param dt : ``[intent=in]``
-     *     Time step duration.
-     * @param tolerance : ``[intent=in]``
-     *     Tolerance used for Newton's iterations (``n_exp`` != 1).
-     *
-     * @returns
-     *     Total number of nodes for which erosion has been
-     *     arbitrarily limited to ensure consistency.
-     */
-    template <class Er, class El, class Dr, class FG, class K>
-    auto erode_stream_power(xtensor_t<Er>& erosion,
-                            const xtensor_t<El>& elevation,
-                            const xtensor_t<Dr>& drainage_area,
-                            const FG& flow_graph,
-                            const xtensor_t<K>& k_coef,
-                            double m_exp,
-                            double n_exp,
-                            double dt,
-                            double tolerance) -> typename FG::size_type
-    {
-        return detail::erode_stream_power_impl(erosion.derived_cast(),
-                                               elevation.derived_cast(),
-                                               drainage_area.derived_cast(),
-                                               flow_graph,
-                                               k_coef.derived_cast(),
-                                               m_exp,
-                                               n_exp,
-                                               dt,
-                                               tolerance);
-    }
-
 }  // namespace fastscapelib
 
 #endif

--- a/include/fastscapelib/flow/flow_graph.hpp
+++ b/include/fastscapelib/flow/flow_graph.hpp
@@ -50,6 +50,7 @@ namespace fastscapelib
 
         using data_type = typename grid_type::grid_data_type;
         using data_array_type = xt_array_t<xt_selector, data_type>;
+        using shape_type = typename data_array_type::shape_type;
 
         flow_graph(G& grid, const router_type& router, const resolver_type& resolver)
             : m_grid(grid)
@@ -76,6 +77,14 @@ namespace fastscapelib
         {
             return m_grid.size();
         };
+
+        shape_type grid_shape() const
+        {
+            // grid shape may have a different type (e.g., from xtensor containers)
+            auto shape = m_grid.shape();
+            shape_type data_array_shape(shape.begin(), shape.end());
+            return data_array_shape;
+        }
 
         const flow_graph_impl_type& impl() const
         {

--- a/include/fastscapelib/flow/flow_graph.hpp
+++ b/include/fastscapelib/flow/flow_graph.hpp
@@ -37,18 +37,20 @@ namespace fastscapelib
         using grid_type = G;
         using router_type = FR;
         using resolver_type = SR;
+        using xt_selector = S;
 
         static_assert(std::is_same<typename router_type::flow_graph_impl_tag,
                                    typename resolver_type::flow_graph_impl_tag>::value,
                       "incompatible flow router and sink resolver types");
         using flow_graph_impl_tag = typename router_type::flow_graph_impl_tag;
-        using flow_graph_impl_type = detail::flow_graph_impl<grid_type, S, flow_graph_impl_tag>;
+        using flow_graph_impl_type
+            = detail::flow_graph_impl<grid_type, xt_selector, flow_graph_impl_tag>;
 
-        using index_type = typename grid_type::size_type;
-        using elevation_type = xt_array_t<S, typename grid_type::grid_data_type>;
+        using size_type = typename grid_type::size_type;
+        using elevation_type = xt_array_t<xt_selector, typename grid_type::grid_data_type>;
 
         template <class T>
-        using data_type = xt_array_t<S, T>;
+        using data_type = xt_array_t<xt_selector, T>;
 
         flow_graph(G& grid, const router_type& router, const resolver_type& resolver)
             : m_grid(grid)
@@ -71,7 +73,7 @@ namespace fastscapelib
             return m_grid;
         };
 
-        index_type size() const
+        size_type size() const
         {
             return m_grid.size();
         };

--- a/include/fastscapelib/flow/flow_graph.hpp
+++ b/include/fastscapelib/flow/flow_graph.hpp
@@ -47,10 +47,9 @@ namespace fastscapelib
             = detail::flow_graph_impl<grid_type, xt_selector, flow_graph_impl_tag>;
 
         using size_type = typename grid_type::size_type;
-        using elevation_type = xt_array_t<xt_selector, typename grid_type::grid_data_type>;
 
-        template <class T>
-        using data_type = xt_array_t<xt_selector, T>;
+        using data_type = typename grid_type::grid_data_type;
+        using data_array_type = xt_array_t<xt_selector, data_type>;
 
         flow_graph(G& grid, const router_type& router, const resolver_type& resolver)
             : m_grid(grid)
@@ -58,7 +57,7 @@ namespace fastscapelib
             , m_router_impl(m_graph_impl, router)
             , m_resolver_impl(m_graph_impl, resolver){};
 
-        const elevation_type& update_routes(const elevation_type& elevation)
+        const data_array_type& update_routes(const data_array_type& elevation)
         {
             const auto& modified_elevation = m_resolver_impl.resolve1(elevation);
             m_router_impl.route1(modified_elevation);
@@ -68,10 +67,10 @@ namespace fastscapelib
             return final_elevation;
         }
 
-        G& grid()
+        grid_type& grid() const
         {
             return m_grid;
-        };
+        }
 
         size_type size() const
         {
@@ -83,13 +82,25 @@ namespace fastscapelib
             return m_graph_impl;
         }
 
-        template <class T>
-        T accumulate(const T& data) const;
-
-        data_type<double> accumulate(const double& data) const;
+        void accumulate(data_array_type& acc, const data_array_type& src) const
+        {
+            return m_graph_impl.accumulate(acc, src);
+        };
+        void accumulate(data_array_type& acc, data_type src) const
+        {
+            return m_graph_impl.accumulate(acc, src);
+        };
+        data_array_type accumulate(const data_array_type& src) const
+        {
+            return m_graph_impl.accumulate(src);
+        };
+        data_array_type accumulate(data_type src) const
+        {
+            return m_graph_impl.accumulate(src);
+        };
 
     private:
-        G& m_grid;
+        grid_type& m_grid;
 
         flow_graph_impl_type m_graph_impl;
 
@@ -101,19 +112,6 @@ namespace fastscapelib
         router_impl_type m_router_impl;
         resolver_impl_type m_resolver_impl;
     };
-
-    template <class G, class FR, class SR, class S>
-    template <class T>
-    auto flow_graph<G, FR, SR, S>::accumulate(const T& data) const -> T
-    {
-        return m_graph_impl.accumulate(data);
-    }
-
-    template <class G, class FR, class SR, class S>
-    auto flow_graph<G, FR, SR, S>::accumulate(const double& data) const -> data_type<double>
-    {
-        return m_graph_impl.accumulate(data);
-    }
 
 
     template <class G, class FR, class SR, class S = typename G::xt_selector>

--- a/include/fastscapelib/flow/flow_graph_impl.hpp
+++ b/include/fastscapelib/flow/flow_graph_impl.hpp
@@ -3,6 +3,10 @@
 
 #include <array>
 
+#include "xtensor/xbroadcast.hpp"
+#include "xtensor/xstrided_view.hpp"
+#include "xtensor/xview.hpp"
+
 #include "fastscapelib/utils/xtensor_utils.hpp"
 
 
@@ -34,46 +38,41 @@ namespace fastscapelib
         public:
             using self_type = flow_graph_impl<G, S, flow_graph_fixed_array_tag>;
             using grid_type = G;
+            using xt_selector = S;
 
-            using index_type = typename grid_type::size_type;
-            using grid_data_type = typename grid_type::grid_data_type;
+            using size_type = typename grid_type::size_type;
             using neighbors_count_type = typename grid_type::neighbors_count_type;
 
-            template <class T>
-            using data_type = xt_array_t<S, T>;
+            using data_type = typename grid_type::grid_data_type;
+            using data_array_type = xt_array_t<xt_selector, data_type>;
 
-            // referenced in flow router and sink resolver implementations
-            using elevation_type = xt_array_t<S, typename grid_type::grid_data_type>;
-
-            using donors_type = xt_tensor_t<S, index_type, 2>;
-            using donors_count_type = xt_tensor_t<S, neighbors_count_type, 1>;
-
+            using donors_type = xt_tensor_t<xt_selector, size_type, 2>;
+            using donors_count_type = xt_tensor_t<xt_selector, neighbors_count_type, 1>;
             using receivers_type = donors_type;
             using receivers_count_type = donors_count_type;
-            using receivers_weight_type = xt_tensor_t<S, double, 2>;
-            using receivers_distance_type = xt_tensor_t<S, grid_data_type, 2>;
+            using receivers_distance_type = xt_tensor_t<xt_selector, data_type, 2>;
+            using receivers_weight_type = xt_tensor_t<xt_selector, data_type, 2>;
+            using stack_type = xt_tensor_t<S, size_type, 1>;
 
-            using stack_type = xt_tensor_t<S, index_type, 1>;
-
-            // using const_dfs_iterator = const index_type*;
-            // using const_reverse_dfs_iterator = std::reverse_iterator<const index_type*>;
+            // using const_dfs_iterator = const size_type*;
+            // using const_reverse_dfs_iterator = std::reverse_iterator<const size_type*>;
 
             flow_graph_impl(grid_type& grid)
                 : m_grid(grid)
             {
-                using shape_type = std::array<index_type, 2>;
+                using shape_type = std::array<size_type, 2>;
                 const shape_type receivers_shape = { grid.size(), grid_type::n_neighbors_max() };
                 const shape_type donors_shape = { grid.size(), grid_type::n_neighbors_max() + 1 };
 
-                m_receivers = xt::ones<index_type>(receivers_shape) * -1;
-                m_receivers_count = xt::zeros<index_type>({ grid.size() });
-                m_receivers_distance = xt::ones<grid_data_type>(receivers_shape) * -1;
-                m_receivers_weight = xt::zeros<double>(receivers_shape);
+                m_receivers = xt::ones<size_type>(receivers_shape) * -1;
+                m_receivers_count = xt::zeros<size_type>({ grid.size() });
+                m_receivers_distance = xt::ones<data_type>(receivers_shape) * -1;
+                m_receivers_weight = xt::zeros<data_type>(receivers_shape);
 
-                m_donors = xt::ones<index_type>(donors_shape) * -1;
-                m_donors_count = xt::zeros<index_type>({ grid.size() });
+                m_donors = xt::ones<size_type>(donors_shape) * -1;
+                m_donors_count = xt::zeros<size_type>({ grid.size() });
 
-                m_dfs_stack = xt::ones<index_type>({ grid.size() }) * -1;
+                m_dfs_stack = xt::ones<size_type>({ grid.size() }) * -1;
             };
 
             G& grid()
@@ -81,7 +80,7 @@ namespace fastscapelib
                 return m_grid;
             };
 
-            index_type size() const
+            size_type size() const
             {
                 return m_grid.size();
             };
@@ -142,9 +141,10 @@ namespace fastscapelib
             // };
 
             template <class T>
-            T accumulate(const T& data) const;
+            void accumulate(data_array_type& acc, T&& src) const;
 
-            data_type<double> accumulate(const double& data) const;
+            template <class T>
+            data_array_type accumulate(T&& src) const;
 
         private:
             grid_type& m_grid;
@@ -168,33 +168,45 @@ namespace fastscapelib
 
         template <class G, class S>
         template <class T>
-        auto flow_graph_impl<G, S, flow_graph_fixed_array_tag>::accumulate(const T& data) const -> T
+        void flow_graph_impl<G, S, flow_graph_fixed_array_tag>::accumulate(data_array_type& acc,
+                                                                           T&& src) const
         {
-            T acc = xt::zeros_like(data);
+            // TODO: assert(acc.shape() == m_grid.shape()) with compatible shape types
+            auto src_arr = xt::broadcast(std::forward<T>(src), m_grid.shape());
+
+            // TODO: safer to flatten acc and src? (case of raster_grid -> 2d arrays)
+            // flatten seems to greatly slow down the execution
+            // alternative? (check if it would work with different layout, e.g., column major)
+            // maybe xt::ravel? -> specify row::major explicitly (maybe faster?)
+            // or acc.flat(idx) ? -> check perfs (not available for xbroadcast expression)
+            // currently: just use operator() works even for 2d arrays. not sure why?
+
+            // re-init accumulated values
+            acc.fill(0);
 
             for (auto inode = m_dfs_stack.crbegin(); inode != m_dfs_stack.crend(); ++inode)
             {
-                acc(*inode) += m_grid.node_area(*inode) * data.data()[*inode];
+                acc.flat(*inode) += m_grid.node_area(*inode) * src_arr(*inode);
 
-                for (index_type r = 0; r < m_receivers_count[*inode]; ++r)
+                for (size_type r = 0; r < m_receivers_count[*inode]; ++r)
                 {
-                    index_type ireceiver = m_receivers(*inode, r);
+                    size_type ireceiver = m_receivers(*inode, r);
                     if (ireceiver != *inode)
                     {
-                        acc(ireceiver) += acc(*inode) * m_receivers_weight(*inode, r);
+                        acc.flat(ireceiver) += acc.flat(*inode) * m_receivers_weight(*inode, r);
                     }
                 }
             }
-
-            return acc;
         }
 
         template <class G, class S>
-        auto flow_graph_impl<G, S, flow_graph_fixed_array_tag>::accumulate(const double& data) const
-            -> data_type<double>
+        template <class T>
+        auto flow_graph_impl<G, S, flow_graph_fixed_array_tag>::accumulate(T&& src) const
+            -> data_array_type
         {
-            data_type<double> tmp = xt::ones<double>(m_grid.shape()) * data;
-            return accumulate(tmp);
+            data_array_type acc = data_array_type::from_shape(m_grid.shape());
+            accumulate(acc, std::forward<T>(src));
+            return acc;
         }
     }
 }

--- a/include/fastscapelib/flow/sink_resolver.hpp
+++ b/include/fastscapelib/flow/sink_resolver.hpp
@@ -50,20 +50,20 @@ namespace fastscapelib
          * The declaration for the generic case here contains the minimum that
          * should be (re)implemented in specialized template classes.
          *
-         * @tparam FG The flow graph type.
+         * @tparam FG The flow graph implementation type.
          * @tparam SR The sink resolver type.
          */
         template <class FG, class SR>
         class sink_resolver_impl : public sink_resolver_impl_base<FG, SR>
         {
         public:
-            using graph_type = FG;
+            using graph_impl_type = FG;
             using resolver_type = SR;
-            using base_type = sink_resolver_impl_base<graph_type, resolver_type>;
+            using base_type = sink_resolver_impl_base<graph_impl_type, resolver_type>;
 
-            using elevation_type = typename graph_type::elevation_type;
+            using elevation_type = typename graph_impl_type::elevation_type;
 
-            sink_resolver_impl(graph_type& graph, const resolver_type& resolver)
+            sink_resolver_impl(graph_impl_type& graph, const resolver_type& resolver)
                 : base_type(graph, resolver){};
 
             const elevation_type& resolve1(const elevation_type& elevation)

--- a/include/fastscapelib/flow/sink_resolver.hpp
+++ b/include/fastscapelib/flow/sink_resolver.hpp
@@ -61,16 +61,16 @@ namespace fastscapelib
             using resolver_type = SR;
             using base_type = sink_resolver_impl_base<graph_impl_type, resolver_type>;
 
-            using elevation_type = typename graph_impl_type::elevation_type;
+            using data_array_type = typename graph_impl_type::data_array_type;
 
             sink_resolver_impl(graph_impl_type& graph, const resolver_type& resolver)
                 : base_type(graph, resolver){};
 
-            const elevation_type& resolve1(const elevation_type& elevation)
+            const data_array_type& resolve1(const data_array_type& elevation)
             {
                 return elevation;
             };
-            const elevation_type& resolve2(const elevation_type& elevation)
+            const data_array_type& resolve2(const data_array_type& elevation)
             {
                 return elevation;
             };

--- a/python/fastscapelib/tests/test_eroders.py
+++ b/python/fastscapelib/tests/test_eroders.py
@@ -35,7 +35,7 @@ class TestErodeStreamPower:
 
         h = 1.0
         elevation = np.array([0.0, h, h, 0.0], dtype="d")
-        graph_elevation = flow_graph.update_routes(elevation)
+        flow_graph.update_routes(elevation)
 
         drainage_area = flow_graph.accumulate(1.0)
         erosion = np.zeros_like(elevation)
@@ -77,17 +77,27 @@ class TestErodeStreamPower:
         # Test on a tiny (2x2) 2-d square grid with a planar surface
         # tilted in y (rows) and with all outlets on the 1st row.
         spacing = 300.0
+
+        # top-border base level
+        top_base_level = [
+            NodeStatus.CORE,
+            NodeStatus.CORE,
+            NodeStatus.FIXED_VALUE_BOUNDARY,
+            NodeStatus.CORE,
+        ]
+
         grid = RasterGrid(
             [2, 2],
             [spacing, spacing],
-            RasterBoundaryStatus(NodeStatus.FIXED_VALUE_BOUNDARY),
+            RasterBoundaryStatus(top_base_level),
             [],
         )
+
         flow_graph = FlowGraph(grid, SingleFlowRouter(), NoSinkResolver())
 
         h = 1.0
         elevation = np.array([[0.0, 0.0], [h, h]], dtype="d")
-        graph_elevation = flow_graph.update_routes(elevation)
+        flow_graph.update_routes(elevation)
 
         drainage_area = flow_graph.accumulate(1.0)
         erosion = np.zeros_like(elevation)

--- a/python/fastscapelib/tests/test_eroders.py
+++ b/python/fastscapelib/tests/test_eroders.py
@@ -2,78 +2,76 @@ import numpy as np
 import pytest
 
 from fastscapelib.eroders import (
+    SPLEroder,
     erode_linear_diffusion_d,
     erode_linear_diffusion_var_d,
-    erode_stream_power_d,
-    erode_stream_power_var_d,
 )
-from fastscapelib.flow import (
-    FlowGraph,
-    MultipleFlowRouter,
-    NoSinkResolver,
-    SingleFlowRouter,
-)
-from fastscapelib.grid import (
-    Node,
-    NodeStatus,
-    ProfileGrid,
-    RasterBoundaryStatus,
-    RasterGrid,
-    RasterNode,
-)
+from fastscapelib.flow import FlowGraph, NoSinkResolver, SingleFlowRouter
+from fastscapelib.grid import NodeStatus, ProfileGrid, RasterBoundaryStatus, RasterGrid
 
 
-class TestErodeStreamPower:
-    @pytest.mark.parametrize(
-        "func,k",
-        [(erode_stream_power_d, 1e-3), (erode_stream_power_var_d, np.full(4, 1e-3))],
-    )
-    def test_profile_grid(self, func, k):
+class TestSPLEroder:
+    def test_constructor_properties(self):
+        bstatus = RasterBoundaryStatus(NodeStatus.FIXED_VALUE_BOUNDARY)
+        grid = RasterGrid([2, 2], [1.0, 1.0], bstatus, [])
+        flow_graph = FlowGraph(grid, SingleFlowRouter(), NoSinkResolver())
+
+        eroder = SPLEroder(flow_graph, 1e-3, 0.4, 1, 1e-5)
+
+        np.testing.assert_equal(eroder.k_coef, np.full(grid.size, 1e-3))
+        assert eroder.area_exp == 0.4
+        assert eroder.slope_exp == 1
+        assert eroder.tolerance == 1e-5
+
+        eroder.area_exp = 0.5
+        assert eroder.area_exp == 0.5
+
+        eroder.slope_exp = 1.2
+        assert eroder.slope_exp == 1.2
+
+        k_coef_arr = np.arange(grid.size, dtype=np.double).reshape(grid.shape)
+        eroder.k_coef = k_coef_arr
+        np.testing.assert_equal(eroder.k_coef, k_coef_arr.flatten())
+
+        k_coef = 1e-5
+        eroder.k_coef = k_coef
+        np.testing.assert_equal(eroder.k_coef, np.full(grid.size, 1e-5))
+
+        with pytest.raises(RuntimeError, match=".*shape mismatch"):
+            eroder.k_coef = np.ones((4, 5))
+
+    @pytest.mark.parametrize("k_coef", [1e-3, np.full((4), 1e-3)])
+    def test_profile_grid(self, k_coef):
         spacing = 300.0
         grid = ProfileGrid(4, 300, [NodeStatus.FIXED_VALUE_BOUNDARY] * 2, [])
+
         flow_graph = FlowGraph(grid, SingleFlowRouter(), NoSinkResolver())
+
+        area_exp = 0.5
+        slope_exp = 1.0
+        tolerance = 1e-3
+        eroder = SPLEroder(flow_graph, k_coef, area_exp, slope_exp, tolerance)
 
         h = 1.0
         elevation = np.array([0.0, h, h, 0.0], dtype="d")
-        flow_graph.update_routes(elevation)
 
+        flow_graph.update_routes(elevation)
         drainage_area = flow_graph.accumulate(1.0)
-        erosion = np.zeros_like(elevation)
-        m_exp = 0.5
-        n_exp = 1.0
 
         dt = 1.0  # use small time step (compare with explicit scheme)
-        tolerance = 1e-3
-
-        n_corr = func(
-            erosion,
-            elevation,
-            drainage_area,
-            flow_graph,
-            k,
-            m_exp,
-            n_exp,
-            dt,
-            tolerance,
-        )
+        erosion = eroder.erode(elevation, drainage_area, dt)
 
         slope = h / spacing
         a = spacing
         k_coef = 1e-3
-        err = dt * k_coef * a**m_exp * slope**n_exp
+        err = dt * k_coef * a**area_exp * slope**slope_exp
         expected_erosion = np.array([0.0, err, err, 0.0], dtype="d")
 
         np.testing.assert_allclose(erosion, expected_erosion, atol=1e-5)
-        assert n_corr == 0
+        assert eroder.n_corr == 0
 
-    @pytest.mark.parametrize(
-        "func,k",
-        [
-            (erode_stream_power_d, 1e-3),
-            (erode_stream_power_var_d, np.full((2, 2), 1e-3)),
-        ],
-    )
-    def test_raster_grid(self, func, k):
+    @pytest.mark.parametrize("k_coef", [1e-3, np.full((2, 2), 1e-3)])
+    def test_raster_grid(self, k_coef):
         # Test on a tiny (2x2) 2-d square grid with a planar surface
         # tilted in y (rows) and with all outlets on the 1st row.
         spacing = 300.0
@@ -95,38 +93,28 @@ class TestErodeStreamPower:
 
         flow_graph = FlowGraph(grid, SingleFlowRouter(), NoSinkResolver())
 
+        area_exp = 0.5
+        slope_exp = 1.0
+        tolerance = 1e-3
+        eroder = SPLEroder(flow_graph, k_coef, area_exp, slope_exp, tolerance)
+
         h = 1.0
         elevation = np.array([[0.0, 0.0], [h, h]], dtype="d")
-        flow_graph.update_routes(elevation)
 
+        flow_graph.update_routes(elevation)
         drainage_area = flow_graph.accumulate(1.0)
-        erosion = np.zeros_like(elevation)
-        m_exp = 0.5
-        n_exp = 1.0
 
         dt = 1  # use small time step (compare with explicit scheme)
-        tolerance = 1e-3
-
-        n_corr = func(
-            erosion,
-            elevation,
-            drainage_area,
-            flow_graph,
-            k,
-            m_exp,
-            n_exp,
-            dt,
-            tolerance,
-        )
+        erosion = eroder.erode(elevation, drainage_area, dt)
 
         slope = h / spacing
         a = spacing**2
         k_coef = 1e-3
-        err = dt * k_coef * a**m_exp * slope**n_exp
+        err = dt * k_coef * a**area_exp * slope**slope_exp
         expected_erosion = np.array([[0.0, 0.0], [err, err]], dtype="d")
 
         np.testing.assert_allclose(erosion, expected_erosion, atol=1e-5)
-        assert n_corr == 0
+        assert eroder.n_corr == 0
 
 
 def _solve_diffusion_analytical(x, y, k_coef, t):
@@ -157,7 +145,8 @@ def test_erode_linear_diffusion(k_coef_type):
     if k_coef_type == "constant":
         func = erode_linear_diffusion_d
         k = k_coef
-    elif k_coef_type == "variable":
+    else:
+        # k_coef_type == "variable"
         func = erode_linear_diffusion_var_d
         k = np.full_like(x, k_coef)
 

--- a/python/fastscapelib/tests/test_flow_graph.py
+++ b/python/fastscapelib/tests/test_flow_graph.py
@@ -21,17 +21,21 @@ class TestFlowGraph:
         )
 
         FlowGraph(profile_grid, SingleFlowRouter(), NoSinkResolver())
-        FlowGraph(profile_grid, MultipleFlowRouter(1.0, 1.1), NoSinkResolver())
+        FlowGraph(raster_grid, MultipleFlowRouter(1.0, 1.1), NoSinkResolver())
 
     def test_update_routes(self):
         grid = ProfileGrid(8, 2.2, [NodeStatus.FIXED_VALUE_BOUNDARY] * 2, [])
         flow_graph = FlowGraph(grid, SingleFlowRouter(), NoSinkResolver())
-        elevation = np.r_[0.82, 0.16, 0.14, 0.20, 0.71, 0.97, 0.41, 0.09]
 
-        graph_elevation = flow_graph.update_routes(elevation)
+        # pit at 3rd node
+        elevation = np.array([0.0, 0.2, 0.1, 0.2, 0.4, 0.6, 0.3, 0.0])
+
+        new_elevation = flow_graph.update_routes(elevation)
+
+        npt.assert_array_equal(elevation, new_elevation)
 
         npt.assert_equal(
-            flow_graph.impl().receivers()[:, 0], np.r_[1, 2, 2, 2, 3, 6, 7, 7]
+            flow_graph.impl().receivers()[:, 0], np.array([0, 0, 2, 2, 3, 6, 7, 7])
         )
         npt.assert_equal(flow_graph.impl().receivers_count(), np.ones(elevation.size))
         npt.assert_equal(
@@ -46,83 +50,92 @@ class TestFlowGraph:
             flow_graph.impl().donors(),
             np.array(
                 [
+                    [1, m, m],
                     [m, m, m],
-                    [0, m, m],
-                    [1, 2, 3],
+                    [2, 3, m],
                     [4, m, m],
                     [m, m, m],
                     [m, m, m],
                     [5, m, m],
-                    [6, 7, m],
+                    [6, m, m],
                 ]
             ),
         )
         npt.assert_equal(
-            flow_graph.impl().donors_count(), np.r_[0, 1, 3, 1, 0, 0, 1, 2]
+            flow_graph.impl().donors_count(), np.array([1, 0, 2, 1, 0, 0, 1, 1])
         )
-
-        npt.assert_equal(graph_elevation, elevation)
 
     def test_accumulate(self):
-        grid = ProfileGrid(8, 2.2, [NodeStatus.FIXED_VALUE_BOUNDARY] * 2, [])
+        # --- test profile grid
+        grid = ProfileGrid(8, 2.0, [NodeStatus.FIXED_VALUE_BOUNDARY] * 2, [])
         flow_graph = FlowGraph(grid, SingleFlowRouter(), NoSinkResolver())
-        elevation = np.r_[0.82, 0.16, 0.14, 0.20, 0.71, 0.97, 0.41, 0.09]
 
-        graph_elevation = flow_graph.update_routes(elevation)
+        # pit at 3rd node
+        elevation = np.array([0.0, 0.2, 0.1, 0.2, 0.4, 0.6, 0.3, 0.0])
 
-        npt.assert_almost_equal(
-            flow_graph.accumulate(np.ones(elevation.shape)),
-            np.r_[2.2, 4.4, 11.0, 4.4, 2.2, 2.2, 4.4, 6.6],
-        )
+        new_elevation = flow_graph.update_routes(elevation)
 
+        npt.assert_array_equal(elevation, new_elevation)
+
+        acc = np.empty_like(elevation)
+        src = np.ones_like(elevation)
+        expected = np.array([4.0, 2.0, 6.0, 4.0, 2.0, 2.0, 4.0, 6.0])
+
+        flow_graph.accumulate(acc, 1.0)
+        npt.assert_array_equal(acc, expected)
+
+        flow_graph.accumulate(acc, src)
+        npt.assert_array_equal(acc, expected)
+
+        npt.assert_almost_equal(flow_graph.accumulate(1.0), expected)
+        npt.assert_almost_equal(flow_graph.accumulate(src), expected)
+
+        # bottom border base-level
+        bottom_base_level = [
+            NodeStatus.CORE,
+            NodeStatus.CORE,
+            NodeStatus.CORE,
+            NodeStatus.FIXED_VALUE_BOUNDARY,
+        ]
+
+        # --- test raster grid
         grid = RasterGrid(
             [4, 4],
-            [1.1, 1.2],
-            RasterBoundaryStatus(NodeStatus.FIXED_VALUE_BOUNDARY),
+            [1.0, 1.0],
+            RasterBoundaryStatus(bottom_base_level),
             [],
         )
         flow_graph = FlowGraph(grid, SingleFlowRouter(), NoSinkResolver())
+
+        # planar surface tilted along the y-axis + small carved channel
         elevation = np.array(
             [
-                [0.82, 0.16, 0.14, 0.20],
-                [0.71, 0.97, 0.41, 0.09],
-                [0.49, 0.01, 0.19, 0.38],
-                [0.29, 0.82, 0.09, 0.88],
+                [0.6, 0.6, 0.6, 0.6],
+                [0.4, 0.4, 0.4, 0.4],
+                [0.2, 0.2, 0.2, 0.2],
+                [0.1, 0.0, 0.1, 0.1],
             ]
         )
 
-        graph_elevation = flow_graph.update_routes(elevation)
+        new_elevation = flow_graph.update_routes(elevation)
+        npt.assert_array_equal(elevation, new_elevation)
 
+        acc = np.empty_like(elevation)
+        src = np.ones_like(elevation)
         expected = np.array(
             [
-                [1.32, 2.64, 3.96, 1.32],
-                [1.32, 1.32, 1.32, 9.24],
-                [1.32, 11.88, 1.32, 1.32],
-                [1.32, 1.32, 2.64, 1.32],
+                [1.0, 1.0, 1.0, 1.0],
+                [2.0, 2.0, 2.0, 2.0],
+                [3.0, 3.0, 3.0, 3.0],
+                [1.0, 10.0, 1.0, 4.0],
             ]
         )
-        npt.assert_almost_equal(
-            flow_graph.accumulate(np.ones(elevation.shape)), expected
-        )
+
+        flow_graph.accumulate(acc, 1.0)
+        npt.assert_array_equal(acc, expected)
+
+        flow_graph.accumulate(acc, src)
+        npt.assert_array_equal(acc, expected)
 
         npt.assert_almost_equal(flow_graph.accumulate(1.0), expected)
-
-        npt.assert_almost_equal(flow_graph.accumulate(5.0), 5 * expected)
-
-        data = np.array(
-            [
-                [1.1, 1.0, 1.1, 1.0],
-                [1.1, 1.0, 1.1, 1.0],
-                [1.1, 1.0, 1.1, 1.0],
-                [1.1, 1.0, 1.1, 1.0],
-            ]
-        )
-        expected = np.array(
-            [
-                [1.452, 2.772, 4.224, 1.32],
-                [1.452, 1.32, 1.452, 9.636],
-                [1.452, 12.54, 1.452, 1.32],
-                [1.452, 1.32, 2.772, 1.32],
-            ]
-        )
-        npt.assert_almost_equal(flow_graph.accumulate(data), expected)
+        npt.assert_almost_equal(flow_graph.accumulate(src), expected)

--- a/python/fastscapelib/tests/test_flow_router.py
+++ b/python/fastscapelib/tests/test_flow_router.py
@@ -25,26 +25,36 @@ class TestSingleFlowRouter:
         cls.profile_flow_graph = FlowGraph(
             profile_grid, SingleFlowRouter(), NoSinkResolver()
         )
-        cls.profile_elevation = np.r_[0.82, 0.16, 0.14, 0.20, 0.71, 0.97, 0.41, 0.09]
+        cls.profile_elevation = np.array([0.0, 0.2, 0.1, 0.2, 0.4, 0.6, 0.3, 0.0])
         cls.result_profile_elevation = cls.profile_flow_graph.update_routes(
             cls.profile_elevation
         )
 
+        # bottom border base level
+        bottom_base_level = [
+            NodeStatus.CORE,
+            NodeStatus.CORE,
+            NodeStatus.CORE,
+            NodeStatus.FIXED_VALUE_BOUNDARY,
+        ]
+
         raster_grid = RasterGrid(
             [4, 4],
-            [1.1, 1.2],
-            RasterBoundaryStatus(NodeStatus.FIXED_VALUE_BOUNDARY),
+            [1.0, 1.0],
+            RasterBoundaryStatus(bottom_base_level),
             [],
         )
         cls.raster_flow_graph = FlowGraph(
             raster_grid, SingleFlowRouter(), NoSinkResolver()
         )
+
+        # planar surface tilted along the y-axis + small carved channel
         cls.raster_elevation = np.array(
             [
-                [0.82, 0.16, 0.14, 0.20],
-                [0.71, 0.97, 0.41, 0.09],
-                [0.49, 0.01, 0.19, 0.38],
-                [0.29, 0.82, 0.09, 0.88],
+                [0.6, 0.6, 0.6, 0.6],
+                [0.4, 0.4, 0.4, 0.4],
+                [0.2, 0.2, 0.2, 0.2],
+                [0.1, 0.0, 0.1, 0.1],
             ]
         )
         cls.result_raster_elevation = cls.raster_flow_graph.update_routes(
@@ -52,20 +62,21 @@ class TestSingleFlowRouter:
         )
 
     def test___init__(self):
-        single_router = SingleFlowRouter()
+        SingleFlowRouter()
 
+        # no parameter
         with pytest.raises(TypeError):
             SingleFlowRouter(1.0)
 
     def test_receivers(self):
         npt.assert_equal(
             self.profile_flow_graph.impl().receivers()[:, 0],
-            np.r_[1, 2, 2, 2, 3, 6, 7, 7],
+            np.array([0, 0, 2, 2, 3, 6, 7, 7]),
         )
 
         npt.assert_equal(
             self.raster_flow_graph.impl().receivers()[:, 0],
-            np.r_[1, 2, 7, 7, 9, 9, 7, 7, 9, 9, 9, 7, 9, 9, 9, 14],
+            np.array([4, 5, 6, 7, 8, 9, 10, 11, 13, 13, 13, 15, 12, 13, 14, 15]),
         )
 
     def test_receivers_count(self):
@@ -76,30 +87,32 @@ class TestSingleFlowRouter:
     def test_receivers_distance(self):
         npt.assert_equal(
             self.profile_flow_graph.impl().receivers_distance()[:, 0],
-            np.r_[1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0] * 2.2,
+            np.array([0, 1, 0, 1, 1, 1, 1, 0]) * 2.2,
         )
 
-        dia = np.sqrt(1.1**2 + 1.2**2)
+        dia = np.sqrt(2)
         npt.assert_equal(
             self.raster_flow_graph.impl().receivers_distance()[:, 0],
-            np.r_[
-                1.2,
-                1.2,
-                dia,
-                1.1,
-                dia,
-                1.1,
-                1.2,
-                0.0,
-                1.2,
-                0.0,
-                1.2,
-                1.1,
-                dia,
-                1.1,
-                dia,
-                1.2,
-            ],
+            np.array(
+                [
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    1.0,
+                    dia,
+                    1.0,
+                    dia,
+                    1.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                    0.0,
+                ]
+            ),
         )
 
     def test_receivers_weight(self):
@@ -119,48 +132,74 @@ class TestSingleFlowRouter:
 
     def test_donors(self):
         m = np.iinfo(np.uint64).max
-        expected_donors = np.full((8, 3), m)
-        expected_donors[1, 0] = 0
-        expected_donors[2, :] = np.r_[1, 2, 3]
-        expected_donors[3, 0] = 4
-        expected_donors[6, 0] = 5
-        expected_donors[7, :2] = np.r_[6, 7]
+        expected_donors = (
+            np.array(
+                [
+                    [1, m, m],
+                    [m, m, m],
+                    [2, 3, m],
+                    [4, m, m],
+                    [m, m, m],
+                    [m, m, m],
+                    [5, m, m],
+                    [6, m, m],
+                ]
+            ),
+        )
+        npt.assert_equal(
+            self.profile_flow_graph.impl().donors(), np.squeeze(expected_donors)
+        )
 
-        npt.assert_equal(self.profile_flow_graph.impl().donors(), expected_donors)
-
-        expected_donors = np.full((16, 9), m)
-        expected_donors[1, 0] = 0
-        expected_donors[2, 0] = 1
-        expected_donors[7, :5] = np.r_[2, 3, 6, 7, 11]
-        expected_donors[9, :8] = np.r_[4, 5, 8, 9, 10, 12, 13, 14]
-        expected_donors[14, 0] = 15
-
-        npt.assert_equal(self.raster_flow_graph.impl().donors(), expected_donors)
+        expected_donors = (
+            np.array(
+                [
+                    [m, m, m, m, m, m, m, m, m],
+                    [m, m, m, m, m, m, m, m, m],
+                    [m, m, m, m, m, m, m, m, m],
+                    [m, m, m, m, m, m, m, m, m],
+                    [0, m, m, m, m, m, m, m, m],
+                    [1, m, m, m, m, m, m, m, m],
+                    [2, m, m, m, m, m, m, m, m],
+                    [3, m, m, m, m, m, m, m, m],
+                    [4, m, m, m, m, m, m, m, m],
+                    [5, m, m, m, m, m, m, m, m],
+                    [6, m, m, m, m, m, m, m, m],
+                    [7, m, m, m, m, m, m, m, m],
+                    [m, m, m, m, m, m, m, m, m],
+                    [8, 9, 10, m, m, m, m, m, m],
+                    [m, m, m, m, m, m, m, m, m],
+                    [11, m, m, m, m, m, m, m, m],
+                ]
+            ),
+        )
+        npt.assert_equal(
+            self.raster_flow_graph.impl().donors(), np.squeeze(expected_donors)
+        )
 
     def test_donors_count(self):
         npt.assert_equal(
-            self.profile_flow_graph.impl().donors_count(), np.r_[0, 1, 3, 1, 0, 0, 1, 2]
+            self.profile_flow_graph.impl().donors_count(), np.r_[1, 0, 2, 1, 0, 0, 1, 1]
         )
 
         npt.assert_equal(
             self.raster_flow_graph.impl().donors_count(),
-            np.r_[0, 1, 1, 0, 0, 0, 0, 5, 0, 8, 0, 0, 0, 0, 1, 0],
+            np.array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 0, 3, 0, 1]),
         )
 
     def test_dfs_stack(self):
         npt.assert_equal(
-            self.profile_flow_graph.impl().dfs_stack(), np.r_[2, 1, 0, 3, 4, 7, 6, 5]
+            self.profile_flow_graph.impl().dfs_stack(), np.r_[0, 1, 2, 3, 4, 7, 6, 5]
         )
 
         npt.assert_equal(
             self.raster_flow_graph.impl().dfs_stack(),
-            np.r_[7, 2, 1, 0, 3, 6, 11, 9, 4, 5, 8, 10, 12, 13, 14, 15],
+            np.array([12, 13, 8, 4, 0, 9, 5, 1, 10, 6, 2, 14, 15, 11, 7, 3]),
         )
 
 
 class TestMultipleFlowRouter:
     def test___init__(self):
-        multiple_router = MultipleFlowRouter(1.0, 1.5)
+        MultipleFlowRouter(1.0, 1.5)
 
         with pytest.raises(TypeError):
             MultipleFlowRouter(1.0)

--- a/python/src/eroders.cpp
+++ b/python/src/eroders.cpp
@@ -18,23 +18,6 @@ namespace fs = fastscapelib;
 
 
 template <class K, class T>
-auto
-erode_stream_power_py(xt::pyarray<T, xt::layout_type::row_major>& erosion,
-                      const xt::pyarray<T, xt::layout_type::row_major>& elevation,
-                      const xt::pyarray<T, xt::layout_type::row_major>& drainage_area,
-                      fs::py_flow_graph& flow_graph,
-                      const K k_coef,
-                      double m_exp,
-                      double n_exp,
-                      double dt,
-                      double tolerance) -> std::size_t
-{
-    py::gil_scoped_release release;
-    return fs::erode_stream_power(
-        erosion, elevation, drainage_area, flow_graph, k_coef, m_exp, n_exp, dt, tolerance);
-}
-
-template <class K, class T>
 void
 erode_linear_diffusion_py(xt::pytensor<T, 2>& erosion,
                           const xt::pytensor<T, 2>& elevation,
@@ -51,8 +34,8 @@ erode_linear_diffusion_py(xt::pytensor<T, 2>& erosion,
 void
 add_spl_bindings(py::module& m)
 {
-    using data_array_type = fs::xt_array_t<fs::py_selector, double>;
     using py_spl_eroder = fs::spl_eroder<fs::py_flow_graph, fs::py_selector>;
+    using data_array_type = py_spl_eroder::data_array_type;
 
     py::class_<py_spl_eroder>(m, "SPLEroder")
         .def(py::init<fs::py_flow_graph&, double, double, double, double>())
@@ -65,27 +48,16 @@ add_spl_bindings(py::module& m)
                           {
                               self.set_k_coef(value.cast<double>());
                           }
-                          else if (py::isinstance<data_array_type&>(value))
+                          else if (py::isinstance<data_array_type>(value))
                           {
-                              self.set_k_coef(value.cast<data_array_type&>());
+                              self.set_k_coef(value.cast<data_array_type>());
                           }
                       })
-        .def_property("m_exp", &py_spl_eroder::m_exp, &py_spl_eroder::set_m_exp)
-        .def_property("m_exp", &py_spl_eroder::n_exp, &py_spl_eroder::set_n_exp)
+        .def_property("area_exp", &py_spl_eroder::area_exp, &py_spl_eroder::set_area_exp)
+        .def_property("slope_exp", &py_spl_eroder::slope_exp, &py_spl_eroder::set_slope_exp)
         .def_property_readonly("tolerance", &py_spl_eroder::tolerance)
         .def_property_readonly("n_corr", &py_spl_eroder::n_corr)
-        .def("erode", &py_spl_eroder::erode);
-
-    m.def("erode_stream_power_d",
-          &erode_stream_power_py<double, double>,
-          "Compute bedrock channel erosion during a single time step "
-          "using the Stream Power Law.");
-
-    m.def("erode_stream_power_var_d",
-          &erode_stream_power_py<xt::pyarray<double, xt::layout_type::row_major>, double>,
-          "Compute bedrock channel erosion during a single time step "
-          "using the Stream Power Law.\n\n"
-          "Version with spatially variable stream power coefficient.");
+        .def("erode", &py_spl_eroder::erode, py::call_guard<py::gil_scoped_release>());
 }
 
 

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -32,10 +32,19 @@ add_flow_graph_bindings(py::module& m)
     pyfgraph.def("impl", &fs::py_flow_graph::impl, py::return_value_policy::reference);
 
     pyfgraph.def("update_routes", &fs::py_flow_graph::update_routes);
+
+    using data_array_type = fs::py_flow_graph::data_array_type;
+    using data_type = fs::py_flow_graph::data_type;
+
     pyfgraph
         .def("accumulate",
-             py::overload_cast<const xt::pyarray<double, xt::layout_type::row_major>&>(
+             py::overload_cast<data_array_type&, const data_array_type&>(
                  &fs::py_flow_graph::accumulate, py::const_))
         .def("accumulate",
-             py::overload_cast<const double&>(&fs::py_flow_graph::accumulate, py::const_));
+             py::overload_cast<data_array_type&, data_type>(&fs::py_flow_graph::accumulate,
+                                                            py::const_))
+        .def("accumulate",
+             py::overload_cast<const data_array_type&>(&fs::py_flow_graph::accumulate, py::const_))
+        .def("accumulate",
+             py::overload_cast<data_type>(&fs::py_flow_graph::accumulate, py::const_));
 }

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -207,8 +207,8 @@ namespace fastscapelib
     /**
      * Flow graph facade class for Python bindings.
      *
-     * It implements type erasure in order to expose
-     * a single class to Python for all grid types.
+     * It implements type erasure in order to expose a single class to Python
+     * for all grid, flow router and sink resolver types.
      *
      */
     class py_flow_graph;
@@ -223,10 +223,12 @@ namespace fastscapelib
             using size_type = std::size_t;
             using data_type = double;
             using data_array_type = xt_array_t<py_selector, data_type>;
+            using shape_type = data_array_type::shape_type;
 
             virtual ~flow_graph_wrapper_base(){};
 
             virtual size_type size() const = 0;
+            virtual shape_type grid_shape() const = 0;
 
             virtual const py_flow_graph_impl& impl() const = 0;
 
@@ -244,9 +246,6 @@ namespace fastscapelib
         public:
             using flow_graph_type = fs::flow_graph<G, FR, SR, fs::py_selector>;
 
-            using size_type = typename flow_graph_wrapper_base::size_type;
-            using data_type = typename flow_graph_wrapper_base::data_type;
-
             flow_graph_wrapper(G& grid, const FR& router, const SR& resolver)
             {
                 p_graph = std::make_unique<flow_graph_type>(grid, router, resolver);
@@ -258,6 +257,11 @@ namespace fastscapelib
             size_type size() const
             {
                 return p_graph->size();
+            };
+
+            shape_type grid_shape() const
+            {
+                return p_graph->grid_shape();
             };
 
             const py_flow_graph_impl& impl() const
@@ -300,25 +304,21 @@ namespace fastscapelib
         using size_type = std::size_t;
         using data_type = double;
         using data_array_type = xt_array_t<py_selector, data_type>;
+        using shape_type = data_array_type::shape_type;
 
         template <class G, class FR, class SR>
         py_flow_graph(G& grid, const FR& router, const SR& resolver)
             : p_wrapped_graph(
                 std::make_unique<detail::flow_graph_wrapper<G, FR, SR>>(grid, router, resolver)){};
-        // : p_grid(std::make_unique<py_grid>(grid))
-
-        // TODO: add `py_grid`, which wraps `fs::grid<D>` with type erasure
-        // and only exposes partial API (shape, size, etc. but no neighbors
-        // methods or iterators)
-
-        // py_grid& grid() const
-        // {
-        //     return *p_grid;
-        // }
 
         size_type size() const
         {
             return p_wrapped_graph->size();
+        };
+
+        shape_type grid_shape() const
+        {
+            return p_wrapped_graph->grid_shape();
         };
 
         const py_flow_graph_impl& impl() const
@@ -350,7 +350,6 @@ namespace fastscapelib
 
     private:
         std::unique_ptr<detail::flow_graph_wrapper_base> p_wrapped_graph;
-        // std::unique_ptr<py_grid> p_grid;
     };
 
 

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -44,9 +44,9 @@ namespace fastscapelib
         public:
             using neighbors_count_type = std::uint8_t;
             using grid_data_type = double;
-            using index_type = std::size_t;
+            using size_type = std::size_t;
 
-            using donors_type = xt_tensor_t<py_selector, index_type, 2>;
+            using donors_type = xt_tensor_t<py_selector, size_type, 2>;
             using donors_count_type = xt_tensor_t<py_selector, neighbors_count_type, 1>;
 
             using receivers_type = donors_type;
@@ -54,7 +54,7 @@ namespace fastscapelib
             using receivers_weight_type = xt_tensor_t<py_selector, double, 2>;
             using receivers_distance_type = xt_tensor_t<py_selector, grid_data_type, 2>;
 
-            using stack_type = xt_tensor_t<py_selector, index_type, 1>;
+            using stack_type = xt_tensor_t<py_selector, size_type, 1>;
 
             virtual ~flow_graph_impl_wrapper_base(){};
 
@@ -80,7 +80,7 @@ namespace fastscapelib
         public:
             using flow_graph_impl_type = FG;
 
-            using index_type = typename flow_graph_impl_wrapper_base::index_type;
+            using size_type = typename flow_graph_impl_wrapper_base::size_type;
             using neighbors_count_type =
                 typename flow_graph_impl_wrapper_base::neighbors_count_type;
             using grid_data_type = typename flow_graph_impl_wrapper_base::grid_data_type;
@@ -144,11 +144,11 @@ namespace fastscapelib
     class py_flow_graph_impl
     {
     public:
-        using index_type = std::size_t;
+        using size_type = std::size_t;
         using neighbors_count_type = std::uint8_t;
         using grid_data_type = double;
 
-        using donors_type = xt_tensor_t<py_selector, index_type, 2>;
+        using donors_type = xt_tensor_t<py_selector, size_type, 2>;
         using donors_count_type = xt_tensor_t<py_selector, neighbors_count_type, 1>;
 
         using receivers_type = donors_type;
@@ -156,7 +156,7 @@ namespace fastscapelib
         using receivers_weight_type = xt_tensor_t<py_selector, double, 2>;
         using receivers_distance_type = xt_tensor_t<py_selector, grid_data_type, 2>;
 
-        using stack_type = xt_tensor_t<py_selector, index_type, 1>;
+        using stack_type = xt_tensor_t<py_selector, size_type, 1>;
 
 
         template <class FG>
@@ -220,12 +220,12 @@ namespace fastscapelib
         class flow_graph_wrapper_base
         {
         public:
-            using index_type = std::size_t;
+            using size_type = std::size_t;
             using data_type = xt_array_t<py_selector, double>;
 
             virtual ~flow_graph_wrapper_base(){};
 
-            virtual index_type size() const = 0;
+            virtual size_type size() const = 0;
 
             virtual const py_flow_graph_impl& impl() const = 0;
 
@@ -242,7 +242,7 @@ namespace fastscapelib
         public:
             using flow_graph_type = fs::flow_graph<G, FR, SR, fs::py_selector>;
 
-            using index_type = typename flow_graph_wrapper_base::index_type;
+            using size_type = typename flow_graph_wrapper_base::size_type;
             using data_type = typename flow_graph_wrapper_base::data_type;
 
             flow_graph_wrapper(G& grid, const FR& router, const SR& resolver)
@@ -253,7 +253,7 @@ namespace fastscapelib
 
             virtual ~flow_graph_wrapper(){};
 
-            index_type size() const
+            size_type size() const
             {
                 return p_graph->size();
             };
@@ -288,15 +288,28 @@ namespace fastscapelib
     class py_flow_graph
     {
     public:
-        using index_type = std::size_t;
+        using size_type = std::size_t;
         using data_type = xt_array_t<py_selector, double>;
+
+        /*
+         * grid_type facade (need to redefine it here - at least partially - as
+         * the template parameter has been erased and also because py_flow_graph
+         * may be reused as template argument for other classes like eroders).
+         *
+         */
+        struct grid_type
+        {
+            using size_type = std::size_t;
+            using shape_type = xt_array_t<py_selector, double>::shape_type;
+            using grid_data_type = double;
+        };
 
         template <class G, class FR, class SR>
         py_flow_graph(G& grid, const FR& router, const SR& resolver)
             : p_wrapped_graph(
                 std::make_unique<detail::flow_graph_wrapper<G, FR, SR>>(grid, router, resolver)){};
 
-        index_type size() const
+        size_type size() const
         {
             return p_wrapped_graph->size();
         };

--- a/test/test_flow_graph.cpp
+++ b/test/test_flow_graph.cpp
@@ -53,11 +53,11 @@ namespace fastscapelib
             graph.update_routes(elevation);
             graph.update_routes(elevation);  // check there is not memory effect
 
-            xt::xtensor<size_type, 1> expected_fixed_receivers{ 4,  5,  6,  7,  8,  9,  10, 11,
-                                                                13, 13, 13, 15, 12, 13, 14, 15 };
+            xt::xtensor<size_type, 1> expected_receivers{ 4,  5,  6,  7,  8,  9,  10, 11,
+                                                          13, 13, 13, 15, 12, 13, 14, 15 };
 
             EXPECT_TRUE(
-                xt::all(xt::equal(xt::col(graph.impl().receivers(), 0), expected_fixed_receivers)));
+                xt::all(xt::equal(xt::col(graph.impl().receivers(), 0), expected_receivers)));
         }
 
         TEST_F(flow_graph, accumulate)

--- a/test/test_flow_graph.cpp
+++ b/test/test_flow_graph.cpp
@@ -24,15 +24,18 @@ namespace fastscapelib
             using grid_type = fs::raster_grid;
             using size_type = typename grid_type::size_type;
 
-            fs::node_status fb = fs::node_status::fixed_value_boundary;
-            fs::raster_boundary_status fixed_value_status{ fb };
+            // bottom border base-level
+            fs::node_status fixed = fs::node_status::fixed_value_boundary;
+            fs::node_status core = fs::node_status::core;
+            fs::raster_boundary_status bottom_base_level{ { core, core, core, fixed } };
 
-            grid_type grid = grid_type({ 4, 4 }, { 1.1, 1.2 }, fixed_value_status);
+            grid_type grid = grid_type({ 4, 4 }, { 1.0, 1.0 }, bottom_base_level);
 
-            xt::xtensor<double, 2> elevation{ { 0.82, 0.16, 0.14, 0.20 },
-                                              { 0.71, 0.97, 0.41, 0.09 },
-                                              { 0.49, 0.01, 0.19, 0.38 },
-                                              { 0.29, 0.82, 0.09, 0.88 } };
+            // planar surface tilted along the y-axis + small carved channel
+            xt::xtensor<double, 2> elevation{ { 0.6, 0.6, 0.6, 0.6 },
+                                              { 0.4, 0.4, 0.4, 0.4 },
+                                              { 0.2, 0.2, 0.2, 0.2 },
+                                              { 0.1, 0.0, 0.1, 0.1 } };
         };
 
         TEST_F(flow_graph, ctor)
@@ -40,7 +43,7 @@ namespace fastscapelib
             auto graph
                 = fs::make_flow_graph(grid, fs::single_flow_router(), fs::no_sink_resolver());
 
-            EXPECT_EQ(graph.grid().size(), 16u);  // dummy test
+            EXPECT_EQ(graph.size(), 16u);
         }
 
         TEST_F(flow_graph, update_routes)
@@ -50,8 +53,8 @@ namespace fastscapelib
             graph.update_routes(elevation);
             graph.update_routes(elevation);  // check there is not memory effect
 
-            xt::xtensor<size_type, 1> expected_fixed_receivers{ 1, 2, 7, 7, 9, 9, 7, 7,
-                                                                9, 9, 9, 7, 9, 9, 9, 14 };
+            xt::xtensor<size_type, 1> expected_fixed_receivers{ 4,  5,  6,  7,  8,  9,  10, 11,
+                                                                13, 13, 13, 15, 12, 13, 14, 15 };
 
             EXPECT_TRUE(
                 xt::all(xt::equal(xt::col(graph.impl().receivers(), 0), expected_fixed_receivers)));
@@ -61,28 +64,23 @@ namespace fastscapelib
         {
             auto graph
                 = fs::make_flow_graph(grid, fs::single_flow_router(), fs::no_sink_resolver());
+
             graph.update_routes(elevation);
 
-            xt::xtensor<double, 2> data1 = xt::ones_like(elevation);
-            xt::xtensor<double, 2> data2{ { 1.1, 1.0, 1.1, 1.0 },
-                                          { 1.1, 1.0, 1.1, 1.0 },
-                                          { 1.1, 1.0, 1.1, 1.0 },
-                                          { 1.1, 1.0, 1.1, 1.0 } };
+            xt::xarray<double> acc = xt::empty_like(elevation);
+            xt::xtensor<double, 2> src = xt::ones_like(elevation);
+            xt::xtensor<double, 2> expected{
+                { 1., 1., 1., 1. }, { 2., 2., 2., 2. }, { 3., 3., 3., 3. }, { 1., 10., 1., 4. }
+            };
 
-            xt::xtensor<double, 2> expected1{ { 1.32, 2.64, 3.96, 1.32 },
-                                              { 1.32, 1.32, 1.32, 9.24 },
-                                              { 1.32, 11.88, 1.32, 1.32 },
-                                              { 1.32, 1.32, 2.64, 1.32 } };
+            graph.accumulate(acc, 1.);
+            EXPECT_TRUE(xt::allclose(expected, acc));
 
-            xt::xtensor<double, 2> expected2{ { 1.452, 2.772, 4.224, 1.32 },
-                                              { 1.452, 1.32, 1.452, 9.636 },
-                                              { 1.452, 12.54, 1.452, 1.32 },
-                                              { 1.452, 1.32, 2.772, 1.32 } };
+            graph.accumulate(acc, src);
+            EXPECT_TRUE(xt::allclose(expected, acc));
 
-            EXPECT_TRUE(xt::allclose(expected1, graph.accumulate(data1)));
-            EXPECT_TRUE(xt::allclose(expected1, graph.accumulate(1.)));
-            EXPECT_TRUE(xt::allclose(expected1 * 5., graph.accumulate(5.)));
-            EXPECT_TRUE(xt::allclose(expected2, graph.accumulate(data2)));
+            EXPECT_TRUE(xt::allclose(expected, graph.accumulate(src)));
+            EXPECT_TRUE(xt::allclose(expected, graph.accumulate(1.)));
         }
     }
 }

--- a/test/test_flow_router.cpp
+++ b/test/test_flow_router.cpp
@@ -28,18 +28,18 @@ namespace fastscapelib
             : public flow_router_impl_base<FG, test_flow_router>
         {
         public:
-            using graph_type = FG;
-            using base_type = flow_router_impl_base<graph_type, test_flow_router>;
+            using graph_impl_type = FG;
+            using base_type = flow_router_impl_base<graph_impl_type, test_flow_router>;
 
-            using elevation_type = typename graph_type::elevation_type;
+            using data_array_type = typename graph_impl_type::data_array_type;
 
             static constexpr size_t n_receivers = 0;
 
-            flow_router_impl(graph_type& graph, const test_flow_router& router)
+            flow_router_impl(graph_impl_type& graph, const test_flow_router& router)
                 : base_type(graph, router){};
 
-            void route1(const elevation_type& /*elevation*/){};
-            void route2(const elevation_type& /*elevation*/){};
+            void route1(const data_array_type& /*elevation*/){};
+            void route2(const data_array_type& /*elevation*/){};
         };
     }
 

--- a/test/test_sink_resolver.cpp
+++ b/test/test_sink_resolver.cpp
@@ -27,28 +27,28 @@ namespace fastscapelib
             : public sink_resolver_impl_base<FG, test_sink_resolver>
         {
         public:
-            using graph_type = FG;
-            using base_type = sink_resolver_impl_base<graph_type, test_sink_resolver>;
+            using graph_impl_type = FG;
+            using base_type = sink_resolver_impl_base<graph_impl_type, test_sink_resolver>;
 
-            using elevation_type = typename graph_type::elevation_type;
+            using data_array_type = typename graph_impl_type::data_array_type;
 
-            sink_resolver_impl(graph_type& graph, const test_sink_resolver& resolver)
+            sink_resolver_impl(graph_impl_type& graph, const test_sink_resolver& resolver)
                 : base_type(graph, resolver)
-                , m_elevation(elevation_type({ 0 })){};
+                , m_elevation(data_array_type({ 0 })){};
 
-            const elevation_type& resolve1(const elevation_type& elevation)
+            const data_array_type& resolve1(const data_array_type& elevation)
             {
                 m_elevation = elevation + 10.;
                 return m_elevation;
             };
-            const elevation_type& resolve2(const elevation_type& elevation)
+            const data_array_type& resolve2(const data_array_type& elevation)
             {
                 m_elevation = elevation + 5.;
                 return m_elevation;
             };
 
         private:
-            elevation_type m_elevation;
+            data_array_type m_elevation;
         };
     }
 


### PR DESCRIPTION
Closes #47.

Use a class for each eroder instead of functions, with an erode `erode()` method that returns an erosion field (todo later: add an overload so that it updates the elevation in-place).

- [x] `spl_eroder`
- [ ] `diffusion_adi_eroder` (raster grid only)

Notes:

Also refactored `flow_graph.accumulate()` here. It is now possible to pass on a accumulated array so that we don't need to re-allocate it at each time step.

Also fixed invalid boundary condition handling by single flow router (and refactored the tests).

Also cleaned-up type aliases so that it is more consistent in grid / flow_graph / eroder classes.