### PR TITLE
Provide hints where CMake should find xtensor.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,9 @@ elseif(FS_DOWNLOAD_XTENSOR)
     FetchContent_MakeAvailable(xtensor)
 
 else()
-    message(STATUS "Searching for xtensor in ${XTENSOR_DIR}")
+    if(XTENSOR_DIR)
+        message(STATUS "Searching for xtensor in ${XTENSOR_DIR}")
+    endif()
     find_package(xtensor REQUIRED
                  HINTS ${XTENSOR_DIR})
     message(STATUS "Found xtensor: ${xtensor_INCLUDE_DIRS}/xtensor")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,9 @@ elseif(FS_DOWNLOAD_XTENSOR)
     FetchContent_MakeAvailable(xtensor)
 
 else()
-    find_package(xtensor REQUIRED)
+    message(STATUS "Searching for xtensor in ${XTENSOR_DIR}")
+    find_package(xtensor REQUIRED
+                 HINTS ${XTENSOR_DIR})
     message(STATUS "Found xtensor: ${xtensor_INCLUDE_DIRS}/xtensor")
 endif()
 

--- a/doc/source/install.md
+++ b/doc/source/install.md
@@ -124,6 +124,9 @@ $ cmake --install build
 Where `/path/to/prefix` is the path where the header files will be installed
 (skip this option if you want to install Fastscapelib in a default location).
 
+If you have installed [xtensor] in a custom directory, you can help CMake find
+it by setting the `-DXTENSOR_DIR` option.
+
 See Section {doc}`build_options` for more information on the available build
 options.
 


### PR DESCRIPTION
If xtensor is not in a standard directory, allow specifying `-DXTENSOR_DIR=...` on the cmake command line.