### PR TITLE
Add multi- and singlemulti- flow routers

### DIFF
--- a/include/fastscapelib/flow/basin_graph.hpp
+++ b/include/fastscapelib/flow/basin_graph.hpp
@@ -90,8 +90,6 @@ namespace fastscapelib
             , m_mst_method(basin_method)
         {
             m_perf_boruvka = 0;
-
-            // TODO: check shape of receivers (should be single flow)
         }
 
         inline size_type basins_count() const
@@ -216,6 +214,8 @@ namespace fastscapelib
     template <class FG>
     void basin_graph<FG>::update_routes(const data_array_type& elevation)
     {
+        // TODO: check single flow (flow graph receivers_count all equal to 1)
+
         connect_basins(elevation);
 
         if (m_mst_method == mst_method::kruskal)

--- a/include/fastscapelib/flow/flow_graph.hpp
+++ b/include/fastscapelib/flow/flow_graph.hpp
@@ -96,9 +96,9 @@ namespace fastscapelib
             return m_graph_impl;
         }
 
-        const std::map<std::string, flow_graph_impl_type>& embedded_graphs() const
+        const std::map<std::string, flow_graph_impl_type>& impl_embedded() const
         {
-            return m_router_impl.embedded_graphs();
+            return m_router_impl.impl_embedded();
         }
 
         void accumulate(data_array_type& acc, const data_array_type& src) const

--- a/include/fastscapelib/flow/flow_graph.hpp
+++ b/include/fastscapelib/flow/flow_graph.hpp
@@ -9,7 +9,9 @@
 #ifndef FASTSCAPELIB_FLOW_FLOW_GRAPH_H
 #define FASTSCAPELIB_FLOW_FLOW_GRAPH_H
 
+#include <map>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 
 #include "xtensor/xstrided_view.hpp"
@@ -92,6 +94,11 @@ namespace fastscapelib
         const flow_graph_impl_type& impl() const
         {
             return m_graph_impl;
+        }
+
+        const std::map<std::string, flow_graph_impl_type>& embedded_graphs() const
+        {
+            return m_router_impl.embedded_graphs();
         }
 
         void accumulate(data_array_type& acc, const data_array_type& src) const

--- a/include/fastscapelib/flow/flow_graph_impl.hpp
+++ b/include/fastscapelib/flow/flow_graph_impl.hpp
@@ -6,8 +6,6 @@
 #include <vector>
 
 #include "xtensor/xbroadcast.hpp"
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xview.hpp"
 
 #include "fastscapelib/grid/base.hpp"
 #include "fastscapelib/utils/xtensor_utils.hpp"

--- a/include/fastscapelib/flow/flow_graph_impl.hpp
+++ b/include/fastscapelib/flow/flow_graph_impl.hpp
@@ -1,6 +1,7 @@
 #ifndef FASTSCAPELIB_FLOW_GRAPH_IMPL_H_
 #define FASTSCAPELIB_FLOW_GRAPH_IMPL_H_
 
+#include <algorithm>
 #include <array>
 #include <stack>
 #include <vector>
@@ -142,27 +143,27 @@ namespace fastscapelib
                 return m_dfs_indices;
             };
 
-            void compute_dfs_indices_downup();
-            void compute_dfs_indices_updown();
+            void compute_dfs_indices_bottomup();
+            void compute_dfs_indices_topdown();
 
-            // const_dfs_iterator dfs_cbegin()
-            // {
-            //     return m_dfs_indices.cbegin();
-            // };
-
-            // const_dfs_iterator dfs_cend()
-            // {
-            //     return m_dfs_indices.cend();
-            // };
-
-            // const_reverse_dfs_iterator dfs_crbegin()
+            // const_reverse_dfs_iterator topdown_begin() const
             // {
             //     return m_dfs_indices.crbegin();
             // };
 
-            // const_reverse_dfs_iterator dfs_crend()
+            // const_reverse_dfs_iterator topdown_end() const
             // {
             //     return m_dfs_indices.crend();
+            // };
+
+            // const_dfs_iterator bottomup_begin() const
+            // {
+            //     return m_dfs_indices.cbegin();
+            // };
+
+            // const_dfs_iterator bottomup_end() const
+            // {
+            //     return m_dfs_indices.cend();
             // };
 
             const std::vector<size_type>& outlets() const
