### PR TITLE
CI: python wheels, bump windows version

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -40,7 +40,7 @@ jobs:
         include:
         - os: ubuntu-latest
           arch: x86_64
-        - os: windows-2019
+        - os: windows-2022
           arch: AMD64
           msvc_arch: x64
         - os: macos-13


### PR DESCRIPTION
Windows 2019 Actions runner image is deprecated, use Windows 2022.