### PR TITLE
Bump Python / Numpy supported versions

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -19,7 +19,7 @@ jobs:
         run: pipx run build --sdist
 
       - name: Upload SDist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -35,7 +35,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16
+        uses: pypa/cibuildwheel@v2.21
         env:
           # skip PyPy and muslinux (for now)
           CIBW_SKIP: "pp* *musllinux*"
@@ -60,7 +60,7 @@ jobs:
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - name: Get dist files
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,5 +104,5 @@ jobs:
 
       - name: Run tests (Numpy 1.xx)
         run: |
-          python -m pip install numpy==1 pytest
+          python -m pip install numpy==1.26.4 pytest
           pytest python/fastscapelib/tests -vv --color=yes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04", "ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,3 +85,24 @@ jobs:
       - name: Run tests
         run: |
           pytest python/fastscapelib/tests -vv --color=yes
+
+  test_npy:
+    name: Test Python (Numpy 1.xx compat)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build and install Fastscapelib Python (Numpy 2.x)
+        run: |
+          python -m pip install . --config-settings=cmake.define.FS_DOWNLOAD_XTENSOR_PYTHON=ON
+
+      - name: Run tests (Numpy 1.xx)
+        run: |
+          python -m pip install numpy==1 pytest
+          pytest python/fastscapelib/tests -vv --color=yes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,14 +39,14 @@ if(SKBUILD AND FS_DOWNLOAD_XTENSOR_PYTHON)
 
     FetchContent_Declare(xtensor
         GIT_REPOSITORY https://github.com/xtensor-stack/xtensor
-        GIT_TAG 0.24.6
+        GIT_TAG 0.25.0
         GIT_SHALLOW TRUE)
     set(CPP17 ON CACHE BOOL "Enable C++17 for xtensor" FORCE)
     FetchContent_MakeAvailable(xtensor)
 
     FetchContent_Declare(xtensor-python
         GIT_REPOSITORY https://github.com/xtensor-stack/xtensor-python
-        GIT_TAG 0.26.1
+        GIT_TAG 0.27.0
         GIT_SHALLOW TRUE)
     FetchContent_MakeAvailable(xtensor-python)
 

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,13 +2,14 @@ name: fastscapelib-docs
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.11
   - breathe
   - cmake
   - xtensor-python
   - pybind11
   - scikit-build-core
   - numpy
+  - numba
   - matplotlib-base
   - pygalmesh
   - sphinx

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -2,7 +2,7 @@ name: fastscapelib-docs
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
+  - python=3.10
   - breathe
   - cmake
   - xtensor-python

--- a/doc/source/api_python/hidden.rst
+++ b/doc/source/api_python/hidden.rst
@@ -7,12 +7,3 @@
 
    MSTMethod
    MSTRouteMethod
-
-
-.. currentmodule:: fastscapelib.flow.numba.flow_kernel
-
-.. autosummary::
-   :toctree: _api_generated/
-
-   NumbaFlowKernel
-   NumbaFlowKernelData

--- a/doc/source/api_python/hidden.rst
+++ b/doc/source/api_python/hidden.rst
@@ -7,5 +7,12 @@
 
    MSTMethod
    MSTRouteMethod
-   flow.numba.flow_kernel.NumbaFlowKernel
-   flow.numba.flow_kernel.NumbaFlowKernelData
+
+
+.. currentmodule:: fastscapelib.flow.numba.flow_kernel
+
+.. autosummary::
+   :toctree: _api_generated/
+
+   NumbaFlowKernel
+   NumbaFlowKernelData

--- a/doc/source/api_python/hidden.rst
+++ b/doc/source/api_python/hidden.rst
@@ -7,5 +7,5 @@
 
    MSTMethod
    MSTRouteMethod
-   flow.numba_flow_kernel.NumbaFlowKernel
-   flow.numba_flow_kernel.NumbaFlowKernelData
+   flow.numba.flow_kernel.NumbaFlowKernel
+   flow.numba.flow_kernel.NumbaFlowKernelData

--- a/doc/source/api_python/hidden.rst
+++ b/doc/source/api_python/hidden.rst
@@ -7,3 +7,5 @@
 
    MSTMethod
    MSTRouteMethod