@@ -232,7 +233,7 @@ namespace fastscapelib
          * and store the node indices for faster graph traversal.
          */
         template <class G, class S>
-        void flow_graph_impl<G, S, flow_graph_fixed_array_tag>::compute_dfs_indices_downup()
+        void flow_graph_impl<G, S, flow_graph_fixed_array_tag>::compute_dfs_indices_bottomup()
         {
             size_type nstack = 0;
 
@@ -269,9 +270,11 @@ namespace fastscapelib
         /*
          * Perform depth-first search in the upstream->dowstream direction
          * and store the node indices for faster graph traversal.
+         *
+         * Note: indices are stored in the downstream->upstream direction!
          */
         template <class G, class S>
-        void flow_graph_impl<G, S, flow_graph_fixed_array_tag>::compute_dfs_indices_updown()
+        void flow_graph_impl<G, S, flow_graph_fixed_array_tag>::compute_dfs_indices_topdown()
         {
             size_type nstack = 0;
             std::stack<size_type> tmp;
@@ -306,6 +309,9 @@ namespace fastscapelib
             }
 
             assert(nstack == size());
+
+            // downstream->upstream order
+            std::reverse(m_dfs_indices.begin(), m_dfs_indices.end());
         }
 
         template <class G, class S>

--- a/include/fastscapelib/flow/flow_router.hpp
+++ b/include/fastscapelib/flow/flow_router.hpp
@@ -152,7 +152,7 @@ namespace fastscapelib
                     donors(irec, donors_count(irec)++) = i;
                 }
 
-                this->m_graph_impl.compute_dfs_indices();
+                this->m_graph_impl.compute_dfs_indices_downup();
             };
 
             void route2(const data_array_type& /*elevation*/){};

--- a/include/fastscapelib/flow/flow_router.hpp
+++ b/include/fastscapelib/flow/flow_router.hpp
@@ -165,7 +165,7 @@ namespace fastscapelib
                     donors(irec, donors_count(irec)++) = i;
                 }
 
-                this->m_graph_impl.compute_dfs_indices_downup();
+                this->m_graph_impl.compute_dfs_indices_bottomup();
             };
 
             void route2(const data_array_type& /*elevation*/){};
@@ -262,7 +262,7 @@ namespace fastscapelib
                 }
 
                 // DFS upstream->downstream so that it works with multi-directions flow
-                this->m_graph_impl.compute_dfs_indices_updown();
+                this->m_graph_impl.compute_dfs_indices_topdown();
             };
 
             void route2(const data_array_type& /*elevation*/){};

--- a/include/fastscapelib/flow/sink_resolver.hpp
+++ b/include/fastscapelib/flow/sink_resolver.hpp
@@ -195,7 +195,7 @@ namespace fastscapelib
 
                 // finalize flow route update (donors and dfs graph traversal indices)
                 this->m_graph_impl.compute_donors();
-                this->m_graph_impl.compute_dfs_indices();
+                this->m_graph_impl.compute_dfs_indices_downup();
 
                 // fill sinks with tiny tilted surface
                 fill_sinks_sloped(elevation);

--- a/include/fastscapelib/flow/sink_resolver.hpp
+++ b/include/fastscapelib/flow/sink_resolver.hpp
@@ -194,9 +194,9 @@ namespace fastscapelib
                 }
 
                 // finalize flow route update (donors and dfs graph traversal indices)
-                // note: DFS down->up direction assumes single flow routing!
+                // note: DFS bottom->up direction assumes single flow routing!
                 this->m_graph_impl.compute_donors();
-                this->m_graph_impl.compute_dfs_indices_downup();
+                this->m_graph_impl.compute_dfs_indices_bottomup();
 
                 // fill sinks with tiny tilted surface
                 fill_sinks_sloped(elevation);

--- a/include/fastscapelib/flow/sink_resolver.hpp
+++ b/include/fastscapelib/flow/sink_resolver.hpp
@@ -194,6 +194,7 @@ namespace fastscapelib
                 }
 
                 // finalize flow route update (donors and dfs graph traversal indices)
