### PR TITLE
Fix segfault when accessing graph snapshot implementation members (Python bindings)

### DIFF
--- a/doc/source/release_notes.md
+++ b/doc/source/release_notes.md
@@ -10,6 +10,9 @@
   {pull}`146`).
 - Fixed ``RuntimeWarning`` (invalid value in cast) issued when calling
   ``FlowGraph.basins()`` in Python ({pull}`147`).
+- Python bindings: fixed Python interpreter crash (segfault) when accessing data
+  members of the implementation of a graph snapshot via ``FlowGraph.impl()``
+  ({pull}`148`).
 
 ## v0.2.0 (9 October 2023)
 

--- a/include/fastscapelib/flow/flow_operator.hpp
+++ b/include/fastscapelib/flow/flow_operator.hpp
@@ -118,7 +118,7 @@ namespace fastscapelib
         public:
             using graph_impl_type = FG;
             using data_array_type = typename graph_impl_type::data_array_type;
-            using graph_impl_map = std::map<std::string, FG&>;
+            using graph_impl_map = std::map<std::string, std::shared_ptr<FG>>;
             using elevation_map = std::map<std::string, std::unique_ptr<data_array_type>>;
 
             void apply(FG& /*graph_impl*/, data_array_type& /*elevation*/)
@@ -180,7 +180,7 @@ namespace fastscapelib
         {
         public:
             using data_array_type = typename FG::data_array_type;
-            using graph_impl_map = std::map<std::string, FG&>;
+            using graph_impl_map = std::map<std::string, std::shared_ptr<FG>>;
             using elevation_map = std::map<std::string, std::unique_ptr<data_array_type>>;
 
             template <class OP>

--- a/include/fastscapelib/flow/flow_snapshot.hpp
+++ b/include/fastscapelib/flow/flow_snapshot.hpp
@@ -71,7 +71,7 @@ namespace fastscapelib
             using base_type = flow_operator_impl_base<FG, flow_snapshot>;
             using data_array_type = typename base_type::data_array_type;
 
-            using graph_impl_map = std::map<std::string, FG&>;
+            using graph_impl_map = std::map<std::string, std::shared_ptr<FG>>;
             using elevation_map = std::map<std::string, std::unique_ptr<data_array_type>>;
 
             flow_operator_impl(std::shared_ptr<flow_snapshot> ptr)
@@ -95,7 +95,7 @@ namespace fastscapelib
         private:
             FG& get_snapshot(graph_impl_map& graph_impl_snapshots) const
             {
-                return graph_impl_snapshots.at(this->m_op_ptr->snapshot_name());
+                return *(graph_impl_snapshots.at(this->m_op_ptr->snapshot_name()));
             }
 
             data_array_type& get_snapshot(elevation_map& elevation_snapshots) const

--- a/python/fastscapelib/tests/test_flow_snapshot.py
+++ b/python/fastscapelib/tests/test_flow_snapshot.py
@@ -103,6 +103,27 @@ def test_snapshot_graph(grid) -> None:
         snapshot_a.update_routes(elevation)
 
 
+def test_snapshot_graph_impl(grid) -> None:
+    # Ensure that this will not crash Python (segfault). The correct pybind11
+    # return value policy for accessing the implementation from a snapshot graph
+    # is "reference_internal" (we need the keep_alive call policy to prevent the
+    # parent Python graph / snapshot / impl wrappers getting garbage collected
+    # when accessing the final graph implementation data members).
+    graph = FlowGraph(
+        grid,
+        [SingleFlowRouter(), FlowSnapshot("a"), MSTSinkResolver(), FlowSnapshot("b")],
+    )
+
+    elevation = np.random.uniform(size=grid.shape)
+    graph.update_routes(elevation)
+
+    graph.graph_snapshot("a").impl().receivers
+    s = graph.graph_snapshot("a")
+    s.impl().receivers
+    simpl = s.impl()
+    simpl.receivers
+
+
 def test_snapshot_elevation(grid) -> None:
     graph = FlowGraph(
         grid,

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -411,7 +411,7 @@ add_flow_graph_bindings(py::module& m)
 
     pyfgraph.def("impl",
                  &fs::py_flow_graph::impl,
-                 py::return_value_policy::reference,
+                 py::return_value_policy::reference_internal,
                  R"doc(impl(self) -> FlowGraphImpl
 
         Graph implementation getter.

--- a/python/src/flow_graph.hpp
+++ b/python/src/flow_graph.hpp
@@ -93,61 +93,63 @@ namespace fastscapelib
         public:
             virtual ~flow_graph_impl_wrapper(){};
 
-            flow_graph_impl_wrapper(FG& graph_impl)
-                : m_graph_impl(graph_impl){};
+            flow_graph_impl_wrapper(const std::shared_ptr<FG>& graph_impl_ptr)
+                : m_graph_impl_ptr(graph_impl_ptr)
+            {
+            }
 
             bool single_flow() const
             {
-                return m_graph_impl.single_flow();
+                return m_graph_impl_ptr->single_flow();
             }
 
             const receivers_type& receivers() const
             {
-                return m_graph_impl.receivers();
+                return m_graph_impl_ptr->receivers();
             };
 
             const receivers_count_type& receivers_count() const
             {
-                return m_graph_impl.receivers_count();
+                return m_graph_impl_ptr->receivers_count();
             };
 
             const receivers_distance_type& receivers_distance() const
             {
-                return m_graph_impl.receivers_distance();
+                return m_graph_impl_ptr->receivers_distance();
             };
 
             const receivers_weight_type& receivers_weight() const
             {
-                return m_graph_impl.receivers_weight();
+                return m_graph_impl_ptr->receivers_weight();
             };
 
             const donors_type& donors() const
             {
-                return m_graph_impl.donors();
+                return m_graph_impl_ptr->donors();
             };
 
             const donors_count_type& donors_count() const
             {
-                return m_graph_impl.donors_count();
+                return m_graph_impl_ptr->donors_count();
             };
 
             const dfs_indices_type& dfs_indices() const
             {
-                return m_graph_impl.dfs_indices();
+                return m_graph_impl_ptr->dfs_indices();
             };
 
             nodes_indices_iterator_type nodes_indices_bottomup() const
             {
-                return m_graph_impl.nodes_indices_bottomup();
+                return m_graph_impl_ptr->nodes_indices_bottomup();
             }
 
             const basins_type& basins() const
             {
-                return m_graph_impl.basins();
+                return m_graph_impl_ptr->basins();
             };
 
         private:
-            FG& m_graph_impl;
+            std::shared_ptr<FG> m_graph_impl_ptr;
         };
     }
 
@@ -172,8 +174,9 @@ namespace fastscapelib
         using basins_type = xt_tensor_t<py_selector, size_type, 1>;
 
         template <class FG>
-        py_flow_graph_impl(FG& graph_impl)
-            : m_wrapper_ptr(std::make_unique<detail::flow_graph_impl_wrapper<FG>>(graph_impl)){};
+        py_flow_graph_impl(const std::shared_ptr<FG>& graph_impl_ptr)
+            : m_wrapper_ptr(
+                std::make_unique<detail::flow_graph_impl_wrapper<FG>>(graph_impl_ptr)){};
 
         bool single_flow() const
         {
@@ -332,14 +335,15 @@ namespace fastscapelib
             flow_graph_wrapper(G& grid, operators_type operators)
             {
                 m_graph_ptr = std::make_unique<flow_graph_type>(grid, std::move(operators));
-                m_graph_impl_ptr = std::make_unique<py_flow_graph_impl>(m_graph_ptr->impl());
+                m_graph_impl_ptr = std::make_unique<py_flow_graph_impl>(m_graph_ptr->impl_ptr());
             }
 
             // used for returning graph snapshots
             flow_graph_wrapper(flow_graph_type* snapshot_graph_ptr)
             {
                 m_snapshot_graph_ptr = snapshot_graph_ptr;
-                m_graph_impl_ptr = std::make_unique<py_flow_graph_impl>(snapshot_graph_ptr->impl());
+                m_graph_impl_ptr
+                    = std::make_unique<py_flow_graph_impl>(m_snapshot_graph_ptr->impl_ptr());
             }
 
             virtual ~flow_graph_wrapper(){};


### PR DESCRIPTION
The `return_value_policy` of `FlowGraph.impl()` wasn't the right one.