### PR TITLE
Deal with the fact that Xtensor moved all of its header files.

### DIFF
--- a/include/fastscapelib/algo/pflood.hpp
+++ b/include/fastscapelib/algo/pflood.hpp
@@ -12,7 +12,22 @@
 #include <limits>
 #include <type_traits>
 
-#include "xtensor/xtensor.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xtensor.hpp>
+#else
+#  include <xtensor/containers/xtensor.hpp>
+#endif
 
 #include "fastscapelib/utils/utils.hpp"
 #include "fastscapelib/utils/consts.hpp"

--- a/include/fastscapelib/eroders/diffusion_adi.hpp
+++ b/include/fastscapelib/eroders/diffusion_adi.hpp
@@ -10,11 +10,31 @@
 #include <type_traits>
 #include <utility>
 
-#include "xtensor/xbroadcast.hpp"
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xnoalias.hpp"
-#include "xtensor/xview.hpp"
-#include "xtensor/xmanipulation.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xbroadcast.hpp>
+#  include <xtensor/xview.hpp>
+#  include <xtensor/xbuilder.hpp>
+#  include <xtensor/xnoalias.hpp>
+#  include <xtensor/xmanipulation.hpp>
+#else
+#  include <xtensor/views/xbroadcast.hpp>
+#  include <xtensor/views/xview.hpp>
+#  include <xtensor/generators/xbuilder.hpp>
+#  include <xtensor/core/xnoalias.hpp>
+#  include <xtensor/misc/xmanipulation.hpp>
+#endif
+
 
 #include "fastscapelib/grid/structured_grid.hpp"
 #include "fastscapelib/utils/utils.hpp"

--- a/include/fastscapelib/eroders/spl.hpp
+++ b/include/fastscapelib/eroders/spl.hpp
@@ -11,12 +11,30 @@
 #include <limits>
 #include <type_traits>
 
-#include "xtensor/xbroadcast.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xmanipulation.hpp"
-
 #include "fastscapelib/utils/utils.hpp"
 #include "fastscapelib/utils/containers.hpp"
+
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xbroadcast.hpp>
+#  include <xtensor/xtensor.hpp>
+#  include <xtensor/xmanipulation.hpp>
+#else
+#  include <xtensor/views/xbroadcast.hpp>
+#  include <xtensor/containers/xtensor.hpp>
+#  include <xtensor/misc/xmanipulation.hpp>
+#endif
+
 
 
 namespace fastscapelib

--- a/include/fastscapelib/flow/flow_graph.hpp
+++ b/include/fastscapelib/flow/flow_graph.hpp
@@ -1,12 +1,27 @@
 #ifndef FASTSCAPELIB_FLOW_FLOW_GRAPH_HPP
 #define FASTSCAPELIB_FLOW_FLOW_GRAPH_HPP
 
-#include "fastscapelib/flow/flow_graph_impl.hpp"
-#include "fastscapelib/flow/flow_kernel.hpp"
-#include "fastscapelib/flow/flow_operator.hpp"
-#include "fastscapelib/utils/thread_pool.hpp"
+#include <fastscapelib/flow/flow_graph_impl.hpp>
+#include <fastscapelib/flow/flow_kernel.hpp>
+#include <fastscapelib/flow/flow_operator.hpp>
+#include <fastscapelib/utils/thread_pool.hpp>
 
-#include "xtensor/xstrided_view.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xstrided_view.hpp>
+#else
+#  include <xtensor/views/xstrided_view.hpp>
+#endif
 
 #include <map>
 #include <memory>

--- a/include/fastscapelib/flow/flow_graph_impl.hpp
+++ b/include/fastscapelib/flow/flow_graph_impl.hpp
@@ -9,13 +9,31 @@
 #include <vector>
 #include <set>
 
-#include "xtensor/xbroadcast.hpp"
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xview.hpp"
 
-#include "fastscapelib/grid/base.hpp"
-#include "fastscapelib/utils/iterators.hpp"
-#include "fastscapelib/utils/containers.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xbroadcast.hpp>
+#  include <xtensor/xstrided_view.hpp>
+#  include <xtensor/xview.hpp>
+#else
+#  include <xtensor/views/xbroadcast.hpp>
+#  include <xtensor/views/xstrided_view.hpp>
+#  include <xtensor/views/xview.hpp>
+#endif
+
+#include <fastscapelib/grid/base.hpp>
+#include <fastscapelib/utils/iterators.hpp>
+#include <fastscapelib/utils/containers.hpp>
 
 
 namespace fastscapelib

--- a/include/fastscapelib/flow/impl/flow_graph_inl.hpp
+++ b/include/fastscapelib/flow/impl/flow_graph_inl.hpp
@@ -8,11 +8,26 @@
 #include <string>
 #include <vector>
 
-#include "fastscapelib/utils/containers.hpp"
-#include "xtensor/xstrided_view.hpp"
+#include <fastscapelib/utils/containers.hpp>
+#include <fastscapelib/flow/flow_graph_impl.hpp>
+#include <fastscapelib/flow/flow_operator.hpp>
 
-#include "fastscapelib/flow/flow_graph_impl.hpp"
-#include "fastscapelib/flow/flow_operator.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xstrided_view.hpp>
+#else
+#  include <xtensor/views/xstrided_view.hpp>
+#endif
 
 
 namespace fastscapelib

--- a/include/fastscapelib/grid/base.hpp
+++ b/include/fastscapelib/grid/base.hpp
@@ -11,9 +11,26 @@
 #include <map>
 #include <vector>
 