+                // note: DFS down->up direction assumes single flow routing!
                 this->m_graph_impl.compute_donors();
                 this->m_graph_impl.compute_dfs_indices_downup();
 

--- a/python/fastscapelib/tests/test_flow_graph.py
+++ b/python/fastscapelib/tests/test_flow_graph.py
@@ -3,9 +3,10 @@ import numpy.testing as npt
 
 from fastscapelib.flow import (
     FlowGraph,
-    MultipleFlowRouter,
+    MultiFlowRouter,
     NoSinkResolver,
     SingleFlowRouter,
+    SingleMultiFlowRouter,
 )
 from fastscapelib.grid import NodeStatus, ProfileGrid, RasterBoundaryStatus, RasterGrid
 
@@ -21,7 +22,8 @@ class TestFlowGraph:
         )
 
         FlowGraph(profile_grid, SingleFlowRouter(), NoSinkResolver())
-        FlowGraph(raster_grid, MultipleFlowRouter(1.0, 1.1), NoSinkResolver())
+        FlowGraph(raster_grid, MultiFlowRouter(1.0), NoSinkResolver())
+        FlowGraph(raster_grid, SingleMultiFlowRouter(1.0), NoSinkResolver())
 
     def test_update_routes(self):
         grid = ProfileGrid(8, 2.2, [NodeStatus.FIXED_VALUE_BOUNDARY] * 2, [])

--- a/python/fastscapelib/tests/test_flow_router.py
+++ b/python/fastscapelib/tests/test_flow_router.py
@@ -4,9 +4,10 @@ import pytest
 
 from fastscapelib.flow import (
     FlowGraph,
-    MultipleFlowRouter,
+    MultiFlowRouter,
     NoSinkResolver,
     SingleFlowRouter,
+    SingleMultiFlowRouter,
 )
 from fastscapelib.grid import (
     Node,
@@ -192,12 +193,17 @@ class TestSingleFlowRouter:
         )
 
 
-class TestMultipleFlowRouter:
+class TestMultiFlowRouter:
     def test___init__(self):
-        MultipleFlowRouter(1.0, 1.5)
+        MultiFlowRouter(2.0)
 
         with pytest.raises(TypeError):
-            MultipleFlowRouter(1.0)
+            MultiFlowRouter(1.0, "a")
+
+
+class TestSingleMultiFlowRouter:
+    def test___init__(self):
+        SingleMultiFlowRouter(2.0)
 
         with pytest.raises(TypeError):
-            MultipleFlowRouter(1.0, "a")
+            SingleMultiFlowRouter(1.0, "a")

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -27,8 +27,8 @@ add_flow_graph_bindings(py::module& m)
 
     py::class_<fs::py_flow_graph> pyfgraph(m, "FlowGraph");
 
-    fs::add_init_methods<fs::py_profile_grid>(pyfgraph);
-    fs::add_init_methods<fs::py_raster_grid>(pyfgraph);
+    fs::register_init_methods<fs::py_profile_grid>(pyfgraph);
+    fs::register_init_methods<fs::py_raster_grid>(pyfgraph);
 
     pyfgraph.def("impl", &fs::py_flow_graph::impl, py::return_value_policy::reference);
 

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -3,6 +3,7 @@
 #include "xtensor-python/pytensor.hpp"
 
 #include "pybind11/pybind11.h"
+#include "pybind11/stl_bind.h"
 
 #include "grid.hpp"
 #include "flow_graph.hpp"
@@ -10,6 +11,12 @@
 
 namespace py = pybind11;
 namespace fs = fastscapelib;
+
+
+using impl_embedded_type = std::map<std::string, fs::py_flow_graph_impl&>;
+
+PYBIND11_MAKE_OPAQUE(impl_embedded_type);
+PYBIND11_MAKE_OPAQUE(std::map<std::string, int>);
 
 
 void
@@ -25,14 +32,15 @@ add_flow_graph_bindings(py::module& m)
         .def_property_readonly("dfs_indices", &fs::py_flow_graph_impl::dfs_indices)
         .def_property_readonly("basins", &fs::py_flow_graph_impl::basins);
 
+    py::bind_map<impl_embedded_type>(m, "ImplEmbedded");
+
     py::class_<fs::py_flow_graph> pyfgraph(m, "FlowGraph");
 
     fs::register_init_methods<fs::py_profile_grid>(pyfgraph);
     fs::register_init_methods<fs::py_raster_grid>(pyfgraph);
 
     pyfgraph.def("impl", &fs::py_flow_graph::impl, py::return_value_policy::reference);
-    pyfgraph.def(
-        "embedded_graphs", &fs::py_flow_graph::embedded_graphs, py::return_value_policy::reference);
+    pyfgraph.def_property_readonly("impl_embedded", &fs::py_flow_graph::impl_embedded);
 
     pyfgraph.def("update_routes", &fs::py_flow_graph::update_routes);
 

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -13,10 +13,9 @@ namespace py = pybind11;
 namespace fs = fastscapelib;
 
 
-using impl_embedded_type = std::map<std::string, fs::py_flow_graph_impl&>;
+using embedded_type = std::map<std::string, const fs::py_flow_graph_impl&>;
 
-PYBIND11_MAKE_OPAQUE(impl_embedded_type);
-PYBIND11_MAKE_OPAQUE(std::map<std::string, int>);
+PYBIND11_MAKE_OPAQUE(embedded_type);
 
 
 void
@@ -32,7 +31,7 @@ add_flow_graph_bindings(py::module& m)
         .def_property_readonly("dfs_indices", &fs::py_flow_graph_impl::dfs_indices)
         .def_property_readonly("basins", &fs::py_flow_graph_impl::basins);
 
-    py::bind_map<impl_embedded_type>(m, "ImplEmbedded");
+    py::bind_map<embedded_type>(m, "EmbeddedGraphMapping");
 
     py::class_<fs::py_flow_graph> pyfgraph(m, "FlowGraph");
 
@@ -40,7 +39,7 @@ add_flow_graph_bindings(py::module& m)
     fs::register_init_methods<fs::py_raster_grid>(pyfgraph);
 
     pyfgraph.def("impl", &fs::py_flow_graph::impl, py::return_value_policy::reference);
-    pyfgraph.def_property_readonly("impl_embedded", &fs::py_flow_graph::impl_embedded);
+    pyfgraph.def_property_readonly("embedded", &fs::py_flow_graph::embedded);
 
     pyfgraph.def("update_routes", &fs::py_flow_graph::update_routes);
 

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -31,6 +31,8 @@ add_flow_graph_bindings(py::module& m)
     fs::register_init_methods<fs::py_raster_grid>(pyfgraph);
 
     pyfgraph.def("impl", &fs::py_flow_graph::impl, py::return_value_policy::reference);
+    pyfgraph.def(
+        "embedded_graphs", &fs::py_flow_graph::embedded_graphs, py::return_value_policy::reference);
 
     pyfgraph.def("update_routes", &fs::py_flow_graph::update_routes);
 

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -241,7 +241,7 @@ namespace fastscapelib
             using data_array_type = xt_array_t<py_selector, data_type>;
             using shape_type = data_array_type::shape_type;
             using data_array_size_type = xt_array_t<py_selector, size_type>;
-            using embedded_graphs_type = std::map<std::string, std::unique_ptr<py_flow_graph_impl>>;
+            using impl_embedded_type = std::map<std::string, std::unique_ptr<py_flow_graph_impl>>;
 
             virtual ~flow_graph_wrapper_base(){};
 
@@ -249,7 +249,7 @@ namespace fastscapelib
             virtual shape_type grid_shape() const = 0;
 
             virtual const py_flow_graph_impl& impl() const = 0;
-            virtual const embedded_graphs_type& embedded_graphs() const = 0;
+            virtual const impl_embedded_type& impl_embedded() const = 0;
 
             virtual const data_array_type& update_routes(const data_array_type& elevation) = 0;
 
@@ -272,9 +272,9 @@ namespace fastscapelib
                 p_graph = std::make_unique<flow_graph_type>(grid, router, resolver);
                 p_graph_impl = std::make_unique<py_flow_graph_impl>(p_graph->impl());
 
