### PR TITLE
Add a set of missing braces.

### DIFF
--- a/include/fastscapelib/flow/flow_graph_impl.hpp
+++ b/include/fastscapelib/flow/flow_graph_impl.hpp
@@ -100,8 +100,9 @@ namespace fastscapelib
                 }
 
                 using shape_type = std::array<size_type, 2>;
-                const shape_type receivers_shape = { grid.size(), n_receivers_max };
-                const shape_type donors_shape = { grid.size(), grid_type::n_neighbors_max() + 1 };
+                const shape_type receivers_shape = { { grid.size(), n_receivers_max } };
+                const shape_type donors_shape
+                    = { { grid.size(), grid_type::n_neighbors_max() + 1 } };
 
                 m_receivers = xt::ones<size_type>(receivers_shape) * -1;
                 m_receivers_count = xt::zeros<size_type>({ grid.size() });


### PR DESCRIPTION
Some compilers are more lenient with the number of braces necessary to initialize arrays, and others are not. Mine is not. So add the missing braces.