-#include "xtensor/xadapt.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xadapt.hpp>
+#  include <xtensor/xtensor.hpp>
+#  include <xtensor/xview.hpp>
+#else
+#  include <xtensor/containers/xadapt.hpp>
+#  include <xtensor/containers/xtensor.hpp>
+#  include <xtensor/views/xview.hpp>
+#endif
 
 #include "fastscapelib/utils/iterators.hpp"
 #include "fastscapelib/utils/containers.hpp"

--- a/include/fastscapelib/grid/profile_grid.hpp
+++ b/include/fastscapelib/grid/profile_grid.hpp
@@ -13,7 +13,22 @@
 #include <map>
 #include <vector>
 
-#include <xtensor/xbroadcast.hpp>
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xbroadcast.hpp>
+#else
+#  include <xtensor/views/xbroadcast.hpp>
+#endif
 
 #include "fastscapelib/grid/base.hpp"
 #include "fastscapelib/grid/structured_grid.hpp"

--- a/include/fastscapelib/grid/raster_grid.hpp
+++ b/include/fastscapelib/grid/raster_grid.hpp
@@ -8,8 +8,24 @@
 #include <vector>
 #include <utility>
 
-#include <xtensor/xbroadcast.hpp>
-#include <xtensor/xtensor.hpp>
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xbroadcast.hpp>
+#  include <xtensor/xtensor.hpp>
+#else
+#  include <xtensor/views/xbroadcast.hpp>
+#  include <xtensor/containers/xtensor.hpp>
+#endif
 
 #include "fastscapelib/grid/base.hpp"
 #include "fastscapelib/grid/structured_grid.hpp"

--- a/include/fastscapelib/grid/structured_grid.hpp
+++ b/include/fastscapelib/grid/structured_grid.hpp
@@ -15,13 +15,35 @@
 #include <map>
 #include <vector>
 
-#include "xtensor/xbuilder.hpp"
-#include "xtensor/xarray.hpp"
-#include "xtensor/xfixed.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xview.hpp"
-#include "xtensor/xindex_view.hpp"
-#include "xtensor/xnoalias.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xindex_view.hpp>
+#  include <xtensor/xview.hpp>
+#  include <xtensor/xbuilder.hpp>
+#  include <xtensor/xarray.hpp>
+#  include <xtensor/xfixed.hpp>
+#  include <xtensor/xtensor.hpp>
+#  include <xtensor/xnoalias.hpp>
+#else
+#  include <xtensor/views/xindex_view.hpp>
+#  include <xtensor/views/xview.hpp>
+#  include <xtensor/generators/xbuilder.hpp>
+#  include <xtensor/containers/xarray.hpp>
+#  include <xtensor/containers/xfixed.hpp>
+#  include <xtensor/containers/xtensor.hpp>
+#  include <xtensor/core/xnoalias.hpp>
+#endif
+
 
 #include "xtl/xiterator_base.hpp"
 

--- a/include/fastscapelib/grid/trimesh.hpp
+++ b/include/fastscapelib/grid/trimesh.hpp
@@ -11,8 +11,24 @@
 #include <utility>
 #include <vector>
 
-#include "xtensor/xstrided_view.hpp"
-#include "xtensor/xhistogram.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xhistogram.hpp>
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/misc/xhistogram.hpp>
+#  include <xtensor/xstrided_view.hpp>
+#else
+#  include <xtensor/views/xstrided_view.hpp>
+#endif
 
 #include "fastscapelib/grid/base.hpp"
 #include "fastscapelib/utils/containers.hpp"

--- a/include/fastscapelib/utils/utils.hpp
+++ b/include/fastscapelib/utils/utils.hpp
@@ -9,7 +9,22 @@
 #include <cstddef>
 #include <type_traits>
 
-#include "xtensor/xcontainer.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xcontainer.hpp>
+#else
+#  include <xtensor/containers/xcontainer.hpp>
+#endif
 
 
 // type used for array indexers

--- a/include/fastscapelib/utils/xtensor_containers.hpp
+++ b/include/fastscapelib/utils/xtensor_containers.hpp
@@ -4,10 +4,29 @@
 #ifndef FASTSCAPELIB_UTILS_XTENSOR_CONTAINERS_HPP
 #define FASTSCAPELIB_UTILS_XTENSOR_CONTAINERS_HPP
 
-#include "xtensor/xarray.hpp"
-#include "xtensor/xtensor.hpp"
-#include "xtensor/xadapt.hpp"
-#include "xtensor/xview.hpp"
+// Include the Xtensor configuration file so that we can query the
+// Xtensor version number below to address the fact that between
+// 0.25.0 and 0.26.0, all Xtensor include files were moved around,
+// see https://github.com/xtensor-stack/xtensor/pull/2829 and the
+// complaints therein.
+#if __has_include(<xtensor/core/xtensor_config.hpp>)  // 0.26.0 and later
+#  include <xtensor/core/xtensor_config.hpp>
+#else // 0.25.0 and earlier
+#  include <xtensor/xtensor_config.hpp>
+#endif
+
+#if XTENSOR_VERSION_MAJOR ==0 && XTENSOR_VERSION_MINOR <= 25
+#  include <xtensor/xarray.hpp>
+#  include <xtensor/xtensor.hpp>
+#  include <xtensor/xadapt.hpp>
+#  include <xtensor/xview.hpp>
+#else
+#  include <xtensor/containers/xarray.hpp>
+#  include <xtensor/containers/xtensor.hpp>
+#  include <xtensor/containers/xadapt.hpp>
+#  include <xtensor/views/xview.hpp>
+#endif
+
 
 #include <stdexcept>
 


### PR DESCRIPTION
Xtensor has moved all of its header files into new locations -- see https://github.com/xtensor-stack/xtensor/pull/2829. This is of course a colossal hassle, but it can be worked around in a way so that it should work with both the old and new header locations.

This patch seems to work for me, and I hope it also still works for the ones of you who still use Xtensor 0.25.0.