-                for (auto const& item : p_graph->embedded_graphs())
+                for (auto const& item : p_graph->impl_embedded())
                 {
-                    m_embedded_graphs.insert(
+                    m_impl_embedded.insert(
                         { item.first, std::make_unique<py_flow_graph_impl>(item.second) });
                 }
             }
@@ -296,9 +296,9 @@ namespace fastscapelib
                 return *p_graph_impl;
             };
 
-            const embedded_graphs_type& embedded_graphs() const
+            const impl_embedded_type& impl_embedded() const
             {
-                return m_embedded_graphs;
+                return m_impl_embedded;
             }
 
             const data_array_type& update_routes(const data_array_type& elevation)
@@ -331,7 +331,7 @@ namespace fastscapelib
         private:
             std::unique_ptr<flow_graph_type> p_graph;
             std::unique_ptr<py_flow_graph_impl> p_graph_impl;
-            embedded_graphs_type m_embedded_graphs;
+            impl_embedded_type m_impl_embedded;
         };
     }
 
@@ -344,7 +344,7 @@ namespace fastscapelib
         using data_array_type = xt_array_t<py_selector, data_type>;
         using shape_type = data_array_type::shape_type;
         using data_array_size_type = xt_array_t<py_selector, size_type>;
-        using embedded_graphs_type = std::map<std::string, std::unique_ptr<py_flow_graph_impl>>;
+        using impl_embedded_type = std::map<std::string, std::unique_ptr<py_flow_graph_impl>>;
 
         template <class G, class FR, class SR>
         py_flow_graph(G& grid, const FR& router, const SR& resolver)
@@ -366,9 +366,17 @@ namespace fastscapelib
             return p_wrapped_graph->impl();
         };
 
-        const embedded_graphs_type& embedded_graphs() const
+        const std::map<std::string, py_flow_graph_impl&> impl_embedded() const
         {
-            return p_wrapped_graph->embedded_graphs();
+            // TODO: create map object in constructor
+
+            std::map<std::string, py_flow_graph_impl&> map;
+
+            for (auto const& item : p_wrapped_graph->impl_embedded())
+            {
+                map.insert({ item.first, *item.second });
+            }
+            return map;
         }
 
         const data_array_type& update_routes(const data_array_type& elevation)
@@ -407,9 +415,10 @@ namespace fastscapelib
     void register_init_methods(py::class_<py_flow_graph>& pyfg)
     {
         pyfg.def(py::init<G&, single_flow_router&, no_sink_resolver&>())
-            .def(py::init<G&, multi_flow_router&, no_sink_resolver&>())
             .def(py::init<G&, single_flow_router&, pflood_sink_resolver&>())
             .def(py::init<G&, single_flow_router&, mst_sink_resolver&>())
+            .def(py::init<G&, multi_flow_router&, no_sink_resolver&>())
+            .def(py::init<G&, multi_flow_router&, pflood_sink_resolver&>())
             .def(py::init<G&, singlemulti_flow_router&, no_sink_resolver&>())
             .def(py::init<G&, singlemulti_flow_router&, pflood_sink_resolver&>())
             .def(py::init<G&, singlemulti_flow_router&, mst_sink_resolver&>());

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -103,50 +103,50 @@ namespace fastscapelib
             virtual ~flow_graph_impl_wrapper(){};
 
             flow_graph_impl_wrapper(FG& graph_impl)
-                : p_graph_impl(graph_impl){};
+                : m_graph_impl(graph_impl){};
 
             const receivers_type& receivers() const
             {
-                return p_graph_impl.receivers();
+                return m_graph_impl.receivers();
             };
 
             const receivers_count_type& receivers_count() const
             {
-                return p_graph_impl.receivers_count();
+                return m_graph_impl.receivers_count();
             };
 
             const receivers_distance_type& receivers_distance() const
             {
-                return p_graph_impl.receivers_distance();
+                return m_graph_impl.receivers_distance();
             };
 
             const receivers_weight_type& receivers_weight() const
             {
-                return p_graph_impl.receivers_weight();
+                return m_graph_impl.receivers_weight();
             };
 
             const donors_type& donors() const
             {
-                return p_graph_impl.donors();
+                return m_graph_impl.donors();
             };
 
             const donors_count_type& donors_count() const
             {
-                return p_graph_impl.donors_count();
+                return m_graph_impl.donors_count();
             };
 
             const dfs_indices_type& dfs_indices() const
             {
-                return p_graph_impl.dfs_indices();
+                return m_graph_impl.dfs_indices();
             };
 
             const basins_type& basins() const
             {
-                return p_graph_impl.basins();
+                return m_graph_impl.basins();
             };
 
         private:
-            flow_graph_impl_type& p_graph_impl;
+            flow_graph_impl_type& m_graph_impl;
         };
     }
 

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -384,12 +384,15 @@ namespace fastscapelib
 
 
     template <class G>