+   flow.numba.flow_kernel.NumbaFlowKernel
+   flow.numba.flow_kernel.NumbaFlowKernelData

--- a/doc/source/install.md
+++ b/doc/source/install.md
@@ -130,7 +130,7 @@ options.
 
 ## Install the Python Library
 
-Fastscapelib's Python package requires Python (3.9+) and [numpy].
+Fastscapelib's Python package requires Python (3.10+) and [numpy].
 
 (install-python-binary)=
 

--- a/environment-python-dev.yml
+++ b/environment-python-dev.yml
@@ -2,7 +2,7 @@ name: fastscapelib-python-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8
+  - python>=3.10
   - numpy
   - numba
   - xtensor-python

--- a/include/fastscapelib/flow/flow_graph.hpp
+++ b/include/fastscapelib/flow/flow_graph.hpp
@@ -251,7 +251,7 @@ namespace fastscapelib
          * @tparam FK The flow kernel type.
          * @tparam FKD The flow kernel data type.
          * @param kernel The flow kernel object to apply along the graph.
-         * @param kernel_data The object holding or referencing input and output data
+         * @param data The object holding or referencing input and output data
          * used by the flow kernel.
          *
          */

--- a/include/fastscapelib/utils/thread_pool.hpp
+++ b/include/fastscapelib/utils/thread_pool.hpp
@@ -57,6 +57,7 @@ namespace fastscapelib
              * @param first_index_ The first index in the range.
              * @param index_after_last_ The index after the last index in the range.
              * @param num_blocks_ The desired number of blocks to divide the range into.