-    void add_init_methods(py::class_<py_flow_graph>& pyfg)
+    void register_init_methods(py::class_<py_flow_graph>& pyfg)
     {
         pyfg.def(py::init<G&, single_flow_router&, no_sink_resolver&>())
-            .def(py::init<G&, multiple_flow_router&, no_sink_resolver&>())
+            .def(py::init<G&, multi_flow_router&, no_sink_resolver&>())
             .def(py::init<G&, single_flow_router&, pflood_sink_resolver&>())
-            .def(py::init<G&, single_flow_router&, mst_sink_resolver&>());
+            .def(py::init<G&, single_flow_router&, mst_sink_resolver&>())
+            .def(py::init<G&, singlemulti_flow_router&, no_sink_resolver&>())
+            .def(py::init<G&, singlemulti_flow_router&, pflood_sink_resolver&>())
+            .def(py::init<G&, singlemulti_flow_router&, mst_sink_resolver&>());
     }
 }
 

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -261,6 +261,12 @@ namespace fastscapelib
             virtual data_array_size_type basins() = 0;
         };
 
+        // TODO: reuse this wrapper class for wrapping embedded flow graphs
+        // Maybe this approach would work?
+        // - add a template tag to select unique_ptr vs. const reference
+        // - add another explicit constructor that takes a const reference
+        // - select constructors with the template Tag (SFINAE)
+        // - apply SFINAE to update_routes too? (disable for embedded graphs)
         template <class G, class FR, class SR>
         class flow_graph_wrapper : public flow_graph_wrapper_base
         {

--- a/python/src/flow_router.cpp
+++ b/python/src/flow_router.cpp
@@ -17,8 +17,11 @@ add_flow_routers_bindings(py::module& m)
 {
     py::class_<fs::single_flow_router>(m, "SingleFlowRouter").def(py::init());
 
-    py::class_<fs::multiple_flow_router>(m, "MultipleFlowRouter")
-        .def(py::init<double, double>())
-        .def_readwrite("p1", &fs::multiple_flow_router::p1)
-        .def_readwrite("p2", &fs::multiple_flow_router::p2);
+    py::class_<fs::multi_flow_router>(m, "MultiFlowRouter")
+        .def(py::init<double>())
+        .def_readwrite("slope_exp", &fs::multi_flow_router::slope_exp);
+
+    py::class_<fs::singlemulti_flow_router>(m, "SingleMultiFlowRouter")
+        .def(py::init<double>())
+        .def_readwrite("slope_exp", &fs::singlemulti_flow_router::slope_exp);
 }

--- a/test/test_flow_router.cpp
+++ b/test/test_flow_router.cpp
@@ -17,6 +17,7 @@ namespace fastscapelib
     struct test_flow_router
     {
         using flow_graph_impl_tag = detail::flow_graph_fixed_array_tag;
+        using embedded_router_type = single_flow_router;
         static constexpr bool is_single = true;
     };
 


### PR DESCRIPTION
- `multi_flow_router` implements multiple flow routing
- `singlemulti_flow_router` is based on `single_flow_router` and `multi_flow_router` and performs both single and multiple flow routing respectively in `route1` and `route2` (needed for using `mst_sink_resolver` with multiple flow routing).
- also implement up->down DFS graph traversal (needed for multiple flow routing)

TODO:

- [ ] expose embedded flow graphs: so that users may optionally access to (copies of) both single and multi flow graphs when using `singlemulti_flow_router` (two single flow graphs may be exposed: pre/post sink resolving)
- [ ] add tests
- [ ] add benchmarks