+             * @param min_size_ The minimum size of each blocks (ignored if zero, default).
              */
             blocks(const T& first_index_,
                    const T& index_after_last_,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ authors = [
 maintainers = [
     {name = "Fastscapelib contributors"},
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = ["numpy", "numba"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
 requires = [
     "scikit-build-core",
-    "pybind11",
-    # TODO: replace by "numpy>=1.25.0,<2" when dropping py3.8 support.
-    # https://github.com/scipy/oldest-supported-numpy/issues/76
-    "oldest-supported-numpy",
+    # pybind11 2.12 added support for numpy 2.0
+    # pybind11 doesn't require numpy at build time, but xtensor-python does!
+    # packages built with numpy 2.x are compatible with numpy 1.xx
+    "pybind11>=2.12,<3",
+    "numpy>=2.0,<3",
 ]
 build-backend = "scikit_build_core.build"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ maintainers = [
 requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.24",
-    "numba",
 ]
 
 [project.urls]
@@ -33,6 +32,7 @@ Home = "https://fastscapelib.readthedocs.io"
 Repository = "https://github.com/fastscape-lem/fastscapelib"
 
 [project.optional-dependencies]
+numba = ["numba"]
 test = ["pytest>=6.0"]
 
 [tool.scikit-build]
@@ -43,6 +43,12 @@ environment = {SKBUILD_CMAKE_ARGS='-DFS_DOWNLOAD_XTENSOR_PYTHON=ON'}
 test-extras = "test"
 test-command = "pytest {project}/python/fastscapelib/tests"
 build-verbosity = 1
+
+[[tool.cibuildwheel.overrides]]
+# TODO: remove when numba supports python 3.13
+select = "cp3{10,11,12}-*"
+inherit.test-requires = "append"
+test-requires = ["numba"]
 
 [tool.cibuildwheel.macos]
 environment = {SKBUILD_CMAKE_ARGS='-DFS_DOWNLOAD_XTENSOR_PYTHON=ON', MACOSX_DEPLOYMENT_TARGET=10.13}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,10 @@ maintainers = [
     {name = "Fastscapelib contributors"},
 ]
 requires-python = ">=3.10"
-dependencies = ["numpy", "numba"]
+dependencies = [
+    "numpy>=1.24",
+    "numba",
+]
 
 [project.urls]
 Home = "https://fastscapelib.readthedocs.io"

--- a/python/fastscapelib/eroders/flow_kernel_eroder.py
+++ b/python/fastscapelib/eroders/flow_kernel_eroder.py
@@ -1,14 +1,19 @@
+from __future__ import annotations
+
 import inspect
+from typing import TYPE_CHECKING
 
 import numba as nb
 
 from fastscapelib.flow import FlowGraph, FlowGraphTraversalDir
-from fastscapelib.flow.numba_flow_kernel import (
-    NumbaFlowKernel,
-    NumbaFlowKernelData,
-    NumbaJittedClass,
-    create_flow_kernel,
-)
+from fastscapelib.flow.numba import create_flow_kernel
+
+if TYPE_CHECKING:
+    from fastscapelib.flow.numba.flow_kernel import (
+        NumbaFlowKernel,
+        NumbaFlowKernelData,
+        NumbaJittedClass,
+    )
 
 
 class FlowKernelEroderMeta(type):

--- a/python/fastscapelib/eroders/flow_kernel_eroder.py
+++ b/python/fastscapelib/eroders/flow_kernel_eroder.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING
-
-import numba as nb
+from typing import TYPE_CHECKING, Any
 
 from fastscapelib.flow import FlowGraph, FlowGraphTraversalDir
 from fastscapelib.flow.numba import create_flow_kernel
 
 if TYPE_CHECKING:
+    import numba as nb
+
     from fastscapelib.flow.numba.flow_kernel import (
         NumbaFlowKernel,
         NumbaFlowKernelData,
@@ -51,7 +51,7 @@ class FlowKernelEroderMeta(type):
 
 
 class FlowKernelEroder(metaclass=FlowKernelEroderMeta):
-    spec: dict[str, nb.types.Type]
+    spec: dict[str, nb.types.Type | tuple[nb.types.Type, Any]]
     outputs: list[str]
     apply_dir: FlowGraphTraversalDir
     _flow_graph: FlowGraph

--- a/python/fastscapelib/flow/__init__.py
+++ b/python/fastscapelib/flow/__init__.py
@@ -15,7 +15,7 @@ from _fastscapelib_py.flow import (  # type: ignore[import]
     _FlowKernelData,
 )
 
-from fastscapelib.flow.numba_flow_kernel import create_flow_kernel
+from fastscapelib.flow.numba import create_flow_kernel
 
 __all__ = [
     "FlowDirection",

--- a/python/fastscapelib/flow/__init__.pyi
+++ b/python/fastscapelib/flow/__init__.pyi
@@ -3,7 +3,7 @@ from typing import Any, ClassVar, List, Union, overload
 import numpy as np
 import numpy.typing as npt
 
-from fastscapelib.flow.numba_flow_kernel import NumbaFlowKernel, NumbaFlowKernelData
+from fastscapelib.flow.numba import NumbaFlowKernel, NumbaFlowKernelData
 from fastscapelib.grid import ProfileGrid, RasterGrid, TriMesh
 
 Grid = Union[ProfileGrid, RasterGrid, TriMesh]

--- a/python/fastscapelib/flow/numba/__init__.py
+++ b/python/fastscapelib/flow/numba/__init__.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable, Iterable
+
+if TYPE_CHECKING:
+    import numba as nb
+
+    from fastscapelib.flow import FlowGraph, FlowGraphTraversalDir
+    from fastscapelib.flow.numba.flow_kernel import (
+        NumbaFlowKernel,
+        NumbaFlowKernelData,
+        NumbaJittedClass,
+    )
+
+
+def create_flow_kernel(
+    flow_graph: FlowGraph,
+    kernel_func: Callable[[NumbaJittedClass], int],
+    spec: dict[str, nb.types.Type | tuple[nb.types.Type, Any]],
+    apply_dir: FlowGraphTraversalDir,
+    outputs: Iterable[str] = (),
+    max_receivers: int = -1,
+    n_threads: int = 1,
+    print_generated_code: bool = False,
+    print_stats: bool = False,
+) -> tuple[NumbaFlowKernel, NumbaFlowKernelData]:
+    """Creates a numba flow kernel.
+
+    Parameters
+    ----------
+    flow_graph : :py:class:`~fastscapelib.FlowGraph`
+        A flow graph object.
+    kernel_func : callable
+        A Python function to apply to each node of the graph. It must take one
+        input argument (numba jit-compiled class) that holds or references input
+        and output kernel data of one graph node. It should return an integer.
+    spec : dict
+        Dictionary where keys are kernel input and output variable names and
+        values are either variable types (i.e. numba scalar or array types) or
+        variable (type, value) tuples (only for scalar variables).
+    apply_dir : :py:class:`~fastscapelib.FlowGraphTraversalDir.`
+        The direction and order in which the flow kernel will be applied along
+        the graph.
+    outputs : iterable
+        The names of the kernel output variables. All names given here must be
+        also present in ``spec``.
+    max_receivers : int
+        Maximum number of flow receiver nodes per graph node. Setting this number
+        to 1 may speed up the application of the kernel function along the graph.
+        Setting this number to -1 (default) will use the maximum number defined
+        from the flow graph object and is generally safer.
+    n_threads : int
+        Number of threads to use for applying the kernel function in parallel
+        along the flow graph (default: 1, the kernel will be applied sequentially).
+        A value > 1 may be useful for kernel functions that are computationally
+        expensive. For trivial kernel functions it is generally more efficient to
+        apply the kernel sequentially (i.e., ``n_threads = 1``).
+    print_generated_code : bool
+        If True, prints the code used to create the numba jit-compiled classes for
+        managing kernel data (default: False). Useful for debugging.
+    print_stats : bool
+        If True, prints a small report on kernel creation performance
+        (default: False).
+
+    Returns
+    -------
+    flow_kernel : :py:class:`~fastscapelib.flow.numba_flow_kernel.NumbaFlowKernel`
+        An object used to apply the flow kernel.
+    flow_kernel_data : :py:class:`~fastscapelib.flow.numba_flow_kernel.NumbaFlowKernelData`
+        An object used to manage flow kernel data.
+
+    """
+    from fastscapelib.flow.numba.flow_kernel import NumbaFlowKernelFactory
+
+    factory = NumbaFlowKernelFactory(
+        flow_graph,
+        kernel_func,
+        spec,
+        apply_dir,
+        outputs=outputs,
+        max_receivers=max_receivers,
+        n_threads=n_threads,
+        print_generated_code=print_generated_code,
+        print_stats=print_stats,
+    )
+    return factory.kernel, factory.data

--- a/python/fastscapelib/flow/numba/__init__.py
+++ b/python/fastscapelib/flow/numba/__init__.py
@@ -64,9 +64,9 @@ def create_flow_kernel(
 
     Returns
     -------
-    flow_kernel : :py:class:`~fastscapelib.flow.numba_flow_kernel.NumbaFlowKernel`
+    flow_kernel : :py:class:`~fastscapelib.flow.numba.flow_kernel.NumbaFlowKernel`
         An object used to apply the flow kernel.
-    flow_kernel_data : :py:class:`~fastscapelib.flow.numba_flow_kernel.NumbaFlowKernelData`
+    flow_kernel_data : :py:class:`~fastscapelib.flow.numba.flow_kernel.NumbaFlowKernelData`
         An object used to manage flow kernel data.
 
     """

--- a/python/fastscapelib/flow/numba/flow_kernel.py
+++ b/python/fastscapelib/flow/numba/flow_kernel.py
@@ -9,7 +9,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from textwrap import dedent, indent
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Iterable,

--- a/python/fastscapelib/flow/numba/flow_kernel.py
+++ b/python/fastscapelib/flow/numba/flow_kernel.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import inspect
-import sys
 import time
 from collections import defaultdict
 from collections.abc import Mapping
@@ -27,21 +26,12 @@ import numba as nb
 import numpy as np
 from numba.experimental.jitclass import _box  # type: ignore[missing-imports]
 
-# type stubs defined in this sub-package (avoid circular imports)
-if TYPE_CHECKING:
-    from fastscapelib.flow import (
-        FlowGraph,
-        FlowGraphTraversalDir,
-        _FlowKernel,
-        _FlowKernelData,
-    )
-else:
-    from _fastscapelib_py.flow import (
-        FlowGraph,
-        FlowGraphTraversalDir,
-        _FlowKernel,
-        _FlowKernelData,
-    )
+from fastscapelib.flow import (
+    FlowGraph,
+    FlowGraphTraversalDir,
+    _FlowKernel,
+    _FlowKernelData,
+)
 
 
 class ConstantAssignmentVisitor(ast.NodeVisitor):
@@ -98,24 +88,10 @@ class NumbaJittedClass(Protocol):
     _numba_type_: Any
 
 
-if sys.version_info < (3, 10):
-    KernelFunc = "NumbaJittedFunc[[NumbaJittedClass], int]"
-    KernelNodeDataGetter = (
-        "NumbaJittedFunc[[int, NumbaJittedClass, NumbaJittedClass], int]"
-    )
-    KernelNodeDataSetter = (
-        "NumbaJittedFunc[[int, NumbaJittedClass, NumbaJittedClass], int]"
-    )
-    KernelNodeDataCreate = "NumbaJittedFunc[[], NumbaJittedClass]"
-else:
-    KernelFunc = NumbaJittedFunc[[NumbaJittedClass], int]
-    KernelNodeDataGetter = NumbaJittedFunc[
-        [int, NumbaJittedClass, NumbaJittedClass], int
-    ]
-    KernelNodeDataSetter = NumbaJittedFunc[
-        [int, NumbaJittedClass, NumbaJittedClass], int
-    ]
-    KernelNodeDataCreate = NumbaJittedFunc[[], NumbaJittedClass]
+KernelFunc = NumbaJittedFunc[[NumbaJittedClass], int]
+KernelNodeDataGetter = NumbaJittedFunc[[int, NumbaJittedClass, NumbaJittedClass], int]
+KernelNodeDataSetter = NumbaJittedFunc[[int, NumbaJittedClass, NumbaJittedClass], int]
+KernelNodeDataCreate = NumbaJittedFunc[[], NumbaJittedClass]
 
 
 @contextmanager
@@ -247,77 +223,6 @@ class NumbaFlowKernel:
     node_data_setter: KernelNodeDataSetter
     node_data_free: Any
     func: KernelFunc
-
-
-def create_flow_kernel(
-    flow_graph: FlowGraph,
-    kernel_func: Callable[["NumbaJittedClass"], int],
-    spec: dict[str, nb.types.Type | tuple[nb.types.Type, Any]],
-    apply_dir: FlowGraphTraversalDir,
-    outputs: Iterable[str] = (),
-    max_receivers: int = -1,
-    n_threads: int = 1,
-    print_generated_code: bool = False,
-    print_stats: bool = False,
-) -> tuple[NumbaFlowKernel, NumbaFlowKernelData]:
-    """Creates a numba flow kernel.
-
-    Parameters
-    ----------
-    flow_graph : :py:class:`~fastscapelib.FlowGraph`
-        A flow graph object.
-    kernel_func : callable
-        A Python function to apply to each node of the graph. It must take one
-        input argument (numba jit-compiled class) that holds or references input
-        and output kernel data of one graph node. It should return an integer.
-    spec : dict
-        Dictionary where keys are kernel input and output variable names and
-        values are either variable types (i.e. numba scalar or array types) or
-        variable (type, value) tuples (only for scalar variables).
-    apply_dir : :py:class:`~fastscapelib.FlowGraphTraversalDir.`
-        The direction and order in which the flow kernel will be applied along
-        the graph.
-    outputs : iterable
-        The names of the kernel output variables. All names given here must be
-        also present in ``spec``.
-    max_receivers : int
-        Maximum number of flow receiver nodes per graph node. Setting this number
-        to 1 may speed up the application of the kernel function along the graph.
-        Setting this number to -1 (default) will use the maximum number defined
-        from the flow graph object and is generally safer.
-    n_threads : int
-        Number of threads to use for applying the kernel function in parallel
-        along the flow graph (default: 1, the kernel will be applied sequentially).
-        A value > 1 may be useful for kernel functions that are computationally
-        expensive. For trivial kernel functions it is generally more efficient to
-        apply the kernel sequentially (i.e., ``n_threads = 1``).
-    print_generated_code : bool
-        If True, prints the code used to create the numba jit-compiled classes for
-        managing kernel data (default: False). Useful for debugging.
-    print_stats : bool
-        If True, prints a small report on kernel creation performance
-        (default: False).
-
-    Returns
-    -------
-    flow_kernel : :py:class:`~fastscapelib.flow.numba_flow_kernel.NumbaFlowKernel`
-        An object used to apply the flow kernel.
-    flow_kernel_data : :py:class:`~fastscapelib.flow.numba_flow_kernel.NumbaFlowKernelData`
-        An object used to manage flow kernel data.
-
-    """
-    factory = NumbaFlowKernelFactory(
-        flow_graph,
-        kernel_func,
-        spec,
-        apply_dir,
-        outputs=outputs,
-        max_receivers=max_receivers,
-        n_threads=n_threads,
-        print_generated_code=print_generated_code,
-        print_stats=print_stats,
-    )
-    return factory.kernel, factory.data
 
 
 class NumbaFlowKernelFactory:

--- a/python/fastscapelib/flow/numba_flow_kernel.py
+++ b/python/fastscapelib/flow/numba_flow_kernel.py
@@ -16,6 +16,7 @@ from typing import (
     Iterable,
     Iterator,
     Optional,
+    ParamSpec,
     Protocol,
     Type,
     TypeVar,
@@ -41,12 +42,6 @@ else:
         _FlowKernel,
         _FlowKernelData,
     )
-
-
-if sys.version_info < (3, 10):
-    from typing_extensions import ParamSpec
-else:
-    from typing import ParamSpec
 
 
 class ConstantAssignmentVisitor(ast.NodeVisitor):

--- a/python/fastscapelib/tests/test_flow_kernel.py
+++ b/python/fastscapelib/tests/test_flow_kernel.py
@@ -1,4 +1,3 @@
-import numba as nb
 import numpy as np
 import pytest
 
@@ -8,8 +7,10 @@ from fastscapelib.flow import (
     MultiFlowRouter,
     PFloodSinkResolver,
 )
-from fastscapelib.flow.numba_flow_kernel import create_flow_kernel
+from fastscapelib.flow.numba import create_flow_kernel
 from fastscapelib.grid import NodeStatus, RasterGrid
+
+nb = pytest.importorskip("numba")
 
 
 @pytest.fixture(scope="module")

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -626,7 +626,8 @@ add_flow_graph_bindings(py::module& m)
             {
                 auto py_apply_kernel = py::module::import("fastscapelib")
                                            .attr("flow")
-                                           .attr("numba_flow_kernel")
+                                           .attr("numba")
+                                           .attr("flow_kernel")
                                            .attr("apply_flow_kernel");
                 return py_apply_kernel(flow_graph, flow_kernel, flow_kernel_data).cast<int>();
             }

--- a/python/src/flow_graph.cpp
+++ b/python/src/flow_graph.cpp
@@ -651,9 +651,9 @@ add_flow_graph_bindings(py::module& m)
 
         Parameters
         ----------
-        kernel : :py:class:`~fastscapelib.flow.numba_flow_kernel.NumbaFlowKernel`
+        kernel : :py:class:`~fastscapelib.flow.numba.flow_kernel.NumbaFlowKernel`
             The flow kernel object to apply along the graph.
-        kernel_data : :py:class:`~fastscapelib.flow.numba_flow_kernel.NumbaFlowKernelData`
+        kernel_data : :py:class:`~fastscapelib.flow.numba.flow_kernel.NumbaFlowKernelData`
             The object holding or referencing input and output data used by the flow kernel.
 
         )doc");


### PR DESCRIPTION
Follow https://scientific-python.org/specs/spec-0000/ for both Python and Numpy.

Build wheels against Numpy 2.x so it works with both Numpy 1.xx and 2.x (isolated builds only... for conda-forge it relies on pinned versions and migrations). 

Make Numba dependency optional (it often requires some time before it supports last Python versions).

TODO:

- [x] CI: build package with numpy 2.x and run tests with numpy 1.xx as suggested [here](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice) (also skip optional dependencies like numba and check that everything goes